### PR TITLE
feat: v1.2.0 — comprehensive bug fixes, new features, and test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,46 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] — 2026-04-05
+## [1.2.0] — 2026-04-05
 
-- No unreleased changes yet.
+### Added
+- **`getOrThrow(key, fetcher?, options?)`** on `CacheStack` and `CacheNamespace` — throws `CacheMissError` instead of returning `null`.
+- **`CacheMissError`** — new error class exported from the package, thrown by `getOrThrow`.
+- **`inspect(key)`** on `CacheStack` and `CacheNamespace` — returns detailed metadata about a cache key: which layers hold it, remaining fresh/stale/error TTLs, staleness status, and associated tags.
+- **`CacheInspectResult`** type for the `inspect()` return value.
+- **`shouldCache`** option on `CacheWriteOptions` — optional predicate called before caching a fetcher's result. Return `false` to skip storage while still returning the value to the caller.
+- **`tagsForKey(key)`** optional method on `CacheTagIndex` interface, implemented in both `TagIndex` and `RedisTagIndex`.
+- **Nested namespaces** — `CacheNamespace.namespace(childPrefix)` creates child namespaces with compounding key prefixes (e.g. `tenant:abc:posts:mykey`).
+- **Per-layer read latency tracking** — `CacheMetricsSnapshot.latencyByLayer` records average, max, and sample count per layer using Welford's online algorithm.
+- **`CacheLayerLatency`** type for per-layer latency statistics (`avgMs`, `maxMs`, `count`).
+- **Prometheus latency gauges** — `createPrometheusMetricsExporter` now emits `layercache_layer_latency_avg_ms`, `layercache_layer_latency_max_ms`, and `layercache_layer_latency_count` per layer.
+- **Express integration** — `createExpressCacheMiddleware(cache, options)` middleware that transparently caches JSON responses with `x-cache: HIT/MISS` headers.
+- **NestJS `forRootAsync`** — `CacheStackModule.forRootAsync({ inject, useFactory })` for async configuration via the NestJS DI container.
+- **`MemcachedLayer.getEntry()`** — enables `StoredValueEnvelope` support (stale-while-revalidate, stale-if-error) in the Memcached layer.
+- **`MemcachedLayer.has()`** — check key existence without deserialization.
+- **`MemcachedLayer.getMany()`** — bulk reads for the Memcached layer.
+- **`MemcachedLayer.serializer`** option — pluggable serializer (default: JSON), bringing parity with `RedisLayer`.
+- **`DiskLayer.maxFiles`** option — limits on-disk cache entries; oldest files (by mtime) are evicted when exceeded.
+- **`TagIndex.maxKnownKeys`** option — prevents unbounded memory growth of the in-memory tag index by pruning the oldest 10% of known keys when the limit is exceeded.
+- **Tests for `DiskLayer`** — 14 new tests covering get/set/delete/keys/ttl/has/maxFiles/envelope/corrupted files.
+- **Tests for `MemcachedLayer`** — 11 new tests covering get/set/delete/getEntry/has/getMany/keyPrefix/serializer/deserialization errors.
+- **Tests for `PrometheusExporter`** — 5 new tests covering single/multiple stacks, latency metrics, label sanitization, and zero-state exports.
+
+### Changed
+- **`RedisLayer` compression is now fully async** — replaced `gzipSync`/`brotliCompressSync`/`gunzipSync`/`brotliDecompressSync` with their async counterparts to avoid blocking the event loop on large payloads.
+- **`MemoryLayer` FIFO semantics clarified** — `getEntry()` no longer increments the access counter for FIFO-evicted caches (access count was unused by FIFO but wastefully bumped). Internal field renamed from `frequency` to `accessCount` for clarity.
+- **`RedisInvalidationBus` now supports multiple concurrent subscriptions** — multiple `CacheStack` instances can share a single bus. The previous `throw` on second `subscribe()` call is removed; each subscriber gets an independent unsubscribe handle.
+- **CLI `invalidate` command** now deletes keys in batches of 500 instead of issuing a single `DEL` command with all keys, preventing timeout on large key sets.
+- **`DiskLayer.keys()`** now returns the original cache key strings (not SHA256 hashes) by storing the key inside each `.lc` file.
+- **`DiskLayer.getEntry()`** added — enables `StoredValueEnvelope` passthrough, aligning behavior with `MemoryLayer` and `RedisLayer`.
+
+### Fixed
+- **Memory leak in `TagIndex`**: `knownKeys` set now supports a configurable `maxKnownKeys` limit to prevent unbounded growth.
+- **`DiskLayer.keys()` returned SHA256 hashes** instead of original cache key names; now returns correct keys.
+- **`MemcachedLayer` ignored serializer**: previously hardcoded `JSON.stringify`/`JSON.parse`, now uses the pluggable `CacheSerializer` interface.
+- **`MemcachedLayer` lacked `getEntry()`**: `StoredValueEnvelope`-based features (stale-while-revalidate, stale-if-error) silently failed on the Memcached layer.
+- **`RedisLayer` sync compression blocked event loop**: large payloads caused latency spikes for other requests.
+- **CLI large-key-set deletion**: `invalidate` could timeout when deleting thousands of keys in a single `DEL` command.
 
 ## [1.1.0] — 2026-04-05
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![npm downloads](https://img.shields.io/npm/dw/layercache)](https://www.npmjs.com/package/layercache)
 [![license](https://img.shields.io/npm/l/layercache)](LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-first-blue)](https://www.typescriptlang.org/)
-[![test coverage](https://img.shields.io/badge/tests-102%20passing-brightgreen)](https://github.com/flyingsquirrel0419/layercache)
+[![test coverage](https://img.shields.io/badge/tests-132%20passing-brightgreen)](https://github.com/flyingsquirrel0419/layercache)
 
 ```
 L1 hit  ~0.01 ms  ← served from memory, zero network
@@ -58,13 +58,17 @@ On a hit, the value is returned from the fastest layer that has it, and automati
 - **Event hooks** — `EventEmitter`-based events for hits, misses, stale serves, errors, and more
 - **Graceful degradation** — skip a failing layer for a configurable retry window
 - **Circuit breaker** — per-key or global; opens after N failures, recovers after cooldown
-- **Compression** — transparent gzip/brotli in `RedisLayer` with a byte threshold
-- **Metrics & stats** — per-layer hit/miss counters, circuit-breaker trips, degraded operations; HTTP stats handler
+- **Compression** — transparent async gzip/brotli in `RedisLayer` (non-blocking) with a byte threshold
+- **Metrics & stats** — per-layer hit/miss counters, **per-layer latency tracking**, circuit-breaker trips, degraded operations; HTTP stats handler
 - **Persistence** — `exportState` / `importState` for in-process snapshots; `persistToFile` / `restoreFromFile` for disk
 - **Admin CLI** — `layercache stats | keys | invalidate` against any Redis URL
-- **Framework integrations** — Fastify plugin, tRPC middleware, GraphQL resolver wrapper
+- **Framework integrations** — Express middleware, Fastify plugin, tRPC middleware, GraphQL resolver wrapper
 - **MessagePack serializer** — drop-in replacement for lower Redis memory usage
-- **NestJS module** — `CacheStackModule.forRoot(...)` with `@InjectCacheStack()`
+- **NestJS module** — `CacheStackModule.forRoot(...)` and `forRootAsync(...)` with `@InjectCacheStack()`
+- **`getOrThrow()`** — throws `CacheMissError` instead of returning `null`, for strict use cases
+- **`inspect()`** — debug a key: see which layers hold it, remaining TTLs, tags, and staleness state
+- **Conditional caching** — `shouldCache` predicate to skip caching specific fetcher results
+- **Nested namespaces** — `namespace('a').namespace('b')` for composable key prefixes
 - **Custom layers** — implement the 5-method `CacheLayer` interface to plug in Memcached, DynamoDB, or anything else
 - **ESM + CJS** — works with both module systems, Node.js ≥ 18
 
@@ -250,6 +254,55 @@ const posts = cache.namespace('posts')
 
 await users.set('123', userData)          // stored as "users:123"
 await users.clear()                       // only deletes "users:*"
+
+// Nested namespaces
+const tenant = cache.namespace('tenant:abc')
+const posts = tenant.namespace('posts')
+await posts.set('1', postData)            // stored as "tenant:abc:posts:1"
+```
+
+### `cache.getOrThrow<T>(key, fetcher?, options?): Promise<T>`
+
+Like `get()`, but throws `CacheMissError` instead of returning `null`. Useful when you know the value must exist (e.g. after a warm-up).
+
+```ts
+import { CacheMissError } from 'layercache'
+
+try {
+  const config = await cache.getOrThrow<Config>('app:config')
+} catch (err) {
+  if (err instanceof CacheMissError) {
+    console.error(`Missing key: ${err.key}`)
+  }
+}
+```
+
+### `cache.inspect(key): Promise<CacheInspectResult | null>`
+
+Returns detailed metadata about a cache key for debugging. Returns `null` if the key is not in any layer.
+
+```ts
+const info = await cache.inspect('user:123')
+// {
+//   key: 'user:123',
+//   foundInLayers: ['memory', 'redis'],
+//   freshTtlSeconds: 45,
+//   staleTtlSeconds: 75,
+//   errorTtlSeconds: 345,
+//   isStale: false,
+//   tags: ['user', 'user:123']
+// }
+```
+
+### Conditional caching with `shouldCache`
+
+Skip caching specific results without affecting the return value:
+
+```ts
+const data = await cache.get('api:response', fetchFromApi, {
+  shouldCache: (value) => (value as any).status === 200
+})
+// If fetchFromApi returns { status: 500 }, the value is returned but NOT cached
 ```
 
 ---
@@ -591,6 +644,26 @@ cache.on('error', ({ event, context }) => logger.error(event, context))
 
 ## Framework integrations
 
+### Express
+
+```ts
+import { CacheStack, MemoryLayer, createExpressCacheMiddleware } from 'layercache'
+
+const cache = new CacheStack([new MemoryLayer({ ttl: 60 })])
+
+// Automatically caches GET responses as JSON
+app.get('/api/users', createExpressCacheMiddleware(cache, { ttl: 30 }), (req, res) => {
+  res.json(await db.getUsers())
+})
+
+// Custom key resolver + tag support
+app.get('/api/user/:id', createExpressCacheMiddleware(cache, {
+  keyResolver: (req) => `user:${req.url}`,
+  tags: ['users'],
+  ttl: 60
+}), handler)
+```
+
 ### tRPC
 
 ```ts
@@ -693,6 +766,25 @@ import { CacheStackModule } from '@cachestack/nestjs'
         new MemoryLayer({ ttl: 20 }),
         new RedisLayer({ client: redis, ttl: 300 })
       ]
+    })
+  ]
+})
+export class AppModule {}
+```
+
+Async configuration (resolve dependencies from DI):
+
+```ts
+@Module({
+  imports: [
+    CacheStackModule.forRootAsync({
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        layers: [
+          new MemoryLayer({ ttl: 20 }),
+          new RedisLayer({ client: new Redis(config.get('REDIS_URL')), ttl: 300 })
+        ]
+      })
     })
   ]
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "layercache",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Unified multi-layer caching for Node.js with memory, Redis, stampede prevention, and invalidation helpers.",
   "license": "MIT",
   "repository": {

--- a/packages/nestjs/src/module.ts
+++ b/packages/nestjs/src/module.ts
@@ -1,4 +1,4 @@
-import { type DynamicModule, Global, Inject, Module, type Provider } from '@nestjs/common'
+import { type DynamicModule, Global, Inject, Module, type Provider, type Type } from '@nestjs/common'
 import { CacheStack } from '../../../src/CacheStack'
 import type { CacheLayer, CacheStackOptions } from '../../../src/types'
 import { CACHE_STACK } from './constants'
@@ -6,6 +6,28 @@ import { CACHE_STACK } from './constants'
 export interface CacheStackModuleOptions {
   layers: CacheLayer[]
   bridgeOptions?: CacheStackOptions
+}
+
+export interface CacheStackModuleAsyncOptions {
+  /**
+   * Tokens to inject into the `useFactory` function.
+   */
+  inject?: Array<Type | string | symbol>
+  /**
+   * Async factory function that returns `CacheStackModuleOptions`.
+   * Useful when the Redis client or other dependencies must be resolved
+   * from the NestJS DI container first.
+   *
+   * ```ts
+   * CacheStackModule.forRootAsync({
+   *   inject: [ConfigService],
+   *   useFactory: (config: ConfigService) => ({
+   *     layers: [new MemoryLayer(), new RedisLayer({ client: createRedis(config) })],
+   *   })
+   * })
+   * ```
+   */
+  useFactory: (...args: unknown[]) => CacheStackModuleOptions | Promise<CacheStackModuleOptions>
 }
 
 export const InjectCacheStack = (): ParameterDecorator & PropertyDecorator => Inject(CACHE_STACK)
@@ -17,6 +39,24 @@ export class CacheStackModule {
     const provider: Provider = {
       provide: CACHE_STACK,
       useFactory: () => new CacheStack(options.layers, options.bridgeOptions)
+    }
+
+    return {
+      global: true,
+      module: CacheStackModule,
+      providers: [provider],
+      exports: [provider]
+    }
+  }
+
+  static forRootAsync(options: CacheStackModuleAsyncOptions): DynamicModule {
+    const provider: Provider = {
+      provide: CACHE_STACK,
+      inject: options.inject ?? [],
+      useFactory: async (...args: unknown[]) => {
+        const resolved = await options.useFactory(...args)
+        return new CacheStack(resolved.layers, resolved.bridgeOptions)
+      }
     }
 
     return {

--- a/src/CacheNamespace.ts
+++ b/src/CacheNamespace.ts
@@ -2,6 +2,7 @@ import type { CacheStack } from './CacheStack'
 import type {
   CacheGetOptions,
   CacheHitRateSnapshot,
+  CacheInspectResult,
   CacheMGetEntry,
   CacheMSetEntry,
   CacheMetricsSnapshot,
@@ -23,6 +24,13 @@ export class CacheNamespace {
 
   async getOrSet<T>(key: string, fetcher: () => Promise<T>, options?: CacheGetOptions): Promise<T | null> {
     return this.cache.getOrSet(this.qualify(key), fetcher, options)
+  }
+
+  /**
+   * Like `get()`, but throws `CacheMissError` instead of returning `null`.
+   */
+  async getOrThrow<T>(key: string, fetcher?: () => Promise<T>, options?: CacheGetOptions): Promise<T> {
+    return this.cache.getOrThrow(this.qualify(key), fetcher, options)
   }
 
   async has(key: string): Promise<boolean> {
@@ -75,6 +83,13 @@ export class CacheNamespace {
     await this.cache.invalidateByPattern(this.qualify(pattern))
   }
 
+  /**
+   * Returns detailed metadata about a single cache key within this namespace.
+   */
+  async inspect(key: string): Promise<CacheInspectResult | null> {
+    return this.cache.inspect(this.qualify(key))
+  }
+
   wrap<TArgs extends unknown[], TResult>(
     keyPrefix: string,
     fetcher: (...args: TArgs) => Promise<TResult>,
@@ -99,6 +114,19 @@ export class CacheNamespace {
 
   getHitRate(): CacheHitRateSnapshot {
     return this.cache.getHitRate()
+  }
+
+  /**
+   * Creates a nested namespace. Keys are prefixed with `parentPrefix:childPrefix:`.
+   *
+   * ```ts
+   * const tenant = cache.namespace('tenant:abc')
+   * const posts = tenant.namespace('posts')
+   * // keys become: "tenant:abc:posts:mykey"
+   * ```
+   */
+  namespace(childPrefix: string): CacheNamespace {
+    return new CacheNamespace(this.cache, `${this.prefix}:${childPrefix}`)
   }
 
   qualify(key: string): string {

--- a/src/CacheStack.ts
+++ b/src/CacheStack.ts
@@ -15,29 +15,31 @@ import {
 import { TtlResolver } from './internal/TtlResolver'
 import { TagIndex } from './invalidation/TagIndex'
 import { StampedeGuard } from './stampede/StampedeGuard'
-import type {
-  CacheAdaptiveTtlOptions,
-  CacheCircuitBreakerOptions,
-  CacheGetOptions,
-  CacheHitRateSnapshot,
-  CacheLayer,
-  CacheLogger,
-  CacheMGetEntry,
-  CacheMSetEntry,
-  CacheMetricsSnapshot,
-  CacheSingleFlightExecutionOptions,
-  CacheSnapshotEntry,
-  CacheStackEvents,
-  CacheStackOptions,
-  CacheStatsSnapshot,
-  CacheTagIndex,
-  CacheWarmEntry,
-  CacheWarmOptions,
-  CacheWarmProgress,
-  CacheWrapOptions,
-  CacheWriteOptions,
-  InvalidationMessage,
-  LayerTtlMap
+import {
+  type CacheAdaptiveTtlOptions,
+  type CacheCircuitBreakerOptions,
+  type CacheGetOptions,
+  type CacheHitRateSnapshot,
+  type CacheInspectResult,
+  type CacheLayer,
+  type CacheLogger,
+  type CacheMGetEntry,
+  type CacheMSetEntry,
+  type CacheMetricsSnapshot,
+  CacheMissError,
+  type CacheSingleFlightExecutionOptions,
+  type CacheSnapshotEntry,
+  type CacheStackEvents,
+  type CacheStackOptions,
+  type CacheStatsSnapshot,
+  type CacheTagIndex,
+  type CacheWarmEntry,
+  type CacheWarmOptions,
+  type CacheWarmProgress,
+  type CacheWrapOptions,
+  type CacheWriteOptions,
+  type InvalidationMessage,
+  type LayerTtlMap
 } from './types'
 
 const DEFAULT_SINGLE_FLIGHT_LEASE_MS = 30_000
@@ -210,6 +212,19 @@ export class CacheStack extends EventEmitter {
    */
   async getOrSet<T>(key: string, fetcher: () => Promise<T>, options?: CacheGetOptions): Promise<T | null> {
     return this.get(key, fetcher, options)
+  }
+
+  /**
+   * Like `get()`, but throws `CacheMissError` instead of returning `null`.
+   * Useful when the value is expected to exist or the fetcher is expected to
+   * return non-null.
+   */
+  async getOrThrow<T>(key: string, fetcher?: () => Promise<T>, options?: CacheGetOptions): Promise<T> {
+    const value = await this.get(key, fetcher, options)
+    if (value === null) {
+      throw new CacheMissError(key)
+    }
+    return value
   }
 
   /**
@@ -538,6 +553,65 @@ export class CacheStack extends EventEmitter {
     return this.metricsCollector.hitRate()
   }
 
+  /**
+   * Returns detailed metadata about a single cache key: which layers contain it,
+   * remaining fresh/stale/error TTLs, and associated tags.
+   * Returns `null` if the key does not exist in any layer.
+   */
+  async inspect(key: string): Promise<CacheInspectResult | null> {
+    const normalizedKey = this.validateCacheKey(key)
+    await this.startup
+
+    const foundInLayers: string[] = []
+    let freshTtlSeconds: number | null = null
+    let staleTtlSeconds: number | null = null
+    let errorTtlSeconds: number | null = null
+    let isStale = false
+
+    for (const layer of this.layers) {
+      if (this.shouldSkipLayer(layer)) {
+        continue
+      }
+      const stored = await this.readLayerEntry(layer, normalizedKey)
+      if (stored === null) {
+        continue
+      }
+
+      const resolved = resolveStoredValue(stored)
+      if (resolved.state === 'expired') {
+        continue
+      }
+
+      foundInLayers.push(layer.name)
+
+      // Take TTL info from the first (fastest) layer that has it
+      if (foundInLayers.length === 1 && resolved.envelope) {
+        const now = Date.now()
+        freshTtlSeconds =
+          resolved.envelope.freshUntil !== null
+            ? Math.max(0, Math.ceil((resolved.envelope.freshUntil - now) / 1_000))
+            : null
+        staleTtlSeconds =
+          resolved.envelope.staleUntil !== null
+            ? Math.max(0, Math.ceil((resolved.envelope.staleUntil - now) / 1_000))
+            : null
+        errorTtlSeconds =
+          resolved.envelope.errorUntil !== null
+            ? Math.max(0, Math.ceil((resolved.envelope.errorUntil - now) / 1_000))
+            : null
+        isStale = resolved.state === 'stale-while-revalidate' || resolved.state === 'stale-if-error'
+      }
+    }
+
+    if (foundInLayers.length === 0) {
+      return null
+    }
+
+    const tags = await this.getTagsForKey(normalizedKey)
+
+    return { key: normalizedKey, foundInLayers, freshTtlSeconds, staleTtlSeconds, errorTtlSeconds, isStale, tags }
+  }
+
   async exportState(): Promise<CacheSnapshotEntry[]> {
     await this.startup
     const exported = new Map<string, CacheSnapshotEntry>()
@@ -711,6 +785,11 @@ export class CacheStack extends EventEmitter {
       return null
     }
 
+    // Conditional caching: skip storage if shouldCache returns false
+    if (options?.shouldCache && !options.shouldCache(fetched)) {
+      return fetched
+    }
+
     await this.storeEntry(key, 'value', fetched, options)
     return fetched
   }
@@ -746,7 +825,10 @@ export class CacheStack extends EventEmitter {
     for (let index = 0; index < this.layers.length; index += 1) {
       const layer = this.layers[index]
       if (!layer) continue
+      const readStart = performance.now()
       const stored = await this.readLayerEntry(layer, key)
+      const readDuration = performance.now() - readStart
+      this.metricsCollector.recordLatency(layer.name, readDuration)
       if (stored === null) {
         this.metricsCollector.incrementLayer('missesByLayer', layer.name)
         continue
@@ -1005,6 +1087,13 @@ export class CacheStack extends EventEmitter {
         this.ttlResolver.deleteProfile(key)
       }
     }
+  }
+
+  private async getTagsForKey(key: string): Promise<string[]> {
+    if (this.tagIndex.tagsForKey) {
+      return this.tagIndex.tagsForKey(key)
+    }
+    return []
   }
 
   private formatError(error: unknown): string {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -60,7 +60,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
         const tagIndex = new RedisTagIndex({ client: redis, prefix: args.tagIndexPrefix ?? 'layercache:tag-index' })
         const keys = await tagIndex.keysForTag(args.tag)
         if (keys.length > 0) {
-          await redis.del(...keys)
+          await batchDelete(redis, keys)
         }
         process.stdout.write(`${JSON.stringify({ deletedKeys: keys.length, tag: args.tag }, null, 2)}\n`)
         return
@@ -68,7 +68,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
 
       const keys = await scanKeys(redis, args.pattern ?? '*')
       if (keys.length > 0) {
-        await redis.del(...keys)
+        await batchDelete(redis, keys)
       }
       process.stdout.write(`${JSON.stringify({ deletedKeys: keys.length, pattern: args.pattern ?? '*' }, null, 2)}\n`)
       return
@@ -128,6 +128,15 @@ function parseArgs(argv: string[]): ParsedArgs {
   }
 
   return parsed
+}
+
+const BATCH_DELETE_SIZE = 500
+
+async function batchDelete(redis: Redis, keys: string[]): Promise<void> {
+  for (let i = 0; i < keys.length; i += BATCH_DELETE_SIZE) {
+    const batch = keys.slice(i, i + BATCH_DELETE_SIZE)
+    await redis.del(...batch)
+  }
 }
 
 async function scanKeys(redis: Redis, pattern: string): Promise<string[]> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export { TagIndex } from './invalidation/TagIndex'
 export { createCacheStatsHandler } from './http/createCacheStatsHandler'
 export { createCachedMethodDecorator } from './decorators/createCachedMethodDecorator'
 export { createFastifyLayercachePlugin } from './integrations/fastify'
+export { createExpressCacheMiddleware } from './integrations/express'
 export { cacheGraphqlResolver } from './integrations/graphql'
 export { createTrpcCacheMiddleware } from './integrations/trpc'
 export { MemoryLayer } from './layers/MemoryLayer'
@@ -20,31 +21,34 @@ export { MsgpackSerializer } from './serialization/MsgpackSerializer'
 export { RedisSingleFlightCoordinator } from './singleflight/RedisSingleFlightCoordinator'
 export { StampedeGuard } from './stampede/StampedeGuard'
 export { createPrometheusMetricsExporter } from './metrics/PrometheusExporter'
-export type {
-  CacheSingleFlightCoordinator,
-  CacheSingleFlightExecutionOptions,
-  CacheAdaptiveTtlOptions,
-  CacheCircuitBreakerOptions,
-  CacheDegradationOptions,
-  CacheHitRateSnapshot,
-  CacheStackEvents,
-  CacheStackOptions,
-  CacheStatsSnapshot,
-  CacheSnapshotEntry,
-  CacheWarmEntry,
-  CacheWarmOptions,
-  CacheWarmProgress,
-  CacheWrapOptions,
-  CacheGetOptions,
-  CacheLayer,
-  CacheLogger,
-  CacheMGetEntry,
-  CacheMetricsSnapshot,
-  CacheMSetEntry,
-  CacheTagIndex,
-  CacheSerializer,
-  CacheWriteOptions,
-  InvalidationBus,
-  InvalidationMessage,
-  LayerTtlMap
+export {
+  CacheMissError,
+  type CacheSingleFlightCoordinator,
+  type CacheSingleFlightExecutionOptions,
+  type CacheAdaptiveTtlOptions,
+  type CacheCircuitBreakerOptions,
+  type CacheDegradationOptions,
+  type CacheHitRateSnapshot,
+  type CacheInspectResult,
+  type CacheLayerLatency,
+  type CacheStackEvents,
+  type CacheStackOptions,
+  type CacheStatsSnapshot,
+  type CacheSnapshotEntry,
+  type CacheWarmEntry,
+  type CacheWarmOptions,
+  type CacheWarmProgress,
+  type CacheWrapOptions,
+  type CacheGetOptions,
+  type CacheLayer,
+  type CacheLogger,
+  type CacheMGetEntry,
+  type CacheMetricsSnapshot,
+  type CacheMSetEntry,
+  type CacheTagIndex,
+  type CacheSerializer,
+  type CacheWriteOptions,
+  type InvalidationBus,
+  type InvalidationMessage,
+  type LayerTtlMap
 } from './types'

--- a/src/integrations/express.ts
+++ b/src/integrations/express.ts
@@ -1,0 +1,85 @@
+import type { CacheStack } from '../CacheStack'
+import type { CacheGetOptions } from '../types'
+
+interface ExpressLikeRequest {
+  method?: string
+  url?: string
+  originalUrl?: string
+  path?: string
+  query?: Record<string, unknown>
+}
+
+interface ExpressLikeResponse {
+  statusCode?: number
+  setHeader?: (name: string, value: string) => void
+  json?: (body: unknown) => void
+  end?: (body?: string) => void
+}
+
+type NextFunction = (error?: unknown) => void
+
+interface ExpressCacheMiddlewareOptions extends CacheGetOptions {
+  /**
+   * Resolves a cache key from the incoming request. Defaults to
+   * `GET:<req.originalUrl || req.url>`.
+   */
+  keyResolver?: (req: ExpressLikeRequest) => string
+  /**
+   * Only cache responses for these HTTP methods. Defaults to `['GET']`.
+   */
+  methods?: string[]
+}
+
+/**
+ * Express/Connect-compatible middleware that caches JSON responses.
+ *
+ * ```ts
+ * import express from 'express'
+ * import { CacheStack, MemoryLayer, createExpressCacheMiddleware } from 'layercache'
+ *
+ * const cache = new CacheStack([new MemoryLayer({ ttl: 60 })])
+ * const app = express()
+ *
+ * app.get('/api/data', createExpressCacheMiddleware(cache, { ttl: 30 }), (req, res) => {
+ *   res.json({ fresh: true })
+ * })
+ * ```
+ */
+export function createExpressCacheMiddleware(cache: CacheStack, options: ExpressCacheMiddlewareOptions = {}) {
+  const allowedMethods = new Set((options.methods ?? ['GET']).map((m) => m.toUpperCase()))
+
+  return async (req: ExpressLikeRequest, res: ExpressLikeResponse, next: NextFunction): Promise<void> => {
+    const method = (req.method ?? 'GET').toUpperCase()
+    if (!allowedMethods.has(method)) {
+      next()
+      return
+    }
+
+    const key = options.keyResolver ? options.keyResolver(req) : `${method}:${req.originalUrl ?? req.url ?? '/'}`
+
+    const cached = await cache.get<unknown>(key, undefined, options)
+    if (cached !== null) {
+      res.setHeader?.('content-type', 'application/json; charset=utf-8')
+      res.setHeader?.('x-cache', 'HIT')
+      if (res.json) {
+        res.json(cached)
+      } else {
+        res.end?.(JSON.stringify(cached))
+      }
+      return
+    }
+
+    // Intercept res.json to capture the response body for caching
+    const originalJson = res.json?.bind(res)
+    if (originalJson) {
+      res.json = (body: unknown) => {
+        res.setHeader?.('x-cache', 'MISS')
+        // Fire and forget — don't delay the response
+        void cache.set(key, body, options)
+        return originalJson(body)
+      }
+    }
+
+    next()
+  }
+}

--- a/src/internal/MetricsCollector.ts
+++ b/src/internal/MetricsCollector.ts
@@ -1,18 +1,45 @@
-import type { CacheHitRateSnapshot, CacheMetricsSnapshot } from '../types'
+import type { CacheHitRateSnapshot, CacheLayerLatency, CacheMetricsSnapshot } from '../types'
 
 export class MetricsCollector {
   private data: CacheMetricsSnapshot = this.empty()
 
   get snapshot(): CacheMetricsSnapshot {
-    return { ...this.data }
+    return {
+      ...this.data,
+      hitsByLayer: { ...this.data.hitsByLayer },
+      missesByLayer: { ...this.data.missesByLayer },
+      latencyByLayer: Object.fromEntries(Object.entries(this.data.latencyByLayer).map(([k, v]) => [k, { ...v }]))
+    }
   }
 
-  increment(field: keyof Omit<CacheMetricsSnapshot, 'hitsByLayer' | 'missesByLayer' | 'resetAt'>, amount = 1): void {
+  increment(
+    field: keyof Omit<CacheMetricsSnapshot, 'hitsByLayer' | 'missesByLayer' | 'latencyByLayer' | 'resetAt'>,
+    amount = 1
+  ): void {
     ;(this.data[field] as number) += amount
   }
 
   incrementLayer(map: 'hitsByLayer' | 'missesByLayer', layerName: string): void {
     this.data[map][layerName] = (this.data[map][layerName] ?? 0) + 1
+  }
+
+  /**
+   * Records a read latency sample for the given layer.
+   * Maintains a rolling average and max using Welford's online algorithm.
+   */
+  recordLatency(layerName: string, durationMs: number): void {
+    const existing = this.data.latencyByLayer[layerName]
+    if (!existing) {
+      this.data.latencyByLayer[layerName] = { avgMs: durationMs, maxMs: durationMs, count: 1 }
+      return
+    }
+
+    existing.count += 1
+    // Welford's online mean update: avg_n = avg_{n-1} + (x - avg_{n-1}) / n
+    existing.avgMs += (durationMs - existing.avgMs) / existing.count
+    if (durationMs > existing.maxMs) {
+      existing.maxMs = durationMs
+    }
   }
 
   reset(): void {
@@ -53,6 +80,7 @@ export class MetricsCollector {
       degradedOperations: 0,
       hitsByLayer: {},
       missesByLayer: {},
+      latencyByLayer: {},
       resetAt: Date.now()
     }
   }

--- a/src/invalidation/RedisInvalidationBus.ts
+++ b/src/invalidation/RedisInvalidationBus.ts
@@ -7,11 +7,19 @@ interface RedisInvalidationBusOptions {
   channel?: string
 }
 
+/**
+ * Redis pub/sub invalidation bus.
+ *
+ * Supports multiple concurrent subscriptions — each `CacheStack` instance
+ * can independently call `subscribe()` and receive its own unsubscribe handle.
+ * The underlying Redis SUBSCRIBE is only issued once and shared across all handlers.
+ */
 export class RedisInvalidationBus implements InvalidationBus {
   private readonly channel: string
   private readonly publisher: Redis
   private readonly subscriber: Redis
-  private activeListener?: (_channel: string, payload: string) => void
+  private readonly handlers = new Set<(message: InvalidationMessage) => Promise<void> | void>()
+  private sharedListener?: (_channel: string, payload: string) => void
 
   constructor(options: RedisInvalidationBusOptions) {
     this.publisher = options.publisher
@@ -20,26 +28,27 @@ export class RedisInvalidationBus implements InvalidationBus {
   }
 
   async subscribe(handler: (message: InvalidationMessage) => Promise<void> | void): Promise<() => Promise<void>> {
-    if (this.activeListener) {
-      throw new Error('RedisInvalidationBus already has an active subscription.')
+    // First subscriber — attach to Redis
+    if (this.handlers.size === 0) {
+      const listener = (_channel: string, payload: string): void => {
+        void this.dispatchToHandlers(payload)
+      }
+      this.sharedListener = listener
+      this.subscriber.on('message', listener)
+      await this.subscriber.subscribe(this.channel)
     }
 
-    const listener = (_channel: string, payload: string): void => {
-      void this.handleMessage(payload, handler)
-    }
-
-    this.activeListener = listener
-    this.subscriber.on('message', listener)
-    await this.subscriber.subscribe(this.channel)
+    this.handlers.add(handler)
 
     return async () => {
-      if (this.activeListener !== listener) {
-        return
-      }
+      this.handlers.delete(handler)
 
-      this.activeListener = undefined
-      this.subscriber.off('message', listener)
-      await this.subscriber.unsubscribe(this.channel)
+      // Last subscriber — detach from Redis
+      if (this.handlers.size === 0 && this.sharedListener) {
+        this.subscriber.off('message', this.sharedListener)
+        this.sharedListener = undefined
+        await this.subscriber.unsubscribe(this.channel)
+      }
     }
   }
 
@@ -47,10 +56,7 @@ export class RedisInvalidationBus implements InvalidationBus {
     await this.publisher.publish(this.channel, JSON.stringify(message))
   }
 
-  private async handleMessage(
-    payload: string,
-    handler: (message: InvalidationMessage) => Promise<void> | void
-  ): Promise<void> {
+  private async dispatchToHandlers(payload: string): Promise<void> {
     let message: InvalidationMessage
 
     try {
@@ -64,11 +70,15 @@ export class RedisInvalidationBus implements InvalidationBus {
       return
     }
 
-    try {
-      await handler(message)
-    } catch (error) {
-      this.reportError('invalidation handler failed', error)
-    }
+    await Promise.all(
+      [...this.handlers].map(async (handler) => {
+        try {
+          await handler(message)
+        } catch (error) {
+          this.reportError('invalidation handler failed', error)
+        }
+      })
+    )
   }
 
   private isInvalidationMessage(value: unknown): value is InvalidationMessage {

--- a/src/invalidation/RedisTagIndex.ts
+++ b/src/invalidation/RedisTagIndex.ts
@@ -65,6 +65,10 @@ export class RedisTagIndex implements CacheTagIndex {
     return this.client.smembers(this.tagKeysKey(tag))
   }
 
+  async tagsForKey(key: string): Promise<string[]> {
+    return this.client.smembers(this.keyTagsKey(key))
+  }
+
   async matchPattern(pattern: string): Promise<string[]> {
     const matches: string[] = []
     let cursor = '0'

--- a/src/invalidation/TagIndex.ts
+++ b/src/invalidation/TagIndex.ts
@@ -1,17 +1,33 @@
 import type { CacheTagIndex } from '../types'
 import { PatternMatcher } from './PatternMatcher'
 
+interface TagIndexOptions {
+  /**
+   * Maximum number of keys tracked in `knownKeys`. When exceeded, the oldest
+   * 10 % of keys are pruned to keep memory bounded.
+   * Defaults to unlimited.
+   */
+  maxKnownKeys?: number
+}
+
 export class TagIndex implements CacheTagIndex {
   private readonly tagToKeys = new Map<string, Set<string>>()
   private readonly keyToTags = new Map<string, Set<string>>()
   private readonly knownKeys = new Set<string>()
+  private readonly maxKnownKeys: number | undefined
+
+  constructor(options: TagIndexOptions = {}) {
+    this.maxKnownKeys = options.maxKnownKeys
+  }
 
   async touch(key: string): Promise<void> {
     this.knownKeys.add(key)
+    this.pruneKnownKeysIfNeeded()
   }
 
   async track(key: string, tags: string[]): Promise<void> {
     this.knownKeys.add(key)
+    this.pruneKnownKeysIfNeeded()
 
     if (tags.length === 0) {
       return
@@ -60,6 +76,10 @@ export class TagIndex implements CacheTagIndex {
     return [...(this.tagToKeys.get(tag) ?? new Set<string>())]
   }
 
+  async tagsForKey(key: string): Promise<string[]> {
+    return [...(this.keyToTags.get(key) ?? new Set<string>())]
+  }
+
   async matchPattern(pattern: string): Promise<string[]> {
     return [...this.knownKeys].filter((key) => PatternMatcher.matches(pattern, key))
   }
@@ -68,5 +88,23 @@ export class TagIndex implements CacheTagIndex {
     this.tagToKeys.clear()
     this.keyToTags.clear()
     this.knownKeys.clear()
+  }
+
+  private pruneKnownKeysIfNeeded(): void {
+    if (this.maxKnownKeys === undefined || this.knownKeys.size <= this.maxKnownKeys) {
+      return
+    }
+
+    // Remove the oldest 10% of keys (Set iteration preserves insertion order)
+    const toRemove = Math.ceil(this.maxKnownKeys * 0.1)
+    let removed = 0
+    for (const key of this.knownKeys) {
+      if (removed >= toRemove) {
+        break
+      }
+      this.knownKeys.delete(key)
+      this.keyToTags.delete(key)
+      removed += 1
+    }
   }
 }

--- a/src/layers/DiskLayer.ts
+++ b/src/layers/DiskLayer.ts
@@ -10,9 +10,17 @@ interface DiskLayerOptions {
   ttl?: number
   name?: string
   serializer?: CacheSerializer
+  /**
+   * Maximum number of cache files to store on disk. When exceeded, the oldest
+   * entries (by file mtime) are evicted to keep the directory bounded.
+   * Defaults to unlimited.
+   */
+  maxFiles?: number
 }
 
 interface DiskEntry {
+  /** Original cache key — stored so that keys() can return real key names. */
+  key: string
   value: unknown
   expiresAt: number | null
 }
@@ -21,6 +29,9 @@ interface DiskEntry {
  * A file-system backed cache layer.
  * Each key is stored as a separate JSON file in `directory`.
  * Useful for persisting cache across process restarts without needing Redis.
+ *
+ * - `keys()` returns the original cache key strings (not hashes).
+ * - `maxFiles` limits on-disk entries; when exceeded, oldest files are evicted.
  *
  * NOTE: DiskLayer is designed for low-to-medium traffic scenarios.
  * For high-throughput workloads, use MemoryLayer + RedisLayer.
@@ -32,12 +43,14 @@ export class DiskLayer implements CacheLayer {
 
   private readonly directory: string
   private readonly serializer: CacheSerializer
+  private readonly maxFiles: number | undefined
 
   constructor(options: DiskLayerOptions) {
     this.directory = options.directory
     this.defaultTtl = options.ttl
     this.name = options.name ?? 'disk'
     this.serializer = options.serializer ?? new JsonSerializer()
+    this.maxFiles = options.maxFiles
   }
 
   async get<T>(key: string): Promise<T | null> {
@@ -72,11 +85,16 @@ export class DiskLayer implements CacheLayer {
   async set(key: string, value: unknown, ttl = this.defaultTtl): Promise<void> {
     await fs.mkdir(this.directory, { recursive: true })
     const entry: DiskEntry = {
+      key,
       value,
       expiresAt: ttl && ttl > 0 ? Date.now() + ttl * 1_000 : null
     }
     const payload = this.serializer.serialize(entry)
     await fs.writeFile(this.keyToPath(key), payload)
+
+    if (this.maxFiles !== undefined) {
+      await this.enforceMaxFiles()
+    }
   }
 
   async has(key: string): Promise<boolean> {
@@ -132,6 +150,10 @@ export class DiskLayer implements CacheLayer {
     )
   }
 
+  /**
+   * Returns the original cache key strings stored on disk.
+   * Expired entries are skipped and cleaned up during the scan.
+   */
   async keys(): Promise<string[]> {
     let entries: string[]
     try {
@@ -140,9 +162,37 @@ export class DiskLayer implements CacheLayer {
       return []
     }
 
-    // Keys are encoded in the filenames; we can only return them as filenames
-    // since the hash is one-way. Return the raw hash names stripped of extension.
-    return entries.filter((name) => name.endsWith('.lc')).map((name) => name.slice(0, -3))
+    const lcFiles = entries.filter((name) => name.endsWith('.lc'))
+    const keys: string[] = []
+
+    await Promise.all(
+      lcFiles.map(async (name) => {
+        const filePath = join(this.directory, name)
+        let raw: Buffer
+        try {
+          raw = await fs.readFile(filePath)
+        } catch {
+          return
+        }
+
+        let entry: DiskEntry
+        try {
+          entry = this.serializer.deserialize<DiskEntry>(raw)
+        } catch {
+          await this.safeDelete(filePath)
+          return
+        }
+
+        if (entry.expiresAt !== null && entry.expiresAt <= Date.now()) {
+          await this.safeDelete(filePath)
+          return
+        }
+
+        keys.push(entry.key)
+      })
+    )
+
+    return keys
   }
 
   async size(): Promise<number> {
@@ -162,5 +212,43 @@ export class DiskLayer implements CacheLayer {
     } catch {
       // File already gone — not an error
     }
+  }
+
+  /**
+   * Removes the oldest files (by mtime) when the directory exceeds maxFiles.
+   */
+  private async enforceMaxFiles(): Promise<void> {
+    if (this.maxFiles === undefined) {
+      return
+    }
+
+    let entries: string[]
+    try {
+      entries = await fs.readdir(this.directory)
+    } catch {
+      return
+    }
+
+    const lcFiles = entries.filter((name) => name.endsWith('.lc'))
+    if (lcFiles.length <= this.maxFiles) {
+      return
+    }
+
+    // Collect mtime for each file and sort oldest-first
+    const withStats = await Promise.all(
+      lcFiles.map(async (name) => {
+        const filePath = join(this.directory, name)
+        try {
+          const stat = await fs.stat(filePath)
+          return { filePath, mtimeMs: stat.mtimeMs }
+        } catch {
+          return { filePath, mtimeMs: 0 }
+        }
+      })
+    )
+
+    withStats.sort((a, b) => a.mtimeMs - b.mtimeMs)
+    const toEvict = withStats.slice(0, lcFiles.length - this.maxFiles)
+    await Promise.all(toEvict.map(({ filePath }) => this.safeDelete(filePath)))
   }
 }

--- a/src/layers/MemcachedLayer.ts
+++ b/src/layers/MemcachedLayer.ts
@@ -1,4 +1,6 @@
-import type { CacheLayer } from '../types'
+import { unwrapStoredValue } from '../internal/StoredValue'
+import { JsonSerializer } from '../serialization/JsonSerializer'
+import type { CacheLayer, CacheSerializer } from '../types'
 
 /**
  * Minimal interface that MemcachedLayer expects from a Memcached client.
@@ -19,10 +21,14 @@ interface MemcachedLayerOptions {
   ttl?: number
   name?: string
   keyPrefix?: string
+  serializer?: CacheSerializer
 }
 
 /**
  * Memcached-backed cache layer.
+ *
+ * Now supports pluggable serializers (default: JSON), StoredValueEnvelope
+ * for stale-while-revalidate / stale-if-error semantics, and bulk reads.
  *
  * Example usage with `memjs`:
  * ```ts
@@ -43,32 +49,47 @@ export class MemcachedLayer implements CacheLayer {
 
   private readonly client: MemcachedClient
   private readonly keyPrefix: string
+  private readonly serializer: CacheSerializer
 
   constructor(options: MemcachedLayerOptions) {
     this.client = options.client
     this.defaultTtl = options.ttl
     this.name = options.name ?? 'memcached'
     this.keyPrefix = options.keyPrefix ?? ''
+    this.serializer = options.serializer ?? new JsonSerializer()
   }
 
   async get<T>(key: string): Promise<T | null> {
+    return unwrapStoredValue<T>(await this.getEntry<T>(key))
+  }
+
+  async getEntry<T = unknown>(key: string): Promise<T | null> {
     const result = await this.client.get(this.withPrefix(key))
     if (!result || result.value === null) {
       return null
     }
 
     try {
-      return JSON.parse(result.value.toString('utf8')) as T
+      return this.serializer.deserialize<T>(result.value)
     } catch {
       return null
     }
   }
 
+  async getMany<T>(keys: string[]): Promise<Array<T | null>> {
+    return Promise.all(keys.map((key) => this.getEntry<T>(key)))
+  }
+
   async set(key: string, value: unknown, ttl = this.defaultTtl): Promise<void> {
-    const payload = JSON.stringify(value)
-    await this.client.set(this.withPrefix(key), payload, {
+    const payload = this.serializer.serialize(value)
+    await this.client.set(this.withPrefix(key), payload as string | Buffer, {
       expires: ttl && ttl > 0 ? ttl : undefined
     })
+  }
+
+  async has(key: string): Promise<boolean> {
+    const result = await this.client.get(this.withPrefix(key))
+    return result !== null && result.value !== null
   }
 
   async delete(key: string): Promise<void> {

--- a/src/layers/MemoryLayer.ts
+++ b/src/layers/MemoryLayer.ts
@@ -25,9 +25,9 @@ interface MemoryLayerOptions {
 interface MemoryEntry {
   value: unknown
   expiresAt: number | null
-  /** Insertion order for FIFO, access count for LFU */
-  frequency: number
-  /** Insertion timestamp, used as tiebreaker */
+  /** Access count — used by LFU to find the least-frequently-used entry. */
+  accessCount: number
+  /** Insertion timestamp in ms — used as a tiebreaker for LFU eviction. */
   insertedAt: number
 }
 
@@ -64,14 +64,15 @@ export class MemoryLayer implements CacheLayer {
     }
 
     if (this.evictionPolicy === 'lru') {
-      // Re-insert to move to "most recently used" position
+      // Re-insert to move to "most recently used" position in Map iteration order
       this.entries.delete(key)
-      entry.frequency += 1
+      entry.accessCount += 1
       this.entries.set(key, entry)
-    } else {
-      // LFU / FIFO: just bump frequency counter
-      entry.frequency += 1
+    } else if (this.evictionPolicy === 'lfu') {
+      // Increment access count so the least-frequently-used entry can be found
+      entry.accessCount += 1
     }
+    // FIFO: access does not affect eviction order — no update needed
 
     return entry.value as T
   }
@@ -89,7 +90,7 @@ export class MemoryLayer implements CacheLayer {
     this.entries.set(key, {
       value,
       expiresAt: ttl && ttl > 0 ? Date.now() + ttl * 1_000 : null,
-      frequency: 0,
+      accessCount: 0,
       insertedAt: Date.now()
     })
 
@@ -167,7 +168,7 @@ export class MemoryLayer implements CacheLayer {
       this.entries.set(entry.key, {
         value: entry.value,
         expiresAt: entry.expiresAt,
-        frequency: 0,
+        accessCount: 0,
         insertedAt: Date.now()
       })
     }
@@ -187,13 +188,13 @@ export class MemoryLayer implements CacheLayer {
       return
     }
 
-    // LFU: evict entry with smallest frequency; break ties by insertedAt (oldest)
+    // LFU: evict entry with smallest accessCount; break ties by insertedAt (oldest)
     let victimKey: string | undefined
-    let minFreq = Number.POSITIVE_INFINITY
+    let minCount = Number.POSITIVE_INFINITY
     let minInsertedAt = Number.POSITIVE_INFINITY
     for (const [key, entry] of this.entries.entries()) {
-      if (entry.frequency < minFreq || (entry.frequency === minFreq && entry.insertedAt < minInsertedAt)) {
-        minFreq = entry.frequency
+      if (entry.accessCount < minCount || (entry.accessCount === minCount && entry.insertedAt < minInsertedAt)) {
+        minCount = entry.accessCount
         minInsertedAt = entry.insertedAt
         victimKey = key
       }

--- a/src/layers/RedisLayer.ts
+++ b/src/layers/RedisLayer.ts
@@ -1,4 +1,5 @@
-import { brotliCompressSync, brotliDecompressSync, gunzipSync, gzipSync } from 'node:zlib'
+import { promisify } from 'node:util'
+import { brotliCompress, brotliDecompress, gunzip, gzip } from 'node:zlib'
 import type Redis from 'ioredis'
 import { unwrapStoredValue } from '../internal/StoredValue'
 import { JsonSerializer } from '../serialization/JsonSerializer'
@@ -7,6 +8,11 @@ import type { CacheLayer, CacheSerializer } from '../types'
 type CompressionAlgorithm = 'gzip' | 'brotli'
 
 const BATCH_DELETE_SIZE = 500
+
+const gzipAsync = promisify(gzip)
+const gunzipAsync = promisify(gunzip)
+const brotliCompressAsync = promisify(brotliCompress)
+const brotliDecompressAsync = promisify(brotliDecompress)
 
 interface RedisLayerOptions {
   client: Redis
@@ -87,7 +93,8 @@ export class RedisLayer implements CacheLayer {
   }
 
   async set(key: string, value: unknown, ttl = this.defaultTtl): Promise<void> {
-    const payload = this.encodePayload(this.serializer.serialize(value))
+    const serialized = this.serializer.serialize(value)
+    const payload = await this.encodePayload(serialized)
     const normalizedKey = this.withPrefix(key)
 
     if (ttl && ttl > 0) {
@@ -186,7 +193,7 @@ export class RedisLayer implements CacheLayer {
 
   private async deserializeOrDelete<T>(key: string, payload: string | Buffer): Promise<T | null> {
     try {
-      return this.serializer.deserialize<T>(this.decodePayload(payload))
+      return this.serializer.deserialize<T>(await this.decodePayload(payload))
     } catch {
       await this.client.del(this.withPrefix(key)).catch(() => undefined)
       return null
@@ -197,7 +204,11 @@ export class RedisLayer implements CacheLayer {
     return typeof payload === 'string' || Buffer.isBuffer(payload)
   }
 
-  private encodePayload(payload: string | Buffer): string | Buffer {
+  /**
+   * Compresses the payload asynchronously if compression is enabled and the
+   * payload exceeds the threshold. This avoids blocking the event loop.
+   */
+  private async encodePayload(payload: string | Buffer): Promise<string | Buffer> {
     if (!this.compression) {
       return payload
     }
@@ -208,22 +219,25 @@ export class RedisLayer implements CacheLayer {
     }
 
     const header = Buffer.from(`LCZ1:${this.compression}:`)
-    const compressed = this.compression === 'gzip' ? gzipSync(source) : brotliCompressSync(source)
+    const compressed = this.compression === 'gzip' ? await gzipAsync(source) : await brotliCompressAsync(source)
 
     return Buffer.concat([header, compressed])
   }
 
-  private decodePayload(payload: string | Buffer): string | Buffer {
+  /**
+   * Decompresses the payload asynchronously if a compression header is present.
+   */
+  private async decodePayload(payload: string | Buffer): Promise<string | Buffer> {
     if (!Buffer.isBuffer(payload)) {
       return payload
     }
 
     if (payload.subarray(0, 10).toString() === 'LCZ1:gzip:') {
-      return gunzipSync(payload.subarray(10))
+      return gunzipAsync(payload.subarray(10))
     }
 
     if (payload.subarray(0, 12).toString() === 'LCZ1:brotli:') {
-      return brotliDecompressSync(payload.subarray(12))
+      return brotliDecompressAsync(payload.subarray(12))
     }
 
     return payload

--- a/src/metrics/PrometheusExporter.ts
+++ b/src/metrics/PrometheusExporter.ts
@@ -4,6 +4,9 @@ import type { CacheStack } from '../CacheStack'
  * Returns a function that generates a Prometheus-compatible text exposition
  * of the cache metrics from one or more CacheStack instances.
  *
+ * Now includes per-layer latency gauges (`layercache_layer_latency_avg_ms`,
+ * `layercache_layer_latency_max_ms`, `layercache_layer_latency_count`).
+ *
  * Usage example:
  * ```ts
  * const collect = createPrometheusMetricsExporter(cache)
@@ -54,6 +57,12 @@ export function createPrometheusMetricsExporter(
     lines.push('# TYPE layercache_hits_by_layer_total counter')
     lines.push('# HELP layercache_misses_by_layer_total Misses broken down by layer')
     lines.push('# TYPE layercache_misses_by_layer_total counter')
+    lines.push('# HELP layercache_layer_latency_avg_ms Average read latency per layer in milliseconds')
+    lines.push('# TYPE layercache_layer_latency_avg_ms gauge')
+    lines.push('# HELP layercache_layer_latency_max_ms Maximum read latency per layer in milliseconds')
+    lines.push('# TYPE layercache_layer_latency_max_ms gauge')
+    lines.push('# HELP layercache_layer_latency_count Number of read latency samples per layer')
+    lines.push('# TYPE layercache_layer_latency_count counter')
 
     for (const { stack, name } of entries) {
       const m = stack.getMetrics()
@@ -79,6 +88,12 @@ export function createPrometheusMetricsExporter(
       }
       for (const [layerName, count] of Object.entries(m.missesByLayer)) {
         lines.push(`layercache_misses_by_layer_total{${label},layer="${sanitizeLabel(layerName)}"} ${count}`)
+      }
+      for (const [layerName, latency] of Object.entries(m.latencyByLayer)) {
+        const layerLabel = `${label},layer="${sanitizeLabel(layerName)}"`
+        lines.push(`layercache_layer_latency_avg_ms{${layerLabel}} ${latency.avgMs.toFixed(4)}`)
+        lines.push(`layercache_layer_latency_max_ms{${layerLabel}} ${latency.maxMs.toFixed(4)}`)
+        lines.push(`layercache_layer_latency_count{${layerLabel}} ${latency.count}`)
       }
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,19 @@
 export type CacheValue = Record<string, unknown> | unknown[] | string | number | boolean | null
 
+/**
+ * Thrown by `CacheStack.getOrThrow()` when no value is found for the given key
+ * (fetcher returned null or no fetcher was provided and the key is absent).
+ */
+export class CacheMissError extends Error {
+  readonly key: string
+
+  constructor(key: string) {
+    super(`Cache miss for key "${key}".`)
+    this.name = 'CacheMissError'
+    this.key = key
+  }
+}
+
 export interface LayerTtlMap {
   [layerName: string]: number | undefined
 }
@@ -16,6 +30,15 @@ export interface CacheWriteOptions {
   refreshAhead?: number | LayerTtlMap
   adaptiveTtl?: boolean | CacheAdaptiveTtlOptions
   circuitBreaker?: CacheCircuitBreakerOptions
+  /**
+   * Optional predicate called with the fetcher's return value before caching.
+   * Return `false` to skip storing the value in the cache (but still return it
+   * to the caller). Useful for not caching failed API responses or empty results.
+   *
+   * @example
+   * cache.get('key', fetchData, { shouldCache: (v) => v.status === 200 })
+   */
+  shouldCache?: (value: unknown) => boolean
 }
 
 export interface CacheGetOptions extends CacheWriteOptions {}
@@ -68,6 +91,16 @@ export interface CacheSerializer {
   deserialize<T>(payload: string | Buffer): T
 }
 
+/** Per-layer latency statistics (rolling window of sampled read durations). */
+export interface CacheLayerLatency {
+  /** Average read latency in milliseconds. */
+  avgMs: number
+  /** Maximum observed read latency in milliseconds. */
+  maxMs: number
+  /** Number of samples used to compute the statistics. */
+  count: number
+}
+
 /** Snapshot of cumulative cache counters. */
 export interface CacheMetricsSnapshot {
   hits: number
@@ -87,6 +120,8 @@ export interface CacheMetricsSnapshot {
   degradedOperations: number
   hitsByLayer: Record<string, number>
   missesByLayer: Record<string, number>
+  /** Per-layer read latency statistics (sampled from successful reads). */
+  latencyByLayer: Record<string, CacheLayerLatency>
   /** Timestamp (ms since epoch) when metrics were last reset. */
   resetAt: number
 }
@@ -111,6 +146,8 @@ export interface CacheTagIndex {
   track(key: string, tags: string[]): Promise<void>
   remove(key: string): Promise<void>
   keysForTag(tag: string): Promise<string[]>
+  /** Returns the tags associated with a specific key, or an empty array. */
+  tagsForKey?(key: string): Promise<string[]>
   matchPattern(pattern: string): Promise<string[]>
   clear(): Promise<void>
 }
@@ -231,6 +268,23 @@ export interface CacheStatsSnapshot {
     degradedUntil: number | null
   }>
   backgroundRefreshes: number
+}
+
+/** Detailed inspection result for a single cache key. */
+export interface CacheInspectResult {
+  key: string
+  /** Layers in which the key is currently stored (not expired). */
+  foundInLayers: string[]
+  /** Remaining fresh TTL in seconds, or null if no expiry or not an envelope. */
+  freshTtlSeconds: number | null
+  /** Remaining stale-while-revalidate window in seconds, or null. */
+  staleTtlSeconds: number | null
+  /** Remaining stale-if-error window in seconds, or null. */
+  errorTtlSeconds: number | null
+  /** Whether the key is currently serving stale-while-revalidate. */
+  isStale: boolean
+  /** Tags associated with this key (from the TagIndex). */
+  tags: string[]
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/invalidation/RedisInvalidationBus.test.ts
+++ b/tests/invalidation/RedisInvalidationBus.test.ts
@@ -78,16 +78,41 @@ describe('RedisInvalidationBus', () => {
     subscriber.disconnect()
   })
 
-  it('prevents multiple active subscriptions on the same bus instance', async () => {
+  it('supports multiple concurrent subscriptions', async () => {
     const publisher = new Redis()
     const subscriber = publisher.duplicate()
-    const bus = new RedisInvalidationBus({ publisher, subscriber, channel: 'layercache:test:duplicate-subscribe' })
+    const bus = new RedisInvalidationBus({ publisher, subscriber, channel: 'layercache:test:multi-subscribe' })
 
-    const unsubscribe = await bus.subscribe(() => undefined)
+    const handler1 = vi.fn()
+    const handler2 = vi.fn()
 
-    await expect(bus.subscribe(() => undefined)).rejects.toThrow(/active subscription/i)
+    const unsub1 = await bus.subscribe(handler1)
+    const unsub2 = await bus.subscribe(handler2)
 
-    await unsubscribe()
+    await publisher.publish(
+      'layercache:test:multi-subscribe',
+      JSON.stringify({ scope: 'key', sourceId: 'inst', keys: ['k'], operation: 'delete' })
+    )
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(handler1).toHaveBeenCalledTimes(1)
+    expect(handler2).toHaveBeenCalledTimes(1)
+
+    // Unsubscribing one handler should not affect the other
+    await unsub1()
+
+    await publisher.publish(
+      'layercache:test:multi-subscribe',
+      JSON.stringify({ scope: 'clear', sourceId: 'inst', operation: 'clear' })
+    )
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(handler1).toHaveBeenCalledTimes(1) // no more calls
+    expect(handler2).toHaveBeenCalledTimes(2)
+
+    await unsub2()
     publisher.disconnect()
     subscriber.disconnect()
   })

--- a/tests/layers/DiskLayer.test.ts
+++ b/tests/layers/DiskLayer.test.ts
@@ -1,0 +1,131 @@
+import { promises as fs } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { DiskLayer } from '../../src/layers/DiskLayer'
+
+describe('DiskLayer', () => {
+  let dir: string
+  let layer: DiskLayer
+
+  beforeEach(async () => {
+    dir = join(tmpdir(), `layercache-disk-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    layer = new DiskLayer({ directory: dir, ttl: 60 })
+  })
+
+  afterEach(async () => {
+    try {
+      await fs.rm(dir, { recursive: true, force: true })
+    } catch {
+      // ignore
+    }
+  })
+
+  it('should set and get a value', async () => {
+    await layer.set('key1', { hello: 'world' })
+    const result = await layer.get<{ hello: string }>('key1')
+    expect(result).toEqual({ hello: 'world' })
+  })
+
+  it('should return null for a missing key', async () => {
+    const result = await layer.get('nonexistent')
+    expect(result).toBeNull()
+  })
+
+  it('should delete a key', async () => {
+    await layer.set('key1', 'value1')
+    await layer.delete('key1')
+    const result = await layer.get('key1')
+    expect(result).toBeNull()
+  })
+
+  it('should return correct size', async () => {
+    await layer.set('a', 1)
+    await layer.set('b', 2)
+    expect(await layer.size()).toBe(2)
+    await layer.delete('a')
+    expect(await layer.size()).toBe(1)
+  })
+
+  it('should clear all entries', async () => {
+    await layer.set('a', 1)
+    await layer.set('b', 2)
+    await layer.clear()
+    expect(await layer.size()).toBe(0)
+  })
+
+  it('should return original keys from keys()', async () => {
+    await layer.set('user:1', 'alice')
+    await layer.set('user:2', 'bob')
+    const keys = await layer.keys()
+    expect(keys.sort()).toEqual(['user:1', 'user:2'])
+  })
+
+  it('should expire entries based on TTL', async () => {
+    const shortTtlLayer = new DiskLayer({ directory: dir, ttl: 0.001 })
+    await shortTtlLayer.set('expired-key', 'value')
+    // Wait for the entry to expire (1 ms TTL)
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    const result = await shortTtlLayer.get('expired-key')
+    expect(result).toBeNull()
+  })
+
+  it('should report has() correctly', async () => {
+    await layer.set('exists', true)
+    expect(await layer.has('exists')).toBe(true)
+    expect(await layer.has('nope')).toBe(false)
+  })
+
+  it('should report ttl() correctly', async () => {
+    await layer.set('with-ttl', 'val', 120)
+    const remaining = await layer.ttl('with-ttl')
+    expect(remaining).toBeGreaterThan(0)
+    expect(remaining).toBeLessThanOrEqual(120)
+  })
+
+  it('should return null ttl for missing key', async () => {
+    expect(await layer.ttl('missing')).toBeNull()
+  })
+
+  it('should deleteMany', async () => {
+    await layer.set('a', 1)
+    await layer.set('b', 2)
+    await layer.set('c', 3)
+    await layer.deleteMany(['a', 'c'])
+    expect(await layer.has('a')).toBe(false)
+    expect(await layer.has('b')).toBe(true)
+    expect(await layer.has('c')).toBe(false)
+  })
+
+  it('should enforce maxFiles', async () => {
+    const boundedLayer = new DiskLayer({ directory: dir, maxFiles: 3 })
+    await boundedLayer.set('a', 1)
+    await boundedLayer.set('b', 2)
+    await boundedLayer.set('c', 3)
+    await boundedLayer.set('d', 4) // should evict oldest
+    const keys = await boundedLayer.keys()
+    expect(keys.length).toBeLessThanOrEqual(3)
+  })
+
+  it('should store envelope (getEntry returns raw stored value)', async () => {
+    await layer.set('envelope-key', {
+      __layercache: 1,
+      kind: 'value',
+      value: 42,
+      freshUntil: null,
+      staleUntil: null,
+      errorUntil: null
+    })
+    const entry = await layer.getEntry('envelope-key')
+    expect(entry).toHaveProperty('__layercache', 1)
+  })
+
+  it('should handle corrupted files gracefully', async () => {
+    await fs.mkdir(dir, { recursive: true })
+    const { createHash } = await import('node:crypto')
+    const hash = createHash('sha256').update('bad-key').digest('hex')
+    await fs.writeFile(join(dir, `${hash}.lc`), 'not-json!!!')
+    const result = await layer.get('bad-key')
+    expect(result).toBeNull()
+  })
+})

--- a/tests/layers/MemcachedLayer.test.ts
+++ b/tests/layers/MemcachedLayer.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { MemcachedLayer } from '../../src/layers/MemcachedLayer'
+import type { MemcachedClient } from '../../src/layers/MemcachedLayer'
+import { MsgpackSerializer } from '../../src/serialization/MsgpackSerializer'
+
+/** Simple in-memory mock of the MemcachedClient interface. */
+class MockMemcachedClient implements MemcachedClient {
+  private store = new Map<string, { value: Buffer; expires?: number; setAt: number }>()
+
+  async get(key: string): Promise<{ value: Buffer | null } | null> {
+    const entry = this.store.get(key)
+    if (!entry) {
+      return null
+    }
+    if (entry.expires !== undefined && Date.now() > entry.setAt + entry.expires * 1_000) {
+      this.store.delete(key)
+      return null
+    }
+    return { value: entry.value }
+  }
+
+  async set(key: string, value: string | Buffer, options?: { expires?: number }): Promise<boolean> {
+    const buf = typeof value === 'string' ? Buffer.from(value) : value
+    this.store.set(key, { value: buf, expires: options?.expires, setAt: Date.now() })
+    return true
+  }
+
+  async delete(key: string): Promise<boolean> {
+    return this.store.delete(key)
+  }
+}
+
+describe('MemcachedLayer', () => {
+  let client: MockMemcachedClient
+  let layer: MemcachedLayer
+
+  beforeEach(() => {
+    client = new MockMemcachedClient()
+    layer = new MemcachedLayer({ client, ttl: 60 })
+  })
+
+  it('should set and get a value', async () => {
+    await layer.set('key1', { hello: 'world' })
+    const result = await layer.get<{ hello: string }>('key1')
+    expect(result).toEqual({ hello: 'world' })
+  })
+
+  it('should return null for missing key', async () => {
+    expect(await layer.get('missing')).toBeNull()
+  })
+
+  it('should delete a key', async () => {
+    await layer.set('key1', 'val')
+    await layer.delete('key1')
+    expect(await layer.get('key1')).toBeNull()
+  })
+
+  it('should deleteMany', async () => {
+    await layer.set('a', 1)
+    await layer.set('b', 2)
+    await layer.deleteMany(['a', 'b'])
+    expect(await layer.get('a')).toBeNull()
+    expect(await layer.get('b')).toBeNull()
+  })
+
+  it('should throw on clear()', async () => {
+    await expect(layer.clear()).rejects.toThrow('MemcachedLayer.clear() is not supported')
+  })
+
+  it('should support getEntry for StoredValueEnvelope', async () => {
+    const envelope = { __layercache: 1, kind: 'value', value: 42, freshUntil: null, staleUntil: null, errorUntil: null }
+    await layer.set('env', envelope)
+    const entry = await layer.getEntry('env')
+    expect(entry).toHaveProperty('__layercache', 1)
+  })
+
+  it('should support has()', async () => {
+    await layer.set('exists', true)
+    expect(await layer.has('exists')).toBe(true)
+    expect(await layer.has('nope')).toBe(false)
+  })
+
+  it('should support getMany', async () => {
+    await layer.set('a', 1)
+    await layer.set('b', 2)
+    const results = await layer.getMany(['a', 'b', 'c'])
+    expect(results).toHaveLength(3)
+    expect(results[2]).toBeNull()
+  })
+
+  it('should use keyPrefix', async () => {
+    const prefixed = new MemcachedLayer({ client, keyPrefix: 'app:', ttl: 60 })
+    await prefixed.set('key1', 'value1')
+    // Original client has the prefixed key
+    const raw = await client.get('app:key1')
+    expect(raw).not.toBeNull()
+    // Unprefixed layer should not see it
+    expect(await layer.get('key1')).toBeNull()
+  })
+
+  it('should use custom serializer', async () => {
+    const msgpackLayer = new MemcachedLayer({
+      client,
+      serializer: new MsgpackSerializer(),
+      ttl: 60
+    })
+    await msgpackLayer.set('key1', { foo: 'bar' })
+    const result = await msgpackLayer.get<{ foo: string }>('key1')
+    expect(result).toEqual({ foo: 'bar' })
+  })
+
+  it('should return null on deserialization error', async () => {
+    // Write garbage directly to the mock
+    await client.set('bad', 'not-valid-json!!!')
+    const result = await layer.get('bad')
+    expect(result).toBeNull()
+  })
+})

--- a/tests/metrics/PrometheusExporter.test.ts
+++ b/tests/metrics/PrometheusExporter.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import { CacheStack } from '../../src/CacheStack'
+import { MemoryLayer } from '../../src/layers/MemoryLayer'
+import { createPrometheusMetricsExporter } from '../../src/metrics/PrometheusExporter'
+
+describe('PrometheusExporter', () => {
+  it('should export valid prometheus text format for a single stack', async () => {
+    const cache = new CacheStack([new MemoryLayer({ ttl: 60 })])
+    const collect = createPrometheusMetricsExporter(cache)
+
+    // Generate some metrics
+    await cache.set('key1', 'value1')
+    await cache.get('key1')
+    await cache.get('missing')
+
+    const output = collect()
+
+    // Check TYPE and HELP lines exist
+    expect(output).toContain('# HELP layercache_hits_total')
+    expect(output).toContain('# TYPE layercache_hits_total counter')
+    expect(output).toContain('# HELP layercache_misses_total')
+    expect(output).toContain('# TYPE layercache_hit_rate gauge')
+
+    // Check counter lines contain correct label
+    expect(output).toContain('layercache_hits_total{cache="default"}')
+    expect(output).toContain('layercache_misses_total{cache="default"}')
+    expect(output).toContain('layercache_sets_total{cache="default"}')
+    expect(output).toContain('layercache_hit_rate{cache="default"}')
+
+    // Check per-layer metrics exist
+    expect(output).toContain('layercache_hits_by_layer_total{cache="default",layer="memory"}')
+
+    // Should end with a newline
+    expect(output.endsWith('\n')).toBe(true)
+
+    await cache.disconnect()
+  })
+
+  it('should export metrics for multiple named stacks', async () => {
+    const cache1 = new CacheStack([new MemoryLayer({ ttl: 10 })])
+    const cache2 = new CacheStack([new MemoryLayer({ ttl: 10, name: 'fast' })])
+
+    const collect = createPrometheusMetricsExporter([
+      { stack: cache1, name: 'primary' },
+      { stack: cache2, name: 'secondary' }
+    ])
+
+    await cache1.set('a', 1)
+    await cache2.set('b', 2)
+
+    const output = collect()
+
+    expect(output).toContain('cache="primary"')
+    expect(output).toContain('cache="secondary"')
+
+    await cache1.disconnect()
+    await cache2.disconnect()
+  })
+
+  it('should export latency metrics', async () => {
+    const cache = new CacheStack([new MemoryLayer({ ttl: 60 })])
+    const collect = createPrometheusMetricsExporter(cache)
+
+    await cache.set('key1', 'val')
+    await cache.get('key1')
+
+    const output = collect()
+
+    expect(output).toContain('# HELP layercache_layer_latency_avg_ms')
+    expect(output).toContain('# TYPE layercache_layer_latency_avg_ms gauge')
+    expect(output).toContain('layercache_layer_latency_avg_ms{cache="default",layer="memory"}')
+    expect(output).toContain('layercache_layer_latency_max_ms{cache="default",layer="memory"}')
+    expect(output).toContain('layercache_layer_latency_count{cache="default",layer="memory"}')
+
+    await cache.disconnect()
+  })
+
+  it('should sanitize label values', async () => {
+    const cache = new CacheStack([new MemoryLayer({ ttl: 10, name: 'layer"evil\\name\n' })])
+    const collect = createPrometheusMetricsExporter([{ stack: cache, name: 'test"cache' }])
+
+    await cache.get('k')
+
+    const output = collect()
+
+    // Double quotes, backslashes and newlines should be replaced with underscores
+    expect(output).not.toContain('"evil')
+    expect(output).toContain('test_cache')
+
+    await cache.disconnect()
+  })
+
+  it('should export zero hit rate when no operations have occurred', () => {
+    const cache = new CacheStack([new MemoryLayer({ ttl: 10 })])
+    const collect = createPrometheusMetricsExporter(cache)
+    const output = collect()
+
+    expect(output).toContain('layercache_hit_rate{cache="default"} 0.000000')
+  })
+})


### PR DESCRIPTION
Bug fixes:
- MemcachedLayer: add getEntry/has/getMany, pluggable serializer (was hardcoded JSON)
- DiskLayer: keys() now returns original key names (not SHA256 hashes), store key in entry
- RedisLayer: replace sync gzipSync/brotliCompressSync with async to avoid event loop blocking
- MemoryLayer: fix FIFO semantics (don't bump accessCount for FIFO eviction policy)
- CLI invalidate: batch deletion (500 keys/batch) to prevent timeout on large key sets
- TagIndex: add maxKnownKeys option to prevent unbounded memory growth
- RedisInvalidationBus: support multiple concurrent subscriptions (was single-subscription only)

New features:
- getOrThrow() on CacheStack and CacheNamespace — throws CacheMissError instead of null
- inspect(key) — debug metadata: layers, TTLs, tags, staleness state
- shouldCache option — conditional caching predicate to skip specific fetcher results
- Nested namespaces — namespace('a').namespace('b') for composable prefixes
- Per-layer latency tracking — avgMs/maxMs/count in CacheMetricsSnapshot
- Express middleware — createExpressCacheMiddleware with x-cache headers
- NestJS forRootAsync — async DI-based configuration
- DiskLayer maxFiles option — mtime-based eviction when disk entries exceed limit
- Prometheus exporter — latency gauges per layer

Tests:
- 14 new DiskLayer tests, 11 MemcachedLayer tests, 5 PrometheusExporter tests
- Updated RedisInvalidationBus tests for multi-subscription
- Total: 132 tests passing (was 102)

https://claude.ai/code/session_01GZX2ZjCH6BKAJPRJnUDLQV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `getOrThrow()` method that throws an error on cache miss
  * Added `inspect()` method to retrieve detailed per-key cache metadata
  * Added conditional caching with `shouldCache` option to prevent storing specific values
  * Added nested namespace support for hierarchical key prefixing
  * Added Express middleware for automatic HTTP response caching
  * Added NestJS async module configuration support
  * Added per-layer latency metrics for performance monitoring

* **Enhancements**
  * Memcached layer now supports custom serializers and bulk read operations
  * DiskLayer now supports max file limits with automatic eviction
  * Redis compression switched to non-blocking async operations
  * TagIndex now supports bounded memory growth

* **Bug Fixes**
  * Fixed memory leaks in tag indexing
  * Fixed blocking operations during compression
  * Improved key handling and serialization reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->