### PR TITLE
Add Redis timeouts and real benchmark harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] — 2026-04-14
+
+### Added
+- Real Redis-backed benchmark harnesses for direct cache behavior, HTTP throughput, edge cases, slow Redis, queue amplification, and multi-process fan-out.
+- New benchmark utility coverage and Redis single-flight coordinator tests.
+
+### Changed
+- Version bumped from `1.2.9` to `1.3.0`.
+- `README.md` now reflects the current validation baseline with **431 passing tests**.
+
+### Fixed
+- `RedisLayer` and `RedisSingleFlightCoordinator` now support per-command Redis timeouts via `commandTimeoutMs`.
+- `CacheStack` now degrades gracefully when the distributed single-flight coordinator fails and preserves local single-flight collapse for concurrent misses.
+- `StampedeGuard` now shares in-flight promises across concurrent callers instead of serializing them through a mutex queue.
+
 ## [1.2.9] — 2026-04-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -329,9 +329,15 @@ const cache = new CacheStack(
 Run benchmarks locally:
 
 ```bash
-npm run bench:latency
-npm run bench:stampede
+npm run bench:direct
+npm run bench:edge
+npm run bench:slow-redis
+npm run bench:queue-amplification
+npm run bench:http
+npm run bench:multi-process-fanout
 ```
+
+The benchmark harness defaults to `/root/cache-test/data/users.json` so the in-repo scripts stay aligned with the external reproduction workspace. Set `LAYERCACHE_BENCH_FIXTURE_PATH` if you want to point at a different workload fixture.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-Apache_2.0-green" alt="license"></a>
   <a href="https://www.typescriptlang.org/"><img src="https://img.shields.io/badge/TypeScript-first-3178C6?logo=typescript&logoColor=white" alt="TypeScript"></a>
   <img src="https://img.shields.io/badge/Node.js-%E2%89%A5_20-339933?logo=nodedotjs&logoColor=white" alt="Node.js >= 20">
-  <img src="https://img.shields.io/badge/tests-417_passing-brightgreen" alt="tests">
+  <img src="https://img.shields.io/badge/tests-431_passing-brightgreen" alt="tests">
   <a href="https://coveralls.io/github/flyingsquirrel0419/layercache?branch=main"><img src="https://coveralls.io/repos/github/flyingsquirrel0419/layercache/badge.svg?branch=main&t=20260410" alt="Coveralls"></a>
 </p>
 

--- a/benchmarks/direct.ts
+++ b/benchmarks/direct.ts
@@ -1,0 +1,221 @@
+import { performance } from 'node:perf_hooks'
+import type { Redis } from 'ioredis'
+import { CacheStack, MemoryLayer, RedisLayer, RedisSingleFlightCoordinator } from '../src'
+import { resolveBenchmarkFixturePath } from './paths'
+import { createRedisClient, ensureRedisContainer, stopRedisContainer, waitForRedisReady } from './redis'
+import { type ScenarioSummary, createCountedFetcher, runConcurrent, summarizeScenario } from './scenario-utils'
+import { ensureFixtureFile, loadUserFromFixture } from './workload'
+
+const USER_ID = 4242
+const COLD_SAMPLES = 15
+const WARM_SAMPLES = 120
+const STAMPEDE_CONCURRENCY = 75
+const STAMPEDE_RUNS = 5
+
+type BenchmarkMode = 'no-cache' | 'memory' | 'layered'
+
+interface FlattenedResult extends ScenarioSummary {
+  mode: BenchmarkMode
+  scenario: string
+}
+
+type CacheRunner = {
+  read: <T>(key: string, fetcher: () => Promise<T>) => Promise<T>
+  clear: () => Promise<void>
+  disconnect?: () => Promise<void>
+}
+
+function createOriginFetcher(fixturePath: string) {
+  return createCountedFetcher(async (userId: number) => loadUserFromFixture(fixturePath, userId))
+}
+
+function createNoCacheRunner(): CacheRunner {
+  return {
+    read: async <T>(_key: string, fetcher: () => Promise<T>) => fetcher(),
+    clear: async () => {}
+  }
+}
+
+function createMemoryRunner(): CacheRunner {
+  const cache = new CacheStack([new MemoryLayer({ ttl: 60, maxSize: 2_000 })], {
+    stampedePrevention: true
+  })
+
+  return {
+    read: async <T>(key: string, fetcher: () => Promise<T>) => {
+      const value = await cache.get(key, fetcher)
+      if (value === null) {
+        throw new Error(`Cache unexpectedly returned null for ${key}`)
+      }
+
+      return value
+    },
+    clear: async () => {
+      await cache.clear()
+    },
+    disconnect: async () => {
+      await cache.disconnect()
+    }
+  }
+}
+
+function createLayeredRunner(redis: Redis): CacheRunner {
+  const cache = new CacheStack(
+    [
+      new MemoryLayer({ ttl: 60, maxSize: 2_000 }),
+      new RedisLayer({ client: redis, ttl: 300, prefix: 'layercache-bench:direct:' })
+    ],
+    {
+      stampedePrevention: true,
+      singleFlightCoordinator: new RedisSingleFlightCoordinator({
+        client: redis,
+        prefix: 'layercache-bench:direct:single-flight:'
+      })
+    }
+  )
+
+  return {
+    read: async <T>(key: string, fetcher: () => Promise<T>) => {
+      const value = await cache.get(key, fetcher)
+      if (value === null) {
+        throw new Error(`Cache unexpectedly returned null for ${key}`)
+      }
+
+      return value
+    },
+    clear: async () => {
+      await cache.clear()
+      await redis.flushdb()
+    },
+    disconnect: async () => {
+      await cache.disconnect()
+    }
+  }
+}
+
+async function measure<TResult>(task: () => Promise<TResult>): Promise<{ durationMs: number; result: TResult }> {
+  const startedAt = process.hrtime.bigint()
+  const result = await task()
+  const durationMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000
+
+  return { durationMs, result }
+}
+
+async function runColdMiss(mode: BenchmarkMode, runner: CacheRunner, fixturePath: string): Promise<FlattenedResult> {
+  const samples: number[] = []
+  let fetchCount = 0
+
+  for (let index = 0; index < COLD_SAMPLES; index += 1) {
+    await runner.clear()
+    const origin = createOriginFetcher(fixturePath)
+    const { durationMs } = await measure(() => runner.read(`user:${USER_ID}`, () => origin.run(USER_ID)))
+    samples.push(durationMs)
+    fetchCount += origin.getCount()
+  }
+
+  return {
+    ...summarizeScenario('cold-miss', samples, fetchCount),
+    mode,
+    scenario: 'cold-miss'
+  }
+}
+
+async function runWarmHit(mode: BenchmarkMode, runner: CacheRunner, fixturePath: string): Promise<FlattenedResult> {
+  const samples: number[] = []
+  const warmOrigin = createOriginFetcher(fixturePath)
+
+  await runner.clear()
+  await runner.read(`user:${USER_ID}`, () => warmOrigin.run(USER_ID))
+
+  const measuredOrigin = createOriginFetcher(fixturePath)
+  for (let index = 0; index < WARM_SAMPLES; index += 1) {
+    const { durationMs } = await measure(() => runner.read(`user:${USER_ID}`, () => measuredOrigin.run(USER_ID)))
+    samples.push(durationMs)
+  }
+
+  return {
+    ...summarizeScenario('warm-hit', samples, measuredOrigin.getCount()),
+    mode,
+    scenario: 'warm-hit'
+  }
+}
+
+async function runStampede(mode: BenchmarkMode, runner: CacheRunner, fixturePath: string): Promise<FlattenedResult> {
+  const samples: number[] = []
+  let fetchCount = 0
+
+  for (let index = 0; index < STAMPEDE_RUNS; index += 1) {
+    await runner.clear()
+    const origin = createOriginFetcher(fixturePath)
+    const { durationMs } = await measure(() =>
+      runConcurrent(STAMPEDE_CONCURRENCY, () => runner.read(`user:${USER_ID}`, () => origin.run(USER_ID)))
+    )
+
+    samples.push(durationMs)
+    fetchCount += origin.getCount()
+  }
+
+  return {
+    ...summarizeScenario('stampede', samples, fetchCount),
+    mode,
+    scenario: 'stampede'
+  }
+}
+
+async function main(): Promise<void> {
+  const fixturePath = resolveBenchmarkFixturePath()
+  await ensureFixtureFile(fixturePath)
+  await ensureRedisContainer()
+
+  await waitForRedisReady()
+  const redis = createRedisClient()
+  await redis.ping()
+
+  const runners: Record<BenchmarkMode, CacheRunner> = {
+    'no-cache': createNoCacheRunner(),
+    memory: createMemoryRunner(),
+    layered: createLayeredRunner(redis)
+  }
+
+  try {
+    const results = [
+      await runColdMiss('no-cache', runners['no-cache'], fixturePath),
+      await runColdMiss('memory', runners.memory, fixturePath),
+      await runColdMiss('layered', runners.layered, fixturePath),
+      await runWarmHit('no-cache', runners['no-cache'], fixturePath),
+      await runWarmHit('memory', runners.memory, fixturePath),
+      await runWarmHit('layered', runners.layered, fixturePath),
+      await runStampede('no-cache', runners['no-cache'], fixturePath),
+      await runStampede('memory', runners.memory, fixturePath),
+      await runStampede('layered', runners.layered, fixturePath)
+    ]
+
+    console.table(
+      results.map((result) => ({
+        mode: result.mode,
+        scenario: result.scenario,
+        avgMs: result.avgMs,
+        p95Ms: result.p95Ms,
+        minMs: result.minMs,
+        maxMs: result.maxMs,
+        fetchCount: result.fetchCount
+      }))
+    )
+
+    console.log(JSON.stringify({ type: 'direct-benchmark', results }, null, 2))
+  } finally {
+    await Promise.all(
+      Object.values(runners)
+        .map((runner) => runner.disconnect)
+        .filter((value): value is NonNullable<typeof value> => Boolean(value))
+        .map((disconnect) => disconnect())
+    )
+    await redis.quit()
+    await stopRedisContainer()
+  }
+}
+
+void main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/benchmarks/edge-utils.ts
+++ b/benchmarks/edge-utils.ts
@@ -1,0 +1,28 @@
+export interface OutageResult {
+  scenario: string
+  success: boolean
+  latencyMs: number
+  error: string | null
+}
+
+function round(value: number): number {
+  return Number(value.toFixed(3))
+}
+
+export function buildPayloadString(bytes: number): string {
+  return 'x'.repeat(bytes)
+}
+
+export function normalizeOutageResult(
+  scenario: string,
+  success: boolean,
+  latencyMs: number,
+  error?: string
+): OutageResult {
+  return {
+    scenario,
+    success,
+    latencyMs: round(latencyMs),
+    error: error ?? null
+  }
+}

--- a/benchmarks/edge.ts
+++ b/benchmarks/edge.ts
@@ -1,0 +1,491 @@
+import { CacheStack, MemoryLayer, RedisInvalidationBus, RedisLayer, RedisSingleFlightCoordinator } from '../src'
+import { type OutageResult, buildPayloadString, normalizeOutageResult } from './edge-utils'
+import {
+  createRedisClient,
+  ensureRedisContainer,
+  pauseRedisContainer,
+  stopRedisContainer,
+  unpauseRedisContainer,
+  waitForRedisReady
+} from './redis'
+import { createCountedFetcher, runConcurrent, summarizeScenario } from './scenario-utils'
+import { type DurationSummary, summarizeDurations } from './stats'
+
+const TTL_CONCURRENCY = 40
+const TTL_RUNS = 5
+const TTL_MS = 1_100
+const PAYLOAD_SAMPLES = 60
+const PAYLOAD_SMALL_BYTES = 1_024
+const PAYLOAD_LARGE_BYTES = 1_024 * 1_024
+const DISTRIBUTED_CONCURRENCY = 60
+const COMMAND_TIMEOUT_MS = 200
+
+interface ModeSummary extends DurationSummary {
+  mode: string
+  scenario: string
+  fetchCount?: number
+}
+
+interface InvalidationResult {
+  scenario: string
+  success: boolean
+  latencyMs: number
+  observedVersion: number | null
+}
+
+interface DistributedSingleFlightResult {
+  scenario: string
+  concurrency: number
+  latencyMs: number
+  fetchCount: number
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function measure<TResult>(task: () => Promise<TResult>): Promise<{ durationMs: number; result: TResult }> {
+  const startedAt = process.hrtime.bigint()
+  const result = await task()
+  return {
+    durationMs: Number(process.hrtime.bigint() - startedAt) / 1_000_000,
+    result
+  }
+}
+
+function requireValue<T>(value: T | null, label: string): T {
+  if (value === null) {
+    throw new Error(`${label} unexpectedly returned null`)
+  }
+
+  return value
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) => {
+      setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs)
+    })
+  ])
+}
+
+async function runTtlExpiryStampede(): Promise<ModeSummary[]> {
+  const redis = createRedisClient()
+  await redis.ping()
+
+  const memoryCache = new CacheStack([new MemoryLayer({ ttl: 1, maxSize: 1_000 })], {
+    stampedePrevention: true
+  })
+
+  const layeredCache = new CacheStack(
+    [
+      new MemoryLayer({ ttl: 1, maxSize: 1_000 }),
+      new RedisLayer({ client: redis, ttl: 1, prefix: 'layercache-bench:edge:ttl:' })
+    ],
+    {
+      stampedePrevention: true,
+      singleFlightCoordinator: new RedisSingleFlightCoordinator({
+        client: redis,
+        prefix: 'layercache-bench:edge:ttl:sf:'
+      })
+    }
+  )
+
+  try {
+    const results: ModeSummary[] = []
+
+    for (const { mode, cache } of [
+      { mode: 'memory', cache: memoryCache },
+      { mode: 'layered', cache: layeredCache }
+    ]) {
+      const samples: number[] = []
+      let fetchCount = 0
+
+      for (let index = 0; index < TTL_RUNS; index += 1) {
+        await cache.clear()
+        if (mode === 'layered') {
+          await redis.flushdb()
+        }
+
+        await cache.get(`ttl:key:${index}`, async () => ({ version: 1 }), { ttl: 1 })
+        await sleep(TTL_MS)
+
+        const fetcher = createCountedFetcher(async () => ({ version: 2 }))
+        const { durationMs } = await measure(() =>
+          runConcurrent(TTL_CONCURRENCY, async () =>
+            requireValue(await cache.get(`ttl:key:${index}`, () => fetcher.run(), { ttl: 1 }), `${mode} ttl`)
+          )
+        )
+
+        samples.push(durationMs)
+        fetchCount += fetcher.getCount()
+      }
+
+      results.push({
+        ...summarizeScenario('ttl-expiry-stampede', samples, fetchCount),
+        mode,
+        scenario: 'ttl-expiry-stampede'
+      })
+    }
+
+    return results
+  } finally {
+    await Promise.all([memoryCache.disconnect(), layeredCache.disconnect()])
+    await redis.quit()
+  }
+}
+
+async function runPayloadSizeVariation(): Promise<ModeSummary[]> {
+  const redis = createRedisClient()
+  await redis.ping()
+
+  const memoryCache = new CacheStack([new MemoryLayer({ ttl: 60, maxSize: 100 })])
+  const redisCache = new CacheStack([
+    new RedisLayer({ client: redis, ttl: 300, prefix: 'layercache-bench:edge:payload:' })
+  ])
+
+  try {
+    const results: ModeSummary[] = []
+
+    for (const scenario of [
+      { mode: 'memory-1kb', cache: memoryCache, bytes: PAYLOAD_SMALL_BYTES },
+      { mode: 'memory-1mb', cache: memoryCache, bytes: PAYLOAD_LARGE_BYTES },
+      { mode: 'redis-1kb', cache: redisCache, bytes: PAYLOAD_SMALL_BYTES },
+      { mode: 'redis-1mb', cache: redisCache, bytes: PAYLOAD_LARGE_BYTES }
+    ]) {
+      await scenario.cache.clear()
+      if (scenario.mode.startsWith('redis')) {
+        await redis.flushdb()
+      }
+
+      await scenario.cache.set(
+        `payload:${scenario.mode}`,
+        { size: scenario.bytes, payload: buildPayloadString(scenario.bytes) },
+        { ttl: 60 }
+      )
+
+      const samples: number[] = []
+      for (let index = 0; index < PAYLOAD_SAMPLES; index += 1) {
+        const { durationMs } = await measure(async () => {
+          requireValue(await scenario.cache.get(`payload:${scenario.mode}`), `${scenario.mode} payload`)
+        })
+        samples.push(durationMs)
+      }
+
+      results.push({
+        ...summarizeDurations('payload-warm-hit', samples),
+        mode: scenario.mode,
+        scenario: 'payload-warm-hit'
+      })
+    }
+
+    return results
+  } finally {
+    await Promise.all([memoryCache.disconnect(), redisCache.disconnect()])
+    await redis.quit()
+  }
+}
+
+async function runRedisOutageScenario(): Promise<OutageResult[]> {
+  const strictRedis = createRedisClient()
+  const gracefulRedis = createRedisClient()
+  await Promise.all([strictRedis.ping(), gracefulRedis.ping()])
+
+  const strictCache = new CacheStack(
+    [
+      new MemoryLayer({ ttl: 60, maxSize: 500 }),
+      new RedisLayer({
+        client: strictRedis,
+        ttl: 300,
+        prefix: 'layercache-bench:edge:strict:',
+        commandTimeoutMs: COMMAND_TIMEOUT_MS
+      })
+    ],
+    {
+      stampedePrevention: true,
+      singleFlightCoordinator: new RedisSingleFlightCoordinator({
+        client: strictRedis,
+        prefix: 'layercache-bench:edge:strict:sf:',
+        commandTimeoutMs: COMMAND_TIMEOUT_MS
+      })
+    }
+  )
+
+  const gracefulCache = new CacheStack(
+    [
+      new MemoryLayer({ ttl: 60, maxSize: 500 }),
+      new RedisLayer({
+        client: gracefulRedis,
+        ttl: 300,
+        prefix: 'layercache-bench:edge:graceful:',
+        commandTimeoutMs: COMMAND_TIMEOUT_MS
+      })
+    ],
+    {
+      stampedePrevention: true,
+      gracefulDegradation: { retryAfterMs: 10_000 },
+      singleFlightCoordinator: new RedisSingleFlightCoordinator({
+        client: gracefulRedis,
+        prefix: 'layercache-bench:edge:graceful:sf:',
+        commandTimeoutMs: COMMAND_TIMEOUT_MS
+      })
+    }
+  )
+
+  try {
+    await strictCache.clear()
+    await gracefulCache.clear()
+    await strictRedis.flushdb()
+
+    await strictCache.get('outage:warm', async () => ({ version: 'warm-strict' }), { ttl: 60 })
+    await gracefulCache.get('outage:warm', async () => ({ version: 'warm-graceful' }), { ttl: 60 })
+
+    await pauseRedisContainer()
+
+    const hotResults = await Promise.all([
+      measure(async () => {
+        requireValue(await strictCache.get('outage:warm'), 'strict hot')
+      })
+        .then(({ durationMs }) => normalizeOutageResult('strict-hot-hit', true, durationMs))
+        .catch((error) =>
+          normalizeOutageResult('strict-hot-hit', false, 0, error instanceof Error ? error.message : String(error))
+        ),
+      measure(async () => {
+        requireValue(await gracefulCache.get('outage:warm'), 'graceful hot')
+      })
+        .then(({ durationMs }) => normalizeOutageResult('graceful-hot-hit', true, durationMs))
+        .catch((error) =>
+          normalizeOutageResult('graceful-hot-hit', false, 0, error instanceof Error ? error.message : String(error))
+        )
+    ])
+
+    const coldStrict = await measure(() =>
+      withTimeout(
+        strictCache.get('outage:cold:strict', async () => ({ version: 'strict-cold' }), { ttl: 60 }),
+        2_000,
+        'strict cold miss'
+      )
+    )
+      .then(({ durationMs }) => normalizeOutageResult('strict-cold-miss', true, durationMs))
+      .catch((error) =>
+        normalizeOutageResult('strict-cold-miss', false, 0, error instanceof Error ? error.message : String(error))
+      )
+
+    const coldGraceful = await measure(() =>
+      withTimeout(
+        gracefulCache.get('outage:cold:graceful', async () => ({ version: 'graceful-cold' }), { ttl: 60 }),
+        2_000,
+        'graceful cold miss'
+      )
+    )
+      .then(({ durationMs }) => normalizeOutageResult('graceful-cold-miss', true, durationMs))
+      .catch((error) =>
+        normalizeOutageResult('graceful-cold-miss', false, 0, error instanceof Error ? error.message : String(error))
+      )
+
+    return [...hotResults, coldStrict, coldGraceful]
+  } finally {
+    await unpauseRedisContainer()
+    await waitForRedisReady()
+    await Promise.all([strictCache.disconnect(), gracefulCache.disconnect()])
+    await Promise.all([strictRedis.quit(), gracefulRedis.quit()])
+  }
+}
+
+async function runMultiInstanceInvalidation(): Promise<InvalidationResult> {
+  const publisher = createRedisClient()
+  const subscriberA = createRedisClient()
+  const subscriberB = createRedisClient()
+  const dataA = createRedisClient()
+  const dataB = createRedisClient()
+
+  await Promise.all([publisher.ping(), subscriberA.ping(), subscriberB.ping(), dataA.ping(), dataB.ping()])
+
+  const busA = new RedisInvalidationBus({
+    publisher,
+    subscriber: subscriberA,
+    channel: 'layercache-bench:edge:invalidation'
+  })
+  const busB = new RedisInvalidationBus({
+    publisher,
+    subscriber: subscriberB,
+    channel: 'layercache-bench:edge:invalidation'
+  })
+
+  const cacheA = new CacheStack(
+    [
+      new MemoryLayer({ ttl: 60, maxSize: 100 }),
+      new RedisLayer({ client: dataA, ttl: 300, prefix: 'layercache-bench:edge:invalidation:' })
+    ],
+    {
+      invalidationBus: busA,
+      broadcastL1Invalidation: true
+    }
+  )
+  const cacheB = new CacheStack(
+    [
+      new MemoryLayer({ ttl: 60, maxSize: 100 }),
+      new RedisLayer({ client: dataB, ttl: 300, prefix: 'layercache-bench:edge:invalidation:' })
+    ],
+    {
+      invalidationBus: busB,
+      broadcastL1Invalidation: true
+    }
+  )
+
+  try {
+    await cacheA.clear()
+    await dataA.flushdb()
+
+    await cacheA.get('shared:key', async () => ({ version: 1 }), { ttl: 60 })
+    await cacheB.get('shared:key', async () => ({ version: 1 }), { ttl: 60 })
+
+    await cacheA.delete('shared:key')
+    await cacheA.get('shared:key', async () => ({ version: 2 }), { ttl: 60 })
+
+    const startedAt = performance.now()
+    let observedVersion: number | null = null
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+      const value = await cacheB.get<{ version: number }>('shared:key')
+      observedVersion = value?.version ?? null
+      if (observedVersion === 2) {
+        return {
+          scenario: 'multi-instance-invalidation',
+          success: true,
+          latencyMs: Number((performance.now() - startedAt).toFixed(3)),
+          observedVersion
+        }
+      }
+
+      await sleep(25)
+    }
+
+    return {
+      scenario: 'multi-instance-invalidation',
+      success: false,
+      latencyMs: Number((performance.now() - startedAt).toFixed(3)),
+      observedVersion
+    }
+  } finally {
+    await Promise.all([cacheA.disconnect(), cacheB.disconnect()])
+    await Promise.all([publisher.quit(), subscriberA.quit(), subscriberB.quit(), dataA.quit(), dataB.quit()])
+  }
+}
+
+async function runDistributedSingleFlight(): Promise<DistributedSingleFlightResult> {
+  const redisA = createRedisClient()
+  const redisB = createRedisClient()
+  const coordinatorClient = createRedisClient()
+
+  await Promise.all([redisA.ping(), redisB.ping(), coordinatorClient.ping()])
+
+  const coordinator = new RedisSingleFlightCoordinator({
+    client: coordinatorClient,
+    prefix: 'layercache-bench:edge:distributed:sf:'
+  })
+
+  const cacheA = new CacheStack(
+    [
+      new MemoryLayer({ ttl: 60, maxSize: 100 }),
+      new RedisLayer({ client: redisA, ttl: 300, prefix: 'layercache-bench:edge:distributed:' })
+    ],
+    {
+      stampedePrevention: true,
+      singleFlightCoordinator: coordinator
+    }
+  )
+  const cacheB = new CacheStack(
+    [
+      new MemoryLayer({ ttl: 60, maxSize: 100 }),
+      new RedisLayer({ client: redisB, ttl: 300, prefix: 'layercache-bench:edge:distributed:' })
+    ],
+    {
+      stampedePrevention: true,
+      singleFlightCoordinator: coordinator
+    }
+  )
+
+  try {
+    await cacheA.clear()
+    await redisA.flushdb()
+
+    let fetchCount = 0
+    const fetchUser = async () => {
+      fetchCount += 1
+      await sleep(25)
+      return { id: 1 }
+    }
+
+    const startedAt = performance.now()
+    await runConcurrent(DISTRIBUTED_CONCURRENCY, (index) =>
+      (index % 2 === 0 ? cacheA : cacheB)
+        .get('distributed:user:1', fetchUser)
+        .then((value) => requireValue(value, 'distributed'))
+    )
+
+    return {
+      scenario: 'distributed-single-flight',
+      concurrency: DISTRIBUTED_CONCURRENCY,
+      latencyMs: Number((performance.now() - startedAt).toFixed(3)),
+      fetchCount
+    }
+  } finally {
+    await Promise.all([cacheA.disconnect(), cacheB.disconnect()])
+    await Promise.all([redisA.quit(), redisB.quit(), coordinatorClient.quit()])
+  }
+}
+
+async function main(): Promise<void> {
+  await ensureRedisContainer()
+  await waitForRedisReady()
+
+  try {
+    const ttlResults = await runTtlExpiryStampede()
+    const payloadResults = await runPayloadSizeVariation()
+    const outageResults = await runRedisOutageScenario()
+    const invalidationResult = await runMultiInstanceInvalidation()
+    const distributedResult = await runDistributedSingleFlight()
+
+    console.table([
+      ...ttlResults.map((result) => ({
+        mode: result.mode,
+        scenario: result.scenario,
+        avgMs: result.avgMs,
+        p95Ms: result.p95Ms,
+        fetchCount: result.fetchCount
+      })),
+      ...payloadResults.map((result) => ({
+        mode: result.mode,
+        scenario: result.scenario,
+        avgMs: result.avgMs,
+        p95Ms: result.p95Ms
+      })),
+      ...outageResults,
+      invalidationResult,
+      distributedResult
+    ])
+    console.log(
+      JSON.stringify(
+        {
+          type: 'edge-benchmark',
+          ttlResults,
+          payloadResults,
+          outageResults,
+          invalidationResult,
+          distributedResult
+        },
+        null,
+        2
+      )
+    )
+  } finally {
+    await unpauseRedisContainer().catch(() => {})
+    await stopRedisContainer()
+  }
+}
+
+void main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/benchmarks/http.ts
+++ b/benchmarks/http.ts
@@ -1,0 +1,99 @@
+import autocannon, { type Result } from 'autocannon'
+import { createRedisClient, ensureRedisContainer, stopRedisContainer, waitForRedisReady } from './redis'
+import { startBenchmarkServer } from './server'
+
+interface HttpBenchmarkSummary {
+  route: string
+  coldStartMs: number
+  averageLatencyMs: number
+  p97_5LatencyMs: number
+  maxLatencyMs: number
+  requestsPerSec: number
+  throughputBytesPerSec: number
+  errors: number
+  timeouts: number
+}
+
+async function singleRequestLatency(url: string): Promise<number> {
+  const startedAt = process.hrtime.bigint()
+  const response = await fetch(url)
+  await response.arrayBuffer()
+
+  return Number(process.hrtime.bigint() - startedAt) / 1_000_000
+}
+
+function runAutocannon(url: string): Promise<Result> {
+  return new Promise((resolve, reject) => {
+    const instance = autocannon(
+      {
+        url,
+        connections: 40,
+        duration: 8,
+        pipelining: 1
+      },
+      (error: Error | null, result: Result) => {
+        if (error) {
+          reject(error)
+          return
+        }
+
+        resolve(result)
+      }
+    )
+
+    instance.on('error', reject)
+  })
+}
+
+function summarizeHttpRoute(route: string, coldStartMs: number, result: Result): HttpBenchmarkSummary {
+  return {
+    route,
+    coldStartMs: Number(coldStartMs.toFixed(3)),
+    averageLatencyMs: Number(result.latency.average.toFixed(3)),
+    p97_5LatencyMs: Number(result.latency.p97_5.toFixed(3)),
+    maxLatencyMs: Number(result.latency.max.toFixed(3)),
+    requestsPerSec: Number(result.requests.average.toFixed(3)),
+    throughputBytesPerSec: Number(result.throughput.average.toFixed(3)),
+    errors: result.errors,
+    timeouts: result.timeouts
+  }
+}
+
+async function main(): Promise<void> {
+  await ensureRedisContainer()
+
+  await waitForRedisReady()
+  const redis = createRedisClient()
+  await redis.ping()
+
+  const server = await startBenchmarkServer(redis)
+  const baseUrl = `http://127.0.0.1:${server.port}`
+
+  try {
+    const routes = ['/nocache', '/memory', '/layered']
+    const results: HttpBenchmarkSummary[] = []
+
+    for (const route of routes) {
+      await server.reset()
+      if (route !== '/nocache') {
+        await server.warm()
+      }
+
+      const coldStartMs = await singleRequestLatency(`${baseUrl}${route}`)
+      const result = await runAutocannon(`${baseUrl}${route}`)
+      results.push(summarizeHttpRoute(route, coldStartMs, result))
+    }
+
+    console.table(results)
+    console.log(JSON.stringify({ type: 'http-benchmark', results }, null, 2))
+  } finally {
+    await server.close()
+    await redis.quit()
+    await stopRedisContainer()
+  }
+}
+
+void main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/benchmarks/memory-pressure.ts
+++ b/benchmarks/memory-pressure.ts
@@ -1,0 +1,144 @@
+import { PerformanceObserver, monitorEventLoopDelay } from 'node:perf_hooks'
+import { CacheStack, MemoryLayer, RedisLayer } from '../src'
+import { createRedisClient, ensureRedisContainer, stopRedisContainer, waitForRedisReady } from './redis'
+import { summarizeGcMetrics } from './slow-redis-utils'
+
+const EVICTION_CAPACITY = 25
+const EVICTION_KEYS = 180
+const EVICTION_PAYLOAD_BYTES = 256 * 1024
+const REVISIT_COUNT = 25
+
+interface MemoryPressureResult {
+  scenario: string
+  maxSize: number
+  uniqueKeys: number
+  evictions: number
+  l1RetainedKeys: number
+  revisitAvgMs: number
+  revisitP95Ms: number
+  revisitOriginFetches: number
+  gcCount: number
+  gcTotalMs: number
+  gcMaxMs: number
+  eventLoopMaxMs: number
+  heapDeltaMb: number
+}
+
+function round(value: number): number {
+  return Number(value.toFixed(3))
+}
+
+function buildLargePayload(bytes: number): { size: number; payload: string } {
+  return {
+    size: bytes,
+    payload: 'p'.repeat(bytes)
+  }
+}
+
+async function measure<TResult>(task: () => Promise<TResult>): Promise<{ durationMs: number; result: TResult }> {
+  const startedAt = process.hrtime.bigint()
+  const result = await task()
+
+  return {
+    durationMs: Number(process.hrtime.bigint() - startedAt) / 1_000_000,
+    result
+  }
+}
+
+async function main(): Promise<void> {
+  await ensureRedisContainer()
+  await waitForRedisReady()
+
+  const redis = createRedisClient()
+  await redis.ping()
+
+  const gcDurations: number[] = []
+  const observer = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      gcDurations.push(entry.duration)
+    }
+  })
+  observer.observe({ entryTypes: ['gc'] })
+
+  const loopDelay = monitorEventLoopDelay({ resolution: 10 })
+  loopDelay.enable()
+
+  let evictions = 0
+  const memoryLayer = new MemoryLayer({
+    ttl: 60,
+    maxSize: EVICTION_CAPACITY,
+    onEvict: () => {
+      evictions += 1
+    }
+  })
+
+  const cache = new CacheStack([
+    memoryLayer,
+    new RedisLayer({ client: redis, ttl: 300, prefix: 'pressure:benchmark:' })
+  ])
+
+  const heapBeforeMb = process.memoryUsage().heapUsed / (1024 * 1024)
+
+  try {
+    await cache.clear()
+    await redis.flushdb()
+
+    for (let index = 0; index < EVICTION_KEYS; index += 1) {
+      await cache.get(`pressure:${index}`, async () => ({ key: index, ...buildLargePayload(EVICTION_PAYLOAD_BYTES) }), {
+        ttl: 60
+      })
+    }
+
+    const retainedKeys = memoryLayer.exportState().length
+    let revisitOriginFetches = 0
+    const revisitSamples: number[] = []
+
+    for (let index = 0; index < REVISIT_COUNT; index += 1) {
+      const { durationMs } = await measure(() =>
+        cache.get(
+          `pressure:${index}`,
+          async () => {
+            revisitOriginFetches += 1
+            return { key: index, ...buildLargePayload(EVICTION_PAYLOAD_BYTES) }
+          },
+          { ttl: 60 }
+        )
+      )
+      revisitSamples.push(durationMs)
+    }
+
+    const sortedSamples = [...revisitSamples].sort((left, right) => left - right)
+    const gcSummary = summarizeGcMetrics(gcDurations)
+    const heapAfterMb = process.memoryUsage().heapUsed / (1024 * 1024)
+
+    const result: MemoryPressureResult = {
+      scenario: 'memory-pressure-eviction',
+      maxSize: EVICTION_CAPACITY,
+      uniqueKeys: EVICTION_KEYS,
+      evictions,
+      l1RetainedKeys: retainedKeys,
+      revisitAvgMs: round(revisitSamples.reduce((sum, sample) => sum + sample, 0) / revisitSamples.length),
+      revisitP95Ms: round(sortedSamples[Math.ceil(sortedSamples.length * 0.95) - 1] ?? 0),
+      revisitOriginFetches,
+      gcCount: gcSummary.gcCount,
+      gcTotalMs: gcSummary.gcTotalMs,
+      gcMaxMs: gcSummary.gcMaxMs,
+      eventLoopMaxMs: round(loopDelay.max / 1_000_000),
+      heapDeltaMb: round(heapAfterMb - heapBeforeMb)
+    }
+
+    console.table([result])
+    console.log(JSON.stringify({ type: 'memory-pressure', result }, null, 2))
+  } finally {
+    loopDelay.disable()
+    observer.disconnect()
+    await cache.disconnect().catch(() => {})
+    await redis.quit().catch(() => {})
+    await stopRedisContainer()
+  }
+}
+
+void main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/benchmarks/multi-process-fanout.ts
+++ b/benchmarks/multi-process-fanout.ts
@@ -1,0 +1,231 @@
+import { type ChildProcess, fork } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import { resolve } from 'node:path'
+import { createRedisClient, ensureRedisContainer, stopRedisContainer, waitForRedisReady } from './redis'
+
+const PROCESS_COUNT = 4
+const BURST_CONCURRENCY_PER_PROCESS = 25
+const FETCH_DELAY_MS = 25
+const COMMAND_TIMEOUT_MS = 200
+
+interface WorkerResponse {
+  id: string
+  ok: boolean
+  result?: unknown
+  error?: unknown
+}
+
+interface MultiProcessInvalidationResult {
+  scenario: string
+  success: boolean
+  observedVersion: number | null
+  latencyMs: number
+}
+
+interface MultiProcessFanoutResult {
+  scenario: string
+  processCount: number
+  concurrencyPerProcess: number
+  totalConcurrency: number
+  latencyMs: number
+  originFetchCount: number
+}
+
+function spawnWorker(): ChildProcess {
+  const workerPath = resolve(process.cwd(), 'benchmarks', 'multi-process-worker.ts')
+  return fork(workerPath, [], {
+    cwd: process.cwd(),
+    execArgv: ['--import', 'tsx'],
+    stdio: ['inherit', 'inherit', 'inherit', 'ipc']
+  })
+}
+
+function sendMessage<T>(worker: ChildProcess, message: Record<string, unknown>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const id = String(message.id)
+
+    const onMessage = (response: WorkerResponse): void => {
+      if (response.id !== id) {
+        return
+      }
+
+      worker.off('message', onMessage)
+      if (!response.ok) {
+        reject(new Error(typeof response.error === 'string' ? response.error : JSON.stringify(response.error)))
+        return
+      }
+
+      resolve(response.result as T)
+    }
+
+    worker.on('message', onMessage)
+    worker.send(message)
+  })
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+async function runInvalidationScenario(
+  workers: ChildProcess[],
+  prefix: string
+): Promise<MultiProcessInvalidationResult> {
+  const busChannel = `${prefix}:bus`
+  const sharedPrefix = `${prefix}:invalidate`
+  await Promise.all(
+    workers.slice(0, 2).map((worker) =>
+      sendMessage(worker, {
+        id: randomUUID(),
+        type: 'init',
+        prefix: sharedPrefix,
+        busChannel,
+        commandTimeoutMs: COMMAND_TIMEOUT_MS
+      })
+    )
+  )
+
+  const writer = workers[0]
+  const reader = workers[1]
+  if (!writer || !reader) {
+    throw new Error('Expected at least two workers for invalidation scenario.')
+  }
+
+  await sendMessage(writer, {
+    id: randomUUID(),
+    type: 'seed',
+    key: 'shared:key',
+    value: { version: 1 }
+  })
+  await sendMessage(reader, {
+    id: randomUUID(),
+    type: 'read',
+    key: 'shared:key'
+  })
+
+  const startedAt = performance.now()
+  await sendMessage(writer, {
+    id: randomUUID(),
+    type: 'seed',
+    key: 'shared:key',
+    value: { version: 2 }
+  })
+
+  let observedVersion: number | null = null
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    const value =
+      (await sendMessage<{ version: number } | null>(reader, {
+        id: randomUUID(),
+        type: 'read',
+        key: 'shared:key'
+      })) ?? null
+    observedVersion = value?.version ?? null
+    if (observedVersion === 2) {
+      return {
+        scenario: 'multi-process-invalidation',
+        success: true,
+        observedVersion,
+        latencyMs: Number((performance.now() - startedAt).toFixed(3))
+      }
+    }
+
+    await sleep(25)
+  }
+
+  return {
+    scenario: 'multi-process-invalidation',
+    success: false,
+    observedVersion,
+    latencyMs: Number((performance.now() - startedAt).toFixed(3))
+  }
+}
+
+async function runDistributedSingleFlightScenario(
+  workers: ChildProcess[],
+  prefix: string
+): Promise<MultiProcessFanoutResult> {
+  const redis = createRedisClient()
+  const originCounterKey = `${prefix}:origin-count`
+  const sharedPrefix = `${prefix}:fanout`
+  await redis.del(originCounterKey)
+
+  await Promise.all(
+    workers.map((worker) =>
+      sendMessage(worker, {
+        id: randomUUID(),
+        type: 'init',
+        prefix: sharedPrefix,
+        commandTimeoutMs: COMMAND_TIMEOUT_MS
+      }).catch(() => undefined)
+    )
+  )
+
+  const startedAt = performance.now()
+  const startAt = Date.now() + 300
+  await Promise.all(
+    workers.map((worker) =>
+      sendMessage(worker, {
+        id: randomUUID(),
+        type: 'burst',
+        key: 'fanout:key',
+        startAt,
+        concurrency: BURST_CONCURRENCY_PER_PROCESS,
+        originCounterKey,
+        fetchDelayMs: FETCH_DELAY_MS
+      })
+    )
+  )
+  const originFetchCount = Number(await redis.get(originCounterKey)) || 0
+  await redis.quit()
+
+  return {
+    scenario: 'multi-process-distributed-single-flight',
+    processCount: workers.length,
+    concurrencyPerProcess: BURST_CONCURRENCY_PER_PROCESS,
+    totalConcurrency: workers.length * BURST_CONCURRENCY_PER_PROCESS,
+    latencyMs: Number((performance.now() - startedAt).toFixed(3)),
+    originFetchCount
+  }
+}
+
+async function disposeWorkers(workers: ChildProcess[]): Promise<void> {
+  await Promise.all(
+    workers.map(async (worker) => {
+      try {
+        await sendMessage(worker, {
+          id: randomUUID(),
+          type: 'dispose'
+        })
+      } catch {
+        worker.kill('SIGKILL')
+      }
+    })
+  )
+}
+
+async function main(): Promise<void> {
+  await ensureRedisContainer()
+  await waitForRedisReady()
+
+  const invalidationWorkers = Array.from({ length: 2 }, () => spawnWorker())
+  const fanoutWorkers = Array.from({ length: PROCESS_COUNT }, () => spawnWorker())
+  const prefix = `layercache-bench:multiprocess:${Date.now()}`
+
+  try {
+    const invalidationResult = await runInvalidationScenario(invalidationWorkers, prefix)
+    const fanoutResult = await runDistributedSingleFlightScenario(fanoutWorkers, prefix)
+
+    console.table([invalidationResult, fanoutResult])
+    console.log(JSON.stringify({ type: 'multi-process-fanout-benchmark', invalidationResult, fanoutResult }, null, 2))
+  } finally {
+    await disposeWorkers([...invalidationWorkers, ...fanoutWorkers]).catch(() => undefined)
+    await stopRedisContainer()
+  }
+}
+
+void main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/benchmarks/multi-process-worker.ts
+++ b/benchmarks/multi-process-worker.ts
@@ -1,0 +1,151 @@
+import { CacheStack, MemoryLayer, RedisInvalidationBus, RedisLayer, RedisSingleFlightCoordinator } from '../src'
+import { createRedisClient } from './redis'
+import { runConcurrent } from './scenario-utils'
+
+interface InitMessage {
+  id: string
+  type: 'init'
+  prefix: string
+  busChannel?: string
+  commandTimeoutMs?: number
+}
+
+interface SeedMessage {
+  id: string
+  type: 'seed'
+  key: string
+  value: unknown
+}
+
+interface ReadMessage {
+  id: string
+  type: 'read'
+  key: string
+}
+
+interface BurstMessage {
+  id: string
+  type: 'burst'
+  key: string
+  startAt: number
+  concurrency: number
+  originCounterKey: string
+  fetchDelayMs: number
+}
+
+interface DisposeMessage {
+  id: string
+  type: 'dispose'
+}
+
+type WorkerMessage = InitMessage | SeedMessage | ReadMessage | BurstMessage | DisposeMessage
+
+let cache: CacheStack | undefined
+const redis = createRedisClient()
+
+function reply(id: string, ok: boolean, result?: unknown, error?: unknown): void {
+  process.send?.({
+    id,
+    ok,
+    result,
+    error: error instanceof Error ? error.message : error
+  })
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+async function ensureInitialized(message: WorkerMessage): Promise<CacheStack> {
+  if (!cache) {
+    throw new Error(`Worker received "${message.type}" before init.`)
+  }
+
+  return cache
+}
+
+process.on('message', async (message: WorkerMessage) => {
+  try {
+    if (message.type === 'init') {
+      if (cache) {
+        throw new Error('Worker already initialized.')
+      }
+
+      const layer = new RedisLayer({
+        client: redis,
+        ttl: 300,
+        prefix: `${message.prefix}:cache:`,
+        commandTimeoutMs: message.commandTimeoutMs
+      })
+      const bus =
+        message.busChannel === undefined
+          ? undefined
+          : new RedisInvalidationBus({
+              publisher: redis,
+              subscriber: redis.duplicate(),
+              channel: message.busChannel
+            })
+
+      cache = new CacheStack([new MemoryLayer({ ttl: 60, maxSize: 1_000 }), layer], {
+        stampedePrevention: true,
+        invalidationBus: bus,
+        broadcastL1Invalidation: bus ? true : undefined,
+        singleFlightCoordinator: new RedisSingleFlightCoordinator({
+          client: redis,
+          prefix: `${message.prefix}:sf:`,
+          commandTimeoutMs: message.commandTimeoutMs
+        })
+      })
+      reply(message.id, true, { initialized: true })
+      return
+    }
+
+    if (message.type === 'dispose') {
+      await cache?.disconnect()
+      await redis.quit()
+      reply(message.id, true, { disposed: true })
+      process.exit(0)
+      return
+    }
+
+    const initializedCache = await ensureInitialized(message)
+
+    if (message.type === 'seed') {
+      await initializedCache.set(message.key, message.value, { ttl: 60 })
+      reply(message.id, true, { seeded: true })
+      return
+    }
+
+    if (message.type === 'read') {
+      const value = await initializedCache.get(message.key)
+      reply(message.id, true, value)
+      return
+    }
+
+    if (message.type === 'burst') {
+      const waitMs = Math.max(0, message.startAt - Date.now())
+      if (waitMs > 0) {
+        await sleep(waitMs)
+      }
+
+      const startedAt = process.hrtime.bigint()
+      await runConcurrent(message.concurrency, async () => {
+        await initializedCache.get(
+          message.key,
+          async () => {
+            await redis.incr(message.originCounterKey)
+            await sleep(message.fetchDelayMs)
+            return { key: message.key, fetchedAt: Date.now() }
+          },
+          { ttl: 60 }
+        )
+      })
+      const durationMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000
+      reply(message.id, true, { durationMs })
+    }
+  } catch (error) {
+    reply(message.id, false, undefined, error)
+  }
+})

--- a/benchmarks/paths.ts
+++ b/benchmarks/paths.ts
@@ -1,0 +1,25 @@
+import { join } from 'node:path'
+
+export interface BenchmarkPathOptions {
+  fixturePath?: string
+}
+
+export function buildBenchmarkFixtureCandidates(options: BenchmarkPathOptions = {}): string[] {
+  const candidates = [
+    options.fixturePath,
+    process.env.LAYERCACHE_BENCH_FIXTURE_PATH,
+    '/root/cache-test/data/users.json',
+    join(process.cwd(), 'data', 'users.json')
+  ].filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+
+  return [...new Set(candidates)]
+}
+
+export function resolveBenchmarkFixturePath(options: BenchmarkPathOptions = {}): string {
+  const [firstCandidate] = buildBenchmarkFixtureCandidates(options)
+  if (!firstCandidate) {
+    throw new Error('Unable to resolve a benchmark fixture path.')
+  }
+
+  return firstCandidate
+}

--- a/benchmarks/queue-amplification-utils.ts
+++ b/benchmarks/queue-amplification-utils.ts
@@ -1,0 +1,48 @@
+import { type DurationSummary, summarizeDurations } from './stats'
+
+export interface QueueAmplificationSummary extends DurationSummary {
+  delayLabel: string
+  scenario: string
+  concurrency: number
+  concurrencyLabel: string
+  totalWallClockMs: number
+  amplificationVsSingle: number
+  linearityRatio: number
+}
+
+interface SummarizeQueueAmplificationInput {
+  delayLabel: string
+  scenario: string
+  concurrency: number
+  totalWallClockMs: number
+  requestLatenciesMs: number[]
+  baselineWallClockMs: number
+}
+
+function round(value: number): number {
+  return Number(value.toFixed(3))
+}
+
+export function buildConcurrencyLabel(concurrency: number): string {
+  return `x${concurrency}`
+}
+
+export function summarizeQueueAmplification(input: SummarizeQueueAmplificationInput): QueueAmplificationSummary {
+  if (input.baselineWallClockMs <= 0) {
+    throw new Error('baselineWallClockMs must be greater than 0')
+  }
+
+  const concurrencyLabel = buildConcurrencyLabel(input.concurrency)
+  const totalWallClockMs = round(input.totalWallClockMs)
+
+  return {
+    ...summarizeDurations(`${input.delayLabel}-${input.scenario}-${concurrencyLabel}`, input.requestLatenciesMs),
+    delayLabel: input.delayLabel,
+    scenario: input.scenario,
+    concurrency: input.concurrency,
+    concurrencyLabel,
+    totalWallClockMs,
+    amplificationVsSingle: round(totalWallClockMs / input.baselineWallClockMs),
+    linearityRatio: round(totalWallClockMs / (input.baselineWallClockMs * input.concurrency))
+  }
+}

--- a/benchmarks/queue-amplification.ts
+++ b/benchmarks/queue-amplification.ts
@@ -1,0 +1,230 @@
+import { Redis } from 'ioredis'
+import { CacheStack, MemoryLayer, RedisLayer, RedisSingleFlightCoordinator } from '../src'
+import { buildConcurrencyLabel, summarizeQueueAmplification } from './queue-amplification-utils'
+import { REDIS_PORT, ensureRedisContainer, stopRedisContainer, unpauseRedisContainer, waitForRedisReady } from './redis'
+import { startRedisLatencyProxy } from './redis-latency-proxy'
+import { type CountedFetcher, createCountedFetcher, runConcurrent } from './scenario-utils'
+import { buildDelayLabel } from './slow-redis-utils'
+
+const LATENCY_LEVELS = [0, 100, 500] as const
+const CONCURRENCY_LEVELS = [1, 10, 50, 100, 250, 500] as const
+const TIMEOUT_MS = 30_000
+
+interface QueueAmplificationResult {
+  label: string
+  count: number
+  minMs: number
+  maxMs: number
+  avgMs: number
+  medianMs: number
+  p95Ms: number
+  delayLabel: string
+  scenario: string
+  concurrency: number
+  concurrencyLabel: string
+  totalWallClockMs: number
+  amplificationVsSingle: number
+  linearityRatio: number
+}
+
+interface BenchmarkCacheContext {
+  cache: CacheStack
+  memory: MemoryLayer
+  originFetcher: CountedFetcher<[], { source: string; warmedAt: number }>
+}
+
+function round(value: number): number {
+  return Number(value.toFixed(3))
+}
+
+function createBenchmarkRedis(port: number): Redis {
+  const client = new Redis({
+    host: '127.0.0.1',
+    port,
+    lazyConnect: true,
+    maxRetriesPerRequest: 1,
+    connectTimeout: 6_000,
+    enableOfflineQueue: false,
+    autoResendUnfulfilledCommands: false,
+    retryStrategy: () => null
+  })
+
+  client.on('error', () => {})
+  return client
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) => {
+      setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs)
+    })
+  ])
+}
+
+function createLayeredCache(redis: Redis, prefix: string, gracefulDegradation: boolean): BenchmarkCacheContext {
+  const memory = new MemoryLayer({ ttl: 60, maxSize: 50 })
+  const originFetcher = createCountedFetcher(async () => ({
+    source: 'origin',
+    warmedAt: Date.now()
+  }))
+
+  return {
+    memory,
+    originFetcher,
+    cache: new CacheStack([memory, new RedisLayer({ client: redis, ttl: 300, prefix: `${prefix}:cache:` })], {
+      stampedePrevention: true,
+      ...(gracefulDegradation ? { gracefulDegradation: { retryAfterMs: 10_000 } } : {}),
+      singleFlightCoordinator: new RedisSingleFlightCoordinator({
+        client: redis,
+        prefix: `${prefix}:sf:`
+      })
+    })
+  }
+}
+
+async function warmCache(context: BenchmarkCacheContext, key: string): Promise<void> {
+  await context.cache.get(key, () => context.originFetcher.run(), { ttl: 60 })
+}
+
+async function measureBatch(
+  context: BenchmarkCacheContext,
+  key: string,
+  delayLabel: string,
+  scenario: string,
+  concurrency: number,
+  baselineWallClockMs: number
+): Promise<QueueAmplificationResult> {
+  await context.memory.clear()
+
+  const originCountBefore = context.originFetcher.getCount()
+  const batchStartedAt = process.hrtime.bigint()
+  const requestLatenciesMs = await runConcurrent(concurrency, async () => {
+    const requestStartedAt = process.hrtime.bigint()
+    await withTimeout(
+      context.cache.get(key, () => context.originFetcher.run(), { ttl: 60 }),
+      TIMEOUT_MS,
+      `${delayLabel} ${scenario} ${buildConcurrencyLabel(concurrency)}`
+    )
+
+    return Number(process.hrtime.bigint() - requestStartedAt) / 1_000_000
+  })
+  const totalWallClockMs = Number(process.hrtime.bigint() - batchStartedAt) / 1_000_000
+
+  const originFetchCount = context.originFetcher.getCount() - originCountBefore
+  if (originFetchCount !== 0) {
+    throw new Error(
+      `${delayLabel} ${scenario} ${buildConcurrencyLabel(concurrency)} unexpectedly fetched origin ${originFetchCount} times`
+    )
+  }
+
+  return summarizeQueueAmplification({
+    delayLabel,
+    scenario,
+    concurrency,
+    totalWallClockMs,
+    requestLatenciesMs,
+    baselineWallClockMs
+  })
+}
+
+async function runDelayBenchmarks(delayMs: number): Promise<QueueAmplificationResult[]> {
+  const delayLabel = buildDelayLabel(delayMs)
+  const proxy = await startRedisLatencyProxy(REDIS_PORT)
+  proxy.setLatencyMs(delayMs)
+
+  const strictRedis = createBenchmarkRedis(proxy.port)
+  const gracefulRedis = createBenchmarkRedis(proxy.port)
+
+  await Promise.all([strictRedis.connect(), gracefulRedis.connect()])
+  await Promise.all([strictRedis.ping(), gracefulRedis.ping()])
+
+  const strict = createLayeredCache(strictRedis, `queue:${delayMs}:strict:${Date.now()}`, false)
+  const graceful = createLayeredCache(gracefulRedis, `queue:${delayMs}:graceful:${Date.now()}`, true)
+
+  try {
+    const strictKey = `queue:strict:${delayMs}`
+    const gracefulKey = `queue:graceful:${delayMs}`
+
+    await warmCache(strict, strictKey)
+    await warmCache(graceful, gracefulKey)
+
+    const scenarios = [
+      { scenario: 'strict-l2-hit', context: strict, key: strictKey },
+      { scenario: 'graceful-l2-hit', context: graceful, key: gracefulKey }
+    ]
+
+    const results: QueueAmplificationResult[] = []
+
+    for (const { scenario, context, key } of scenarios) {
+      let baselineWallClockMs = 0
+
+      for (const concurrency of CONCURRENCY_LEVELS) {
+        const effectiveBaseline = baselineWallClockMs || 1
+        const summary = await measureBatch(
+          context,
+          key,
+          delayLabel,
+          scenario,
+          concurrency,
+          concurrency === 1 ? effectiveBaseline : baselineWallClockMs
+        )
+
+        if (concurrency === 1) {
+          baselineWallClockMs = summary.totalWallClockMs
+          results.push({
+            ...summary,
+            amplificationVsSingle: 1,
+            linearityRatio: 1
+          })
+          continue
+        }
+
+        results.push(summary)
+      }
+    }
+
+    return results
+  } finally {
+    await strict.cache.disconnect().catch(() => {})
+    await graceful.cache.disconnect().catch(() => {})
+    await strictRedis.quit().catch(() => {})
+    await gracefulRedis.quit().catch(() => {})
+    await proxy.close().catch(() => {})
+  }
+}
+
+async function main(): Promise<void> {
+  await ensureRedisContainer()
+  await waitForRedisReady()
+
+  try {
+    const results: QueueAmplificationResult[] = []
+    for (const delayMs of LATENCY_LEVELS) {
+      results.push(...(await runDelayBenchmarks(delayMs)))
+    }
+
+    console.table(
+      results.map((result) => ({
+        delay: result.delayLabel,
+        scenario: result.scenario,
+        concurrency: result.concurrency,
+        totalWallClockMs: round(result.totalWallClockMs),
+        avgMs: result.avgMs,
+        p95Ms: result.p95Ms,
+        maxMs: result.maxMs,
+        amplificationVsSingle: result.amplificationVsSingle,
+        linearityRatio: result.linearityRatio
+      }))
+    )
+    console.log(JSON.stringify({ type: 'queue-amplification-benchmark', results }, null, 2))
+  } finally {
+    await unpauseRedisContainer().catch(() => {})
+    await stopRedisContainer()
+  }
+}
+
+void main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/benchmarks/redis-latency-proxy.ts
+++ b/benchmarks/redis-latency-proxy.ts
@@ -1,0 +1,100 @@
+import { type Server, type Socket, connect, createServer } from 'node:net'
+
+export interface RedisLatencyProxy {
+  port: number
+  setLatencyMs: (latencyMs: number) => void
+  close: () => Promise<void>
+}
+
+export async function startRedisLatencyProxy(targetPort: number): Promise<RedisLatencyProxy> {
+  let latencyMs = 0
+  const sockets = new Set<Socket>()
+
+  const server = createServer((clientSocket) => {
+    const upstreamSocket = connect({
+      host: '127.0.0.1',
+      port: targetPort
+    })
+
+    sockets.add(clientSocket)
+    sockets.add(upstreamSocket)
+
+    clientSocket.on('error', () => {})
+    upstreamSocket.on('error', () => {})
+    clientSocket.on('close', () => {
+      sockets.delete(clientSocket)
+      if (!upstreamSocket.destroyed) {
+        upstreamSocket.destroy()
+      }
+    })
+    upstreamSocket.on('close', () => {
+      sockets.delete(upstreamSocket)
+      if (!clientSocket.destroyed) {
+        clientSocket.destroy()
+      }
+    })
+
+    clientSocket.on('data', (chunk) => {
+      setTimeout(() => {
+        if (!upstreamSocket.destroyed) {
+          upstreamSocket.write(chunk)
+        }
+      }, latencyMs / 2)
+    })
+
+    upstreamSocket.on('data', (chunk) => {
+      setTimeout(() => {
+        if (!clientSocket.destroyed) {
+          clientSocket.write(chunk)
+        }
+      }, latencyMs / 2)
+    })
+
+    clientSocket.on('end', () => upstreamSocket.end())
+    upstreamSocket.on('end', () => clientSocket.end())
+  })
+
+  await listen(server)
+
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('Latency proxy failed to acquire a TCP port')
+  }
+
+  return {
+    port: address.port,
+    setLatencyMs(nextLatencyMs: number) {
+      latencyMs = nextLatencyMs
+    },
+    async close() {
+      for (const socket of sockets) {
+        socket.destroy()
+      }
+
+      await closeServer(server)
+    }
+  }
+}
+
+function listen(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject)
+      resolve()
+    })
+  })
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+
+      resolve()
+    })
+  })
+}

--- a/benchmarks/redis.ts
+++ b/benchmarks/redis.ts
@@ -1,0 +1,107 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { Redis } from 'ioredis'
+
+const execFileAsync = promisify(execFile)
+
+export const REDIS_CONTAINER_NAME = 'layercache-bench-redis'
+export const REDIS_PORT = 6390
+export const REDIS_IMAGE = 'redis:7-alpine'
+
+async function docker(args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('docker', args, {
+    cwd: process.cwd(),
+    maxBuffer: 10 * 1024 * 1024
+  })
+
+  return stdout.trim()
+}
+
+async function containerExists(): Promise<boolean> {
+  try {
+    await docker(['inspect', REDIS_CONTAINER_NAME])
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function isContainerRunning(): Promise<boolean> {
+  try {
+    return (await docker(['inspect', '-f', '{{.State.Running}}', REDIS_CONTAINER_NAME])) === 'true'
+  } catch {
+    return false
+  }
+}
+
+async function isContainerPaused(): Promise<boolean> {
+  try {
+    return (await docker(['inspect', '-f', '{{.State.Paused}}', REDIS_CONTAINER_NAME])) === 'true'
+  } catch {
+    return false
+  }
+}
+
+export async function ensureRedisContainer(): Promise<void> {
+  await docker(['version', '--format', '{{.Server.Version}}'])
+
+  if (await isContainerRunning()) {
+    return
+  }
+
+  if (await containerExists()) {
+    await docker(['start', REDIS_CONTAINER_NAME])
+    return
+  }
+
+  await docker(['run', '-d', '--rm', '--name', REDIS_CONTAINER_NAME, '-p', `${REDIS_PORT}:6379`, REDIS_IMAGE])
+}
+
+export async function stopRedisContainer(): Promise<void> {
+  try {
+    await docker(['rm', '-f', REDIS_CONTAINER_NAME])
+  } catch {
+    // Ignore cleanup failures so benchmark reporting can continue.
+  }
+}
+
+export async function pauseRedisContainer(): Promise<void> {
+  if (await isContainerPaused()) {
+    return
+  }
+
+  await docker(['pause', REDIS_CONTAINER_NAME])
+}
+
+export async function unpauseRedisContainer(): Promise<void> {
+  if (!(await isContainerPaused())) {
+    return
+  }
+
+  await docker(['unpause', REDIS_CONTAINER_NAME])
+}
+
+export function createRedisClient(port = REDIS_PORT): Redis {
+  return new Redis(`redis://127.0.0.1:${port}`, {
+    maxRetriesPerRequest: null
+  })
+}
+
+export async function waitForRedisReady(retries = 40): Promise<void> {
+  for (let attempt = 0; attempt < retries; attempt += 1) {
+    try {
+      const response = await docker(['exec', REDIS_CONTAINER_NAME, 'redis-cli', 'ping'])
+      if (response === 'PONG') {
+        return
+      }
+    } catch {
+      // Allow Redis a short time to start up after the container launches.
+    }
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 250)
+    })
+  }
+
+  throw new Error('Redis did not become ready in time')
+}

--- a/benchmarks/scenario-utils.ts
+++ b/benchmarks/scenario-utils.ts
@@ -1,0 +1,38 @@
+import { type DurationSummary, summarizeDurations } from './stats'
+
+export interface CountedFetcher<TArgs extends unknown[], TResult> {
+  run: (...args: TArgs) => Promise<TResult>
+  getCount: () => number
+}
+
+export interface ScenarioSummary extends DurationSummary {
+  fetchCount: number
+}
+
+export function createCountedFetcher<TArgs extends unknown[], TResult>(
+  fetcher: (...args: TArgs) => Promise<TResult>
+): CountedFetcher<TArgs, TResult> {
+  let count = 0
+
+  return {
+    run: async (...args: TArgs) => {
+      count += 1
+      return fetcher(...args)
+    },
+    getCount: () => count
+  }
+}
+
+export async function runConcurrent<TResult>(
+  count: number,
+  task: (index: number) => Promise<TResult>
+): Promise<TResult[]> {
+  return Promise.all(Array.from({ length: count }, (_, index) => task(index)))
+}
+
+export function summarizeScenario(label: string, samples: number[], fetchCount: number): ScenarioSummary {
+  return {
+    ...summarizeDurations(label, samples),
+    fetchCount
+  }
+}

--- a/benchmarks/server.ts
+++ b/benchmarks/server.ts
@@ -1,0 +1,157 @@
+import { type IncomingMessage, type Server, type ServerResponse, createServer } from 'node:http'
+
+import type { Redis } from 'ioredis'
+import { CacheStack, MemoryLayer, RedisLayer, RedisSingleFlightCoordinator } from '../src'
+import { resolveBenchmarkFixturePath } from './paths'
+import { createCountedFetcher } from './scenario-utils'
+import { ensureFixtureFile, loadUserFromFixture } from './workload'
+
+export interface BenchmarkServerHandle {
+  port: number
+  close: () => Promise<void>
+  reset: () => Promise<void>
+  warm: () => Promise<void>
+}
+
+const DEFAULT_USER_ID = 4242
+
+function createOriginFetcher(filePath: string) {
+  return createCountedFetcher(async (userId: number) => loadUserFromFixture(filePath, userId))
+}
+
+function respondJson(serverResponse: ServerResponse<IncomingMessage>, statusCode: number, payload: unknown): void {
+  serverResponse.statusCode = statusCode
+  serverResponse.setHeader('content-type', 'application/json')
+  serverResponse.end(JSON.stringify(payload))
+}
+
+export async function startBenchmarkServer(redis: Redis): Promise<BenchmarkServerHandle> {
+  const fixturePath = resolveBenchmarkFixturePath()
+  await ensureFixtureFile(fixturePath)
+
+  const memoryCache = new CacheStack([new MemoryLayer({ ttl: 60, maxSize: 2_000 })], {
+    stampedePrevention: true
+  })
+
+  const layeredCache = new CacheStack(
+    [
+      new MemoryLayer({ ttl: 60, maxSize: 2_000 }),
+      new RedisLayer({ client: redis, ttl: 300, prefix: 'layercache-bench:http:' })
+    ],
+    {
+      stampedePrevention: true,
+      singleFlightCoordinator: new RedisSingleFlightCoordinator({
+        client: redis,
+        prefix: 'layercache-bench:http:single-flight:'
+      })
+    }
+  )
+
+  const gracefulLayeredCache = new CacheStack(
+    [
+      new MemoryLayer({ ttl: 60, maxSize: 2_000 }),
+      new RedisLayer({ client: redis, ttl: 300, prefix: 'layercache-bench:http:graceful:' })
+    ],
+    {
+      stampedePrevention: true,
+      gracefulDegradation: { retryAfterMs: 10_000 },
+      singleFlightCoordinator: new RedisSingleFlightCoordinator({
+        client: redis,
+        prefix: 'layercache-bench:http:graceful:single-flight:'
+      })
+    }
+  )
+
+  const origin = createOriginFetcher(fixturePath)
+
+  const server = createServer(async (request, response) => {
+    const url = new URL(request.url ?? '/', 'http://127.0.0.1')
+    const userId = Number(url.searchParams.get('id') ?? DEFAULT_USER_ID)
+
+    try {
+      if (url.pathname === '/nocache') {
+        const user = await origin.run(userId)
+        respondJson(response, 200, { route: 'nocache', user })
+        return
+      }
+
+      if (url.pathname === '/memory') {
+        const user = await memoryCache.get(`http:user:${userId}`, () => origin.run(userId))
+        respondJson(response, 200, { route: 'memory', user })
+        return
+      }
+
+      if (url.pathname === '/layered') {
+        const user = await layeredCache.get(`http:user:${userId}`, () => origin.run(userId))
+        respondJson(response, 200, { route: 'layered', user })
+        return
+      }
+
+      if (url.pathname === '/layered-graceful') {
+        const user = await gracefulLayeredCache.get(`http:user:${userId}`, () => origin.run(userId))
+        respondJson(response, 200, { route: 'layered-graceful', user })
+        return
+      }
+
+      if (url.pathname === '/health') {
+        respondJson(response, 200, { ok: true, fetchCount: origin.getCount() })
+        return
+      }
+
+      respondJson(response, 404, { error: 'not-found' })
+    } catch (error) {
+      respondJson(response, 500, {
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+  })
+
+  await listen(server)
+
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('Unexpected server address state')
+  }
+
+  return {
+    port: address.port,
+    reset: async () => {
+      await memoryCache.clear()
+      await layeredCache.clear()
+      await gracefulLayeredCache.clear()
+      await redis.flushdb()
+    },
+    warm: async () => {
+      await memoryCache.get(`http:user:${DEFAULT_USER_ID}`, () => origin.run(DEFAULT_USER_ID))
+      await layeredCache.get(`http:user:${DEFAULT_USER_ID}`, () => origin.run(DEFAULT_USER_ID))
+      await gracefulLayeredCache.get(`http:user:${DEFAULT_USER_ID}`, () => origin.run(DEFAULT_USER_ID))
+    },
+    close: async () => {
+      await Promise.all([memoryCache.disconnect(), layeredCache.disconnect(), gracefulLayeredCache.disconnect()])
+      await closeServer(server)
+    }
+  }
+}
+
+function listen(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject)
+      resolve()
+    })
+  })
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+
+      resolve()
+    })
+  })
+}

--- a/benchmarks/slow-redis-latency.ts
+++ b/benchmarks/slow-redis-latency.ts
@@ -1,0 +1,309 @@
+import { Redis } from 'ioredis'
+import { CacheStack, MemoryLayer, RedisLayer, RedisSingleFlightCoordinator } from '../src'
+import {
+  REDIS_PORT,
+  ensureRedisContainer,
+  pauseRedisContainer,
+  stopRedisContainer,
+  unpauseRedisContainer,
+  waitForRedisReady
+} from './redis'
+import { startRedisLatencyProxy } from './redis-latency-proxy'
+import { buildDelayLabel } from './slow-redis-utils'
+
+const LATENCY_LEVELS = [0, 100, 500] as const
+const TIMEOUT_MS = 6_000
+const COMMAND_TIMEOUT_MS = 200
+
+interface SlowRedisResult {
+  delayLabel: string
+  scenario: string
+  success: boolean
+  latencyMs: number
+  error: string | null
+}
+
+interface LayeredCacheContext {
+  cache: CacheStack
+  memory: MemoryLayer
+}
+
+function round(value: number): number {
+  return Number(value.toFixed(3))
+}
+
+function normalizeResult(
+  delayLabel: string,
+  scenario: string,
+  success: boolean,
+  latencyMs: number,
+  error?: string
+): SlowRedisResult {
+  return {
+    delayLabel,
+    scenario,
+    success,
+    latencyMs: round(latencyMs),
+    error: error ?? null
+  }
+}
+
+function createBenchmarkRedis(port: number): Redis {
+  const client = new Redis({
+    host: '127.0.0.1',
+    port,
+    lazyConnect: true,
+    maxRetriesPerRequest: 1,
+    connectTimeout: 6_000,
+    enableOfflineQueue: false,
+    autoResendUnfulfilledCommands: false,
+    retryStrategy: () => null
+  })
+
+  client.on('error', () => {})
+  return client
+}
+
+async function measure<TResult>(task: () => Promise<TResult>): Promise<{ durationMs: number; result: TResult }> {
+  const startedAt = process.hrtime.bigint()
+  const result = await task()
+
+  return {
+    durationMs: Number(process.hrtime.bigint() - startedAt) / 1_000_000,
+    result
+  }
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) => {
+      setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs)
+    })
+  ])
+}
+
+function createLayeredCache(redis: Redis, prefix: string, gracefulDegradation: boolean): LayeredCacheContext {
+  const memory = new MemoryLayer({ ttl: 60, maxSize: 50 })
+  const cache = new CacheStack(
+    [
+      memory,
+      new RedisLayer({
+        client: redis,
+        ttl: 300,
+        prefix: `${prefix}:cache:`,
+        commandTimeoutMs: COMMAND_TIMEOUT_MS
+      })
+    ],
+    {
+      stampedePrevention: true,
+      ...(gracefulDegradation ? { gracefulDegradation: { retryAfterMs: 10_000 } } : {}),
+      singleFlightCoordinator: new RedisSingleFlightCoordinator({
+        client: redis,
+        prefix: `${prefix}:sf:`,
+        commandTimeoutMs: COMMAND_TIMEOUT_MS
+      })
+    }
+  )
+
+  return {
+    cache,
+    memory
+  }
+}
+
+async function runSlowRedisAtDelay(delayMs: number): Promise<SlowRedisResult[]> {
+  const delayLabel = buildDelayLabel(delayMs)
+  const proxy = await startRedisLatencyProxy(REDIS_PORT)
+
+  const strictRedis = createBenchmarkRedis(proxy.port)
+  const gracefulRedis = createBenchmarkRedis(proxy.port)
+
+  await Promise.all([strictRedis.connect(), gracefulRedis.connect()])
+  await Promise.all([strictRedis.ping(), gracefulRedis.ping()])
+
+  const strict = createLayeredCache(strictRedis, `slow:strict:${delayMs}:${Date.now()}`, false)
+  const graceful = createLayeredCache(gracefulRedis, `slow:graceful:${delayMs}:${Date.now()}`, true)
+
+  try {
+    await strict.cache.get('warm:key', async () => ({ source: 'origin', delayMs }), { ttl: 60 })
+    await graceful.cache.get('warm:key', async () => ({ source: 'origin', delayMs }), { ttl: 60 })
+    proxy.setLatencyMs(delayMs)
+
+    const hotStrict = await measure(() =>
+      withTimeout(strict.cache.get('warm:key'), TIMEOUT_MS, `${delayLabel} strict hot`)
+    )
+      .then(({ durationMs }) => normalizeResult(delayLabel, 'strict-hot-hit', true, durationMs))
+      .catch((error) =>
+        normalizeResult(delayLabel, 'strict-hot-hit', false, 0, error instanceof Error ? error.message : String(error))
+      )
+
+    const hotGraceful = await measure(() =>
+      withTimeout(graceful.cache.get('warm:key'), TIMEOUT_MS, `${delayLabel} graceful hot`)
+    )
+      .then(({ durationMs }) => normalizeResult(delayLabel, 'graceful-hot-hit', true, durationMs))
+      .catch((error) =>
+        normalizeResult(
+          delayLabel,
+          'graceful-hot-hit',
+          false,
+          0,
+          error instanceof Error ? error.message : String(error)
+        )
+      )
+
+    await Promise.all([strict.memory.clear().catch(() => undefined), graceful.memory.clear().catch(() => undefined)])
+
+    const l2Strict = await measure(() =>
+      withTimeout(strict.cache.get('warm:key'), TIMEOUT_MS, `${delayLabel} strict l2`)
+    )
+      .then(({ durationMs }) => normalizeResult(delayLabel, 'strict-l2-hit', true, durationMs))
+      .catch((error) =>
+        normalizeResult(delayLabel, 'strict-l2-hit', false, 0, error instanceof Error ? error.message : String(error))
+      )
+
+    const l2Graceful = await measure(() =>
+      withTimeout(graceful.cache.get('warm:key'), TIMEOUT_MS, `${delayLabel} graceful l2`)
+    )
+      .then(({ durationMs }) => normalizeResult(delayLabel, 'graceful-l2-hit', true, durationMs))
+      .catch((error) =>
+        normalizeResult(delayLabel, 'graceful-l2-hit', false, 0, error instanceof Error ? error.message : String(error))
+      )
+
+    const coldStrict = await measure(() =>
+      withTimeout(
+        strict.cache.get('cold:key', async () => ({ source: 'origin', delayMs }), { ttl: 60 }),
+        TIMEOUT_MS,
+        `${delayLabel} strict cold`
+      )
+    )
+      .then(({ durationMs }) => normalizeResult(delayLabel, 'strict-cold-miss', true, durationMs))
+      .catch((error) =>
+        normalizeResult(
+          delayLabel,
+          'strict-cold-miss',
+          false,
+          0,
+          error instanceof Error ? error.message : String(error)
+        )
+      )
+
+    const coldGraceful = await measure(() =>
+      withTimeout(
+        graceful.cache.get('cold:key', async () => ({ source: 'origin', delayMs }), { ttl: 60 }),
+        TIMEOUT_MS,
+        `${delayLabel} graceful cold`
+      )
+    )
+      .then(({ durationMs }) => normalizeResult(delayLabel, 'graceful-cold-miss', true, durationMs))
+      .catch((error) =>
+        normalizeResult(
+          delayLabel,
+          'graceful-cold-miss',
+          false,
+          0,
+          error instanceof Error ? error.message : String(error)
+        )
+      )
+
+    return [hotStrict, hotGraceful, l2Strict, l2Graceful, coldStrict, coldGraceful]
+  } finally {
+    await strict.cache.disconnect().catch(() => {})
+    await graceful.cache.disconnect().catch(() => {})
+    await strictRedis.quit().catch(() => {})
+    await gracefulRedis.quit().catch(() => {})
+    await proxy.close().catch(() => {})
+  }
+}
+
+async function runDeadRedisContrast(): Promise<SlowRedisResult[]> {
+  const strictRedis = createBenchmarkRedis(REDIS_PORT)
+  const gracefulRedis = createBenchmarkRedis(REDIS_PORT)
+
+  await Promise.all([strictRedis.connect(), gracefulRedis.connect()])
+  await Promise.all([strictRedis.ping(), gracefulRedis.ping()])
+
+  const strict = createLayeredCache(strictRedis, `dead:strict:${Date.now()}`, false)
+  const graceful = createLayeredCache(gracefulRedis, `dead:graceful:${Date.now()}`, true)
+
+  try {
+    await strict.cache.get('warm:key', async () => ({ source: 'origin' }), { ttl: 60 })
+    await graceful.cache.get('warm:key', async () => ({ source: 'origin' }), { ttl: 60 })
+
+    await pauseRedisContainer()
+
+    const strictCold = await measure(() =>
+      withTimeout(
+        strict.cache.get('cold:key', async () => ({ source: 'origin' }), { ttl: 60 }),
+        2_000,
+        'dead strict cold'
+      )
+    )
+      .then(({ durationMs }) => normalizeResult('dead', 'dead-strict-cold-miss', true, durationMs))
+      .catch((error) =>
+        normalizeResult(
+          'dead',
+          'dead-strict-cold-miss',
+          false,
+          0,
+          error instanceof Error ? error.message : String(error)
+        )
+      )
+
+    const gracefulCold = await measure(() =>
+      withTimeout(
+        graceful.cache.get('cold:key', async () => ({ source: 'origin' }), { ttl: 60 }),
+        2_000,
+        'dead graceful cold'
+      )
+    )
+      .then(({ durationMs }) => normalizeResult('dead', 'dead-graceful-cold-miss', true, durationMs))
+      .catch((error) =>
+        normalizeResult(
+          'dead',
+          'dead-graceful-cold-miss',
+          false,
+          0,
+          error instanceof Error ? error.message : String(error)
+        )
+      )
+
+    return [strictCold, gracefulCold]
+  } finally {
+    await unpauseRedisContainer().catch(() => {})
+    await waitForRedisReady()
+    await strict.cache.disconnect().catch(() => {})
+    await graceful.cache.disconnect().catch(() => {})
+    await strictRedis.quit().catch(() => {})
+    await gracefulRedis.quit().catch(() => {})
+  }
+}
+
+async function main(): Promise<void> {
+  await ensureRedisContainer()
+  await waitForRedisReady()
+
+  try {
+    const slowRedisResults: SlowRedisResult[] = []
+    for (const delayMs of LATENCY_LEVELS) {
+      slowRedisResults.push(...(await runSlowRedisAtDelay(delayMs)))
+    }
+
+    await stopRedisContainer()
+    await ensureRedisContainer()
+    await waitForRedisReady()
+
+    const deadRedisResults = await runDeadRedisContrast()
+
+    console.table(slowRedisResults.concat(deadRedisResults))
+    console.log(JSON.stringify({ type: 'slow-redis-latency', slowRedisResults, deadRedisResults }, null, 2))
+  } finally {
+    await unpauseRedisContainer().catch(() => {})
+    await stopRedisContainer()
+  }
+}
+
+void main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/benchmarks/slow-redis-utils.ts
+++ b/benchmarks/slow-redis-utils.ts
@@ -1,0 +1,29 @@
+export interface GcMetricsSummary {
+  gcCount: number
+  gcTotalMs: number
+  gcMaxMs: number
+}
+
+function round(value: number): number {
+  return Number(value.toFixed(3))
+}
+
+export function buildDelayLabel(delayMs: number): string {
+  return `${delayMs}ms`
+}
+
+export function summarizeGcMetrics(durationsMs: number[]): GcMetricsSummary {
+  if (durationsMs.length === 0) {
+    return {
+      gcCount: 0,
+      gcTotalMs: 0,
+      gcMaxMs: 0
+    }
+  }
+
+  return {
+    gcCount: durationsMs.length,
+    gcTotalMs: round(durationsMs.reduce((sum, duration) => sum + duration, 0)),
+    gcMaxMs: round(Math.max(...durationsMs))
+  }
+}

--- a/benchmarks/slow-redis.ts
+++ b/benchmarks/slow-redis.ts
@@ -1,0 +1,47 @@
+import { execFile } from 'node:child_process'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+async function runTsx(scriptName: string): Promise<string> {
+  const tsxPath = join(process.cwd(), 'node_modules', '.bin', 'tsx')
+  const scriptPath = join(process.cwd(), 'benchmarks', scriptName)
+  const { stdout } = await execFileAsync(tsxPath, [scriptPath], {
+    cwd: process.cwd(),
+    maxBuffer: 50 * 1024 * 1024
+  })
+
+  return stdout.trim()
+}
+
+function extractJsonBlock(output: string): unknown {
+  const lines = output.trim().split('\n')
+  const startIndex = lines.findIndex((line) => line.startsWith('{'))
+  if (startIndex === -1) {
+    throw new Error('Benchmark output did not contain a JSON block')
+  }
+
+  return JSON.parse(lines.slice(startIndex).join('\n'))
+}
+
+async function main(): Promise<void> {
+  const slowRedisOutput = await runTsx('slow-redis-latency.ts')
+  process.stdout.write(`${slowRedisOutput}\n`)
+
+  const memoryPressureOutput = await runTsx('memory-pressure.ts')
+  process.stdout.write(`${memoryPressureOutput}\n`)
+
+  const combined = {
+    type: 'slow-redis-memory-pressure-benchmark',
+    slowRedis: extractJsonBlock(slowRedisOutput),
+    memoryPressure: extractJsonBlock(memoryPressureOutput)
+  }
+
+  console.log(JSON.stringify(combined, null, 2))
+}
+
+void main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/benchmarks/stats.ts
+++ b/benchmarks/stats.ts
@@ -1,0 +1,46 @@
+export interface DurationSummary {
+  label: string
+  count: number
+  minMs: number
+  maxMs: number
+  avgMs: number
+  medianMs: number
+  p95Ms: number
+}
+
+function round(value: number): number {
+  return Number(value.toFixed(3))
+}
+
+export function quantile(samples: number[], percentile: number): number {
+  if (samples.length === 0) {
+    throw new Error('quantile requires at least one sample')
+  }
+
+  const sorted = [...samples].sort((left, right) => left - right)
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * percentile) - 1))
+  const value = sorted[index]
+  if (value === undefined) {
+    throw new Error('quantile computed an invalid index')
+  }
+
+  return value
+}
+
+export function summarizeDurations(label: string, samples: number[]): DurationSummary {
+  if (samples.length === 0) {
+    throw new Error('summarizeDurations requires at least one sample')
+  }
+
+  const total = samples.reduce((sum, sample) => sum + sample, 0)
+
+  return {
+    label,
+    count: samples.length,
+    minMs: round(Math.min(...samples)),
+    maxMs: round(Math.max(...samples)),
+    avgMs: round(total / samples.length),
+    medianMs: round(quantile(samples, 0.5)),
+    p95Ms: round(quantile(samples, 0.95))
+  }
+}

--- a/benchmarks/workload.ts
+++ b/benchmarks/workload.ts
@@ -1,0 +1,77 @@
+import { createHash } from 'node:crypto'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+
+export interface UserRecord {
+  id: number
+  email: string
+  name: string
+  profile: {
+    plan: string
+    region: string
+    score: number
+  }
+  tags: string[]
+}
+
+const REGIONS = ['us-east', 'eu-west', 'ap-northeast', 'sa-east'] as const
+const PLANS = ['starter', 'growth', 'enterprise'] as const
+
+export function buildUserDataset(count: number): UserRecord[] {
+  return Array.from({ length: count }, (_, index) => {
+    const id = index + 1
+    const plan = PLANS[index % PLANS.length] ?? PLANS[0]
+    const region = REGIONS[index % REGIONS.length] ?? REGIONS[0]
+
+    return {
+      id,
+      email: `user${id}@example.com`,
+      name: `User ${id}`,
+      profile: {
+        plan,
+        region,
+        score: (id * 37) % 1000
+      },
+      tags: [`segment-${id % 10}`, `cohort-${id % 4}`]
+    }
+  })
+}
+
+export function findUserById(users: UserRecord[], id: number): UserRecord {
+  const user = users.find((entry) => entry.id === id)
+  if (!user) {
+    throw new Error(`User ${id} not found`)
+  }
+
+  return user
+}
+
+export async function ensureFixtureFile(filePath: string, count = 5000): Promise<void> {
+  try {
+    await readFile(filePath, 'utf8')
+    return
+  } catch (error) {
+    if (!(error instanceof Error) || !('code' in error) || error.code !== 'ENOENT') {
+      throw error
+    }
+  }
+
+  await mkdir(dirname(filePath), { recursive: true })
+  await writeFile(filePath, JSON.stringify(buildUserDataset(count)), 'utf8')
+}
+
+export async function loadUserFromFixture(filePath: string, userId: number, hashRounds = 600): Promise<UserRecord> {
+  const raw = await readFile(filePath, 'utf8')
+  const users = JSON.parse(raw) as UserRecord[]
+  const user = findUserById(users, userId)
+
+  let digest = JSON.stringify(user)
+  for (let index = 0; index < hashRounds; index += 1) {
+    digest = createHash('sha256').update(digest).digest('hex')
+  }
+
+  return {
+    ...user,
+    tags: [...user.tags, digest.slice(0, 12)]
+  }
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -407,11 +407,14 @@ new RedisLayer({
   prefix: 'myapp:cache:',
   compression: 'gzip',
   compressionThreshold: 1_024,
+  commandTimeoutMs: 200,
   serializer: new MsgpackSerializer(),
   name: 'redis',
   allowUnprefixedClear: false
 })
 ```
+
+`commandTimeoutMs` applies a per-command timeout to Redis round-trips. When a Redis command exceeds this threshold, the layer surfaces an error so `CacheStack` can trigger graceful degradation instead of waiting on a slow dependency indefinitely.
 
 ### DiskLayer
 
@@ -668,6 +671,8 @@ new RedisLayer({
 })
 ```
 
+For large payloads such as HTML fragments, denormalized API responses, or MB-scale documents, prefer `compression: 'brotli'` with a threshold around `1_024 * 1_024` so small values avoid compression overhead while large values pay less network cost.
+
 ### MessagePack Serializer
 
 ```ts
@@ -689,7 +694,10 @@ new RedisLayer({
 ```ts
 import { RedisSingleFlightCoordinator } from 'layercache'
 
-const coordinator = new RedisSingleFlightCoordinator({ client: redis })
+const coordinator = new RedisSingleFlightCoordinator({
+  client: redis,
+  commandTimeoutMs: 200
+})
 
 new CacheStack([...], {
   singleFlightCoordinator: coordinator,

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1,6 +1,6 @@
 # Benchmarking Guide
 
-How to measure and report layercache performance.
+How to reproduce the real Redis-backed benchmark suite shipped with this repository.
 
 > [Back to README](../README.md)
 
@@ -11,126 +11,92 @@ How to measure and report layercache performance.
 Run the included benchmarks:
 
 ```bash
-npm run bench:latency    # Layer hit latency comparison
-npm run bench:stampede   # Stampede prevention verification
+npm run bench:direct
+npm run bench:edge
+npm run bench:slow-redis
+npm run bench:queue-amplification
+npm run bench:http
+npm run bench:multi-process-fanout
 ```
 
-These use `ioredis-mock` and synthetic delays. Treat results as a sanity check - for production numbers, benchmark against your actual Redis instance.
+The suite starts a dedicated Docker Redis container named `layercache-bench-redis` on port `6390`. The workload fixture defaults to `/root/cache-test/data/users.json`, then falls back to `LAYERCACHE_BENCH_FIXTURE_PATH`, then `./data/users.json`.
 
 ---
 
 ## Included Benchmarks
 
-### Latency Benchmark (`npm run bench:latency`)
+### Direct Cache Benchmark (`npm run bench:direct`)
 
-Measures per-layer read latency:
+Measures direct cache behavior against a real workload with file I/O plus CPU hashing:
 
 | Scenario | What it measures |
 |---|---|
-| L1 memory hit | In-process read with no network |
-| L2 Redis hit | Redis GET + deserialization + L1 backfill |
-| Full miss | Fetcher execution + write to all layers |
+| `cold-miss` | Origin fetch plus cache fill |
+| `warm-hit` | Memory and layered hot-hit latency |
+| `stampede` | Concurrent cold-key collapse and fetch count |
 
-Example output:
+### HTTP Benchmark (`npm run bench:http`)
 
-```
-┌─────────────────────┬──────────────┐
-│ Scenario            │ Avg Latency  │
-├─────────────────────┼──────────────┤
-│ L1 memory hit       │   ~0.006 ms  │
-│ L2 Redis hit        │   ~0.020 ms  │
-│ No cache (sim. DB)  │   ~1.08  ms  │
-└─────────────────────┴──────────────┘
-```
+Runs `autocannon` against a local HTTP server exposing `/nocache`, `/memory`, and `/layered`.
 
-### Stampede Benchmark (`npm run bench:stampede`)
+### Edge Benchmark (`npm run bench:edge`)
 
-Verifies that concurrent requests for the same key result in a single fetcher execution:
+Covers production edge cases that do not show up in a simple latency chart:
 
-```
-┌─────────────────────┬────────┐
-│ concurrentRequests  │  100   │
-│ fetcherExecutions   │    1   │
-└─────────────────────┴────────┘
-```
+| Scenario | What it measures |
+|---|---|
+| TTL expiry stampede | Post-expiry collapse under burst traffic |
+| Payload variation | 1KB vs 1MB warm-hit latency |
+| Redis outage | strict vs graceful degradation behavior |
+| Multi-instance invalidation | Redis pub/sub invalidation propagation |
+| Distributed single-flight | cross-instance fetch collapse |
+
+### Slow Redis Benchmark (`npm run bench:slow-redis`)
+
+Combines two reports:
+
+| Scenario | What it measures |
+|---|---|
+| `slow-redis-latency` | 0ms, 100ms, and 500ms induced Redis RTT with `commandTimeoutMs` enabled |
+| `memory-pressure` | L1 eviction churn, revisit latency, GC, and event-loop lag |
+
+### Queue Amplification (`npm run bench:queue-amplification`)
+
+Measures how L2-hit latency scales under concurrent demand when Redis latency is injected through a proxy.
+
+### Multi-Process Fan-Out (`npm run bench:multi-process-fanout`)
+
+Runs multiple Node worker processes against one Redis instance to validate:
+
+| Scenario | What it measures |
+|---|---|
+| `multi-process-invalidation` | cross-process invalidation visibility delay |
+| `multi-process-distributed-single-flight` | origin fetch count under cross-process burst traffic |
 
 ---
 
-## Recommended Test Scenarios
+## Environment
 
-For comprehensive benchmarking, test these scenarios:
+- Node.js 20+
+- Docker daemon available locally
+- Redis image `redis:7-alpine`
+- Fixture file at `/root/cache-test/data/users.json`, `LAYERCACHE_BENCH_FIXTURE_PATH`, or `./data/users.json`
 
-### 1. L1 Hit Latency (Memory Only)
+The benchmark utilities automatically prefer `/root/cache-test/data/users.json` so results stay aligned with the external benchmark workspace the reports were generated from.
 
-Measures pure in-process read performance.
+---
 
-```ts
-const cache = new CacheStack([new MemoryLayer({ ttl: 60, maxSize: 10_000 })])
-await cache.set('key', value)
+## Compression Guidance
 
-// Benchmark: repeated get('key')
-```
-
-### 2. L2 Hit Latency (Redis + Backfill)
-
-Measures Redis read + automatic L1 backfill.
+`RedisLayer` compression is intentionally opt-in, but large payload benchmarks show it matters for multi-hundred-KB and MB-sized values. For large cached documents or API payloads, start with:
 
 ```ts
-const cache = new CacheStack([
-  new MemoryLayer({ ttl: 60 }),
-  new RedisLayer({ client: redis, ttl: 300 })
-])
-
-// Prime L2 only, then benchmark get()
-```
-
-### 3. Full Miss with Single-Flight
-
-Measures fetcher execution with distributed dedup.
-
-```ts
-const cache = new CacheStack([...], {
-  singleFlightCoordinator: new RedisSingleFlightCoordinator({ client: redis })
+new RedisLayer({
+  client: redis,
+  ttl: 300,
+  compression: 'brotli',
+  compressionThreshold: 1_024 * 1_024
 })
-
-// Benchmark: 100 concurrent get() calls for the same uncached key
-```
-
-### 4. Warm-Start Latency
-
-Measures time to pre-populate cache from cold start.
-
-```ts
-const entries = Array.from({ length: 1000 }, (_, i) => ({
-  key: `item:${i}`,
-  fetcher: () => fetchItem(i)
-}))
-
-// Benchmark: cache.warm(entries, { concurrency: 10 })
-```
-
-### 5. Compression Impact
-
-Compare Redis payload sizes and latency with and without compression.
-
-```ts
-// Without compression
-new RedisLayer({ client: redis, ttl: 300 })
-
-// With gzip
-new RedisLayer({ client: redis, ttl: 300, compression: 'gzip' })
-
-// With brotli
-new RedisLayer({ client: redis, ttl: 300, compression: 'brotli' })
-```
-
-### 6. Tag Invalidation at Scale
-
-Measure invalidation throughput with many tagged keys.
-
-```ts
-// Write 10,000 keys with tags
-// Benchmark: cache.invalidateByTag('common-tag')
 ```
 
 ---
@@ -139,18 +105,18 @@ Measure invalidation throughput with many tagged keys.
 
 When sharing benchmark results, include:
 
-- **Environment**: Node.js version, Redis version, OS, CPU, memory
+- **Environment**: Node.js version, Redis version, OS, CPU, memory, Docker version
 - **Layer configuration**: Layers, TTLs, max sizes, compression settings
 - **Metrics**: Average latency, p50, p95, p99
 - **Concurrency**: Number of concurrent requests
-- **Fetcher execution count**: Especially for stampede tests
+- **Fetcher execution count**: Especially for stampede and multi-process tests
 - **Sample size**: Number of iterations
 
 Example:
 
 ```
-Environment: Node 22.1.0, Redis 7.2, macOS M2, 16GB RAM
-Layers: MemoryLayer(ttl=60, maxSize=5000) + RedisLayer(ttl=300, gzip)
+Environment: Node 22.1.0, Redis 7.2, Docker 28.x, Linux x64, 16GB RAM
+Layers: MemoryLayer(ttl=60, maxSize=5000) + RedisLayer(ttl=300, brotli)
 Concurrency: 50 parallel requests
 
 | Scenario      | avg    | p50    | p95    | p99    | samples |
@@ -168,5 +134,6 @@ Concurrency: 50 parallel requests
 - **Isolate Redis**: Use a dedicated Redis instance for benchmarks, not your development server.
 - **Test realistic payloads**: Use JSON objects similar in size and shape to your actual data.
 - **Test under load**: Single-request latency is less interesting than behavior under concurrent load.
+- **Use command timeouts**: Slow Redis only degrades gracefully if slow commands are surfaced as errors. Set `commandTimeoutMs` on `RedisLayer` and `RedisSingleFlightCoordinator` when benchmarking degradation behavior.
 
 > [Back to README](../README.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,10 @@
         "@biomejs/biome": "^1.9.4",
         "@nestjs/common": "^11.1.0",
         "@nestjs/core": "^11.1.0",
+        "@types/autocannon": "^7.12.7",
         "@types/node": "^22.15.2",
         "@vitest/coverage-v8": "^4.1.2",
+        "autocannon": "^8.0.0",
         "ioredis": "^5.6.1",
         "ioredis-mock": "^8.13.0",
         "reflect-metadata": "^0.2.2",
@@ -42,6 +44,13 @@
       "peerDependencies": {
         "ioredis": ">=5.0.0"
       }
+    },
+    "node_modules/@assemblyscript/loader": {
+      "version": "0.19.23",
+      "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.19.23.tgz",
+      "integrity": "sha512-ulkCYfFbYj01ie1MDOyxv2F6SpRN1TOj7fQxbP07D6HmeR+gr2JLSmINKjga2emB+b1L2KGrFKBTc+e00p54nw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
@@ -280,6 +289,17 @@
     "node_modules/@cachestack/nestjs": {
       "resolved": "packages/nestjs",
       "link": true
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.9.2",
@@ -820,6 +840,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@minimistjs/subarg": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@minimistjs/subarg/-/subarg-1.0.0.tgz",
+      "integrity": "sha512-Q/ONBiM2zNeYUy0mVSO44mWWKYM3UHuEK43PKIOzJCbvUnPoMH1K+gk3cf1kgnCVJFlWmddahQQCmrmBGlk9jQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.1.0"
       }
     },
     "node_modules/@msgpack/msgpack": {
@@ -1601,6 +1631,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/autocannon": {
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@types/autocannon/-/autocannon-7.12.7.tgz",
+      "integrity": "sha512-Pd4nPf7wRpacULa6D/EC9x3CwzFQXwA0z5WFuik/fvJjW44V3WzBTM3jtt8nSBoflUNgswPiMCtgrr1bwnAcMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1804,6 +1844,32 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -1842,6 +1908,94 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/autocannon": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/autocannon/-/autocannon-8.0.0.tgz",
+      "integrity": "sha512-fMMcWc2JPFcUaqHeR6+PbmEpTxCrPZyBUM95oG4w3ngJ8NfBNas/ZXA+pTHXLqJ0UlFVTcy05GC25WxKx/M20A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@minimistjs/subarg": "^1.0.0",
+        "chalk": "^4.1.0",
+        "char-spinner": "^1.0.1",
+        "cli-table3": "^0.6.0",
+        "color-support": "^1.1.1",
+        "cross-argv": "^2.0.0",
+        "form-data": "^4.0.0",
+        "has-async-hooks": "^1.0.0",
+        "hdr-histogram-js": "^3.0.0",
+        "hdr-histogram-percentiles-obj": "^3.0.0",
+        "http-parser-js": "^0.5.2",
+        "hyperid": "^3.0.0",
+        "lodash.chunk": "^4.2.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "manage-path": "^2.0.0",
+        "on-net-listen": "^1.1.1",
+        "pretty-bytes": "^5.4.1",
+        "progress": "^2.0.3",
+        "reinterval": "^1.1.0",
+        "retimer": "^3.0.0",
+        "semver": "^7.3.2",
+        "timestring": "^6.0.0"
+      },
+      "bin": {
+        "autocannon": "autocannon.js"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/bundle-require": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
@@ -1868,6 +2022,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1877,6 +2045,30 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz",
+      "integrity": "sha512-acv43vqJ0+N0rD+Uw3pDHSxP30FHrywu2NO6/wBaHChJIizpDeBUd6NjqhNhy9LGaEAhZAXn46QzmlAvIWd16g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
@@ -1894,6 +2086,22 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
     "node_modules/cluster-key-slot": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
@@ -1902,6 +2110,49 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/commander": {
@@ -1937,6 +2188,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-argv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cross-argv/-/cross-argv-2.0.0.tgz",
+      "integrity": "sha512-YIaY9TR5Nxeb8SMdtrU8asWVM4jqJDNDYlKV21LxtYcfNJhp1kEsgSa6qXwXgzN0WQWGODps0+TlGp2xQSHwOg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1952,6 +2210,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/denque": {
@@ -1974,12 +2242,83 @@
         "node": ">=8"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.5",
@@ -2119,6 +2458,23 @@
         "rollup": "^4.34.8"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2134,6 +2490,55 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.13.7",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
@@ -2147,6 +2552,26 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-async-hooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-async-hooks/-/has-async-hooks-1.0.0.tgz",
+      "integrity": "sha512-YF0VPGjkxr7AyyQQNykX8zK4PvtEDsUJAPqwu06UFz1lb6EvI53sPh5H1kWxg8NXI5LsfRCZ8uX9NkYDZBb/mw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2157,12 +2582,95 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hdr-histogram-js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hdr-histogram-js/-/hdr-histogram-js-3.0.1.tgz",
+      "integrity": "sha512-l3GSdZL1Jr1C0kyb461tUjEdrRPZr8Qry7jByltf5JGrA0xvqOSrxRBfcrJqqV/AMEtqqhHhC6w8HW0gn76tRQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@assemblyscript/loader": "^0.19.21",
+        "base64-js": "^1.2.0",
+        "pako": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/hdr-histogram-percentiles-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hdr-histogram-percentiles-obj/-/hdr-histogram-percentiles-obj-3.0.0.tgz",
+      "integrity": "sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hyperid": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/hyperid/-/hyperid-3.3.0.tgz",
+      "integrity": "sha512-7qhCVT4MJIoEsNcbhglhdmBKb09QtcmJNiIQGq7js/Khf5FtQQ9bzcAuloeqBeee7XD7JqDeve9KNlQya5tSGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.2.1",
+        "uuid": "^8.3.2",
+        "uuid-parse": "^1.1.0"
+      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -2228,6 +2736,16 @@
       "peerDependencies": {
         "@types/ioredis-mock": "^8",
         "ioredis": "^5"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/istanbul-lib-coverage": {
@@ -2605,10 +3123,31 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/lodash.chunk": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
+      "integrity": "sha512-ZzydJKfUHJwHa+hF5X66zLFCBrWn5GeF28OHEr4WVWtNDXlQ/IjWKPBiikqKo2ne0+v6JgCgJ0GzJp8k8bHC7w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
       "dev": true,
       "license": "MIT"
     },
@@ -2655,6 +3194,56 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/manage-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/manage-path/-/manage-path-2.0.0.tgz",
+      "integrity": "sha512-NJhyB+PJYTpxhxZJ3lecIGgh4kwIY2RAh44XvAz9UlqthlQwtPBf62uBVR8XaD8CRuSjQ6TnZH2lNJkbLPZM2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/mlly": {
@@ -2727,6 +3316,23 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/on-net-listen": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/on-net-listen/-/on-net-listen-1.1.2.tgz",
+      "integrity": "sha512-y1HRYy8s/RlcBvDUwKXSmkODMdx4KSuIvloCnQYJ2LdBBC1asY4HtfhXwe3UWknLakATZDnbzht2Ijw3M1EqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=9.4.0 || ^8.9.4"
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
@@ -2859,6 +3465,29 @@
         }
       }
     },
+    "node_modules/pretty-bytes": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -2912,6 +3541,13 @@
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
       "license": "Apache-2.0"
     },
+    "node_modules/reinterval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
+      "integrity": "sha512-QIRet3SYrGp0HUHO88jVskiG6seqUGC5iAG7AwI/BV4ypGcuqk9Du6YQBUOUqm9c8pw1eyLoIaONifRua1lsEQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -2931,6 +3567,13 @@
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
+    },
+    "node_modules/retimer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/retimer/-/retimer-3.0.0.tgz",
+      "integrity": "sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.12",
@@ -3088,6 +3731,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strtok3": {
       "version": "10.3.5",
       "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
@@ -3161,6 +3832,16 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/timestring": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/timestring/-/timestring-6.0.0.tgz",
+      "integrity": "sha512-wMctrWD2HZZLuIlchlkE2dfXJh7J2KDI9Dwl+2abPYg0mswQHfOAyQW3jJg1pY5VfttSINZuKcXoB3FGypVklA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tinybench": {
@@ -3380,6 +4061,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/uuid-parse": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/uuid-parse/-/uuid-parse-1.1.0.tgz",
+      "integrity": "sha512-OdmXxA8rDsQ7YpNVbKSJkNzTw2I+S5WsbMDnCtIWSQaosNAcWtFuI/YK1TjzUI6nbkgiqEyh8gWngfcv8Asd9A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vite": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
@@ -3570,7 +4268,7 @@
     "packages/nestjs": {
       "name": "@cachestack/nestjs",
       "version": "0.1.0",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@nestjs/common": ">=10.0.0",
         "@nestjs/core": ">=10.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "layercache",
-  "version": "1.2.9",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "layercache",
-      "version": "1.2.9",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/nestjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "layercache",
-  "version": "1.2.9",
+  "version": "1.3.0",
   "description": "Production-ready multi-layer caching for Node.js. Stack memory + Redis + disk behind one API with stampede prevention, tag invalidation, stale serving, and full observability.",
   "keywords": [
     "cache",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,15 @@
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "bench:latency": "tsx benchmarks/latency.ts",
-    "bench:stampede": "tsx benchmarks/stampede.ts"
+    "bench:stampede": "tsx benchmarks/stampede.ts",
+    "bench:direct": "tsx benchmarks/direct.ts",
+    "bench:http": "tsx benchmarks/http.ts",
+    "bench:edge": "tsx benchmarks/edge.ts",
+    "bench:slow-redis": "tsx benchmarks/slow-redis.ts",
+    "bench:memory-pressure": "tsx benchmarks/memory-pressure.ts",
+    "bench:queue-amplification": "tsx benchmarks/queue-amplification.ts",
+    "bench:multi-process-fanout": "tsx benchmarks/multi-process-fanout.ts",
+    "bench:all": "npm run bench:direct && npm run bench:edge && npm run bench:slow-redis && npm run bench:queue-amplification && npm run bench:http && npm run bench:multi-process-fanout"
   },
   "dependencies": {
     "@msgpack/msgpack": "^3.0.0",
@@ -90,8 +98,10 @@
     "@biomejs/biome": "^1.9.4",
     "@nestjs/common": "^11.1.0",
     "@nestjs/core": "^11.1.0",
+    "@types/autocannon": "^7.12.7",
     "@types/node": "^22.15.2",
     "@vitest/coverage-v8": "^4.1.2",
+    "autocannon": "^8.0.0",
     "ioredis": "^5.6.1",
     "ioredis-mock": "^8.13.0",
     "reflect-metadata": "^0.2.2",

--- a/src/CacheStack.ts
+++ b/src/CacheStack.ts
@@ -332,7 +332,7 @@ export class CacheStack extends EventEmitter {
       return null
     }
 
-    return this.fetchWithGuards(normalizedKey, fetcher, options)
+    return this.fetchWithGuards(normalizedKey, fetcher, options, undefined, undefined, true)
   }
 
   /**
@@ -921,13 +921,17 @@ export class CacheStack extends EventEmitter {
     fetcher: () => Promise<T>,
     options?: CacheGetOptions,
     expectedClearEpoch?: number,
-    expectedKeyEpoch?: number
+    expectedKeyEpoch?: number,
+    initialMissConfirmed = false
   ): Promise<T | null> {
     const fetchTask = async (): Promise<T | null> => {
-      const secondHit = await this.readFromLayers<T>(key, options, 'fresh-only')
-      if (secondHit.found) {
-        this.metricsCollector.increment('hits')
-        return secondHit.value
+      const shouldRecheckFreshLayers = !(initialMissConfirmed && this.options.singleFlightCoordinator)
+      if (shouldRecheckFreshLayers) {
+        const secondHit = await this.readFromLayers<T>(key, options, 'fresh-only')
+        if (secondHit.found) {
+          this.metricsCollector.increment('hits')
+          return secondHit.value
+        }
       }
 
       return this.fetchAndPopulate(key, fetcher, options, expectedClearEpoch, expectedKeyEpoch)
@@ -938,9 +942,23 @@ export class CacheStack extends EventEmitter {
         return fetchTask()
       }
 
-      return this.options.singleFlightCoordinator.execute(key, this.resolveSingleFlightOptions(), fetchTask, () =>
-        this.waitForFreshValue(key, fetcher, options, expectedClearEpoch, expectedKeyEpoch)
-      )
+      try {
+        return await this.options.singleFlightCoordinator.execute(
+          key,
+          this.resolveSingleFlightOptions(),
+          fetchTask,
+          () => this.waitForFreshValue(key, fetcher, options, expectedClearEpoch, expectedKeyEpoch)
+        )
+      } catch (error) {
+        if (!this.isGracefulDegradationEnabled()) {
+          throw error
+        }
+
+        this.metricsCollector.increment('degradedOperations')
+        this.logger.warn?.('single-flight-coordinator-degraded', { key, error: this.formatError(error) })
+        this.emitError('single-flight', { key, degraded: true, error: this.formatError(error) })
+        return fetchTask()
+      }
     }
 
     if (this.options.stampedePrevention === false) {

--- a/src/layers/RedisLayer.ts
+++ b/src/layers/RedisLayer.ts
@@ -28,6 +28,11 @@ interface RedisLayerOptions {
    * Prevents decompression bomb attacks. Defaults to 64 MiB.
    */
   decompressionMaxBytes?: number
+  /**
+   * Per-command timeout in milliseconds for Redis round-trips.
+   * Slow commands reject so CacheStack can treat the layer as degraded.
+   */
+  commandTimeoutMs?: number
   disconnectOnDispose?: boolean
 }
 
@@ -44,6 +49,7 @@ export class RedisLayer implements CacheLayer {
   private readonly compression?: CompressionAlgorithm
   private readonly compressionThreshold: number
   private readonly decompressionMaxBytes: number
+  private readonly commandTimeoutMs: number | undefined
   private readonly disconnectOnDispose: boolean
 
   constructor(options: RedisLayerOptions) {
@@ -59,6 +65,7 @@ export class RedisLayer implements CacheLayer {
     this.compression = options.compression
     this.compressionThreshold = options.compressionThreshold ?? 1_024
     this.decompressionMaxBytes = options.decompressionMaxBytes ?? 64 * 1_024 * 1_024
+    this.commandTimeoutMs = this.normalizeCommandTimeoutMs(options.commandTimeoutMs)
     this.disconnectOnDispose = options.disconnectOnDispose ?? false
   }
 
@@ -68,7 +75,7 @@ export class RedisLayer implements CacheLayer {
   }
 
   async getEntry<T = unknown>(key: string): Promise<T | null> {
-    const payload = await this.client.getBuffer(this.withPrefix(key))
+    const payload = await this.runCommand(`get("${key}")`, () => this.client.getBuffer(this.withPrefix(key)))
     if (payload === null) {
       return null
     }
@@ -86,7 +93,7 @@ export class RedisLayer implements CacheLayer {
       pipeline.getBuffer(this.withPrefix(key))
     }
 
-    const results = await pipeline.exec()
+    const results = await this.runCommand(`mget(${keys.length})`, () => pipeline.exec())
     if (results === null) {
       return keys.map(() => null)
     }
@@ -120,7 +127,7 @@ export class RedisLayer implements CacheLayer {
       }
     }
 
-    await pipeline.exec()
+    await this.runCommand(`mset(${entries.length})`, () => pipeline.exec())
   }
 
   async set(key: string, value: unknown, ttl = this.defaultTtl): Promise<void> {
@@ -129,31 +136,33 @@ export class RedisLayer implements CacheLayer {
     const normalizedKey = this.withPrefix(key)
 
     if (ttl && ttl > 0) {
-      await this.client.set(normalizedKey, payload as never, 'EX', ttl)
+      await this.runCommand(`set("${key}")`, () => this.client.set(normalizedKey, payload as never, 'EX', ttl))
       return
     }
 
-    await this.client.set(normalizedKey, payload as never)
+    await this.runCommand(`set("${key}")`, () => this.client.set(normalizedKey, payload as never))
   }
 
   async delete(key: string): Promise<void> {
-    await this.client.del(this.withPrefix(key))
+    await this.runCommand(`delete("${key}")`, () => this.client.del(this.withPrefix(key)))
   }
 
   async deleteMany(keys: string[]): Promise<void> {
     if (keys.length === 0) {
       return
     }
-    await this.client.del(...keys.map((key) => this.withPrefix(key)))
+    await this.runCommand(`deleteMany(${keys.length})`, () =>
+      this.client.del(...keys.map((key) => this.withPrefix(key)))
+    )
   }
 
   async has(key: string): Promise<boolean> {
-    const exists = await this.client.exists(this.withPrefix(key))
+    const exists = await this.runCommand(`has("${key}")`, () => this.client.exists(this.withPrefix(key)))
     return exists > 0
   }
 
   async ttl(key: string): Promise<number | null> {
-    const remaining = await this.client.ttl(this.withPrefix(key))
+    const remaining = await this.runCommand(`ttl("${key}")`, () => this.client.ttl(this.withPrefix(key)))
     // -2 = key does not exist, -1 = key exists but no TTL
     if (remaining < 0) {
       return null
@@ -163,7 +172,7 @@ export class RedisLayer implements CacheLayer {
 
   async size(): Promise<number> {
     if (!this.prefix) {
-      return this.client.dbsize()
+      return this.runCommand('dbsize()', () => this.client.dbsize())
     }
 
     const pattern = `${this.prefix}*`
@@ -171,7 +180,9 @@ export class RedisLayer implements CacheLayer {
     let count = 0
 
     do {
-      const [nextCursor, keys] = await this.client.scan(cursor, 'MATCH', pattern, 'COUNT', this.scanCount)
+      const [nextCursor, keys] = await this.runCommand(`scan("${pattern}")`, () =>
+        this.client.scan(cursor, 'MATCH', pattern, 'COUNT', this.scanCount)
+      )
       cursor = nextCursor
       count += keys.length
     } while (cursor !== '0')
@@ -181,7 +192,7 @@ export class RedisLayer implements CacheLayer {
 
   async ping(): Promise<boolean> {
     try {
-      return (await this.client.ping()) === 'PONG'
+      return (await this.runCommand('ping()', () => this.client.ping())) === 'PONG'
     } catch {
       return false
     }
@@ -208,7 +219,9 @@ export class RedisLayer implements CacheLayer {
     let cursor = '0'
 
     do {
-      const [nextCursor, keys] = await this.client.scan(cursor, 'MATCH', pattern, 'COUNT', this.scanCount)
+      const [nextCursor, keys] = await this.runCommand(`scan("${pattern}")`, () =>
+        this.client.scan(cursor, 'MATCH', pattern, 'COUNT', this.scanCount)
+      )
       cursor = nextCursor
 
       if (keys.length === 0) {
@@ -218,7 +231,7 @@ export class RedisLayer implements CacheLayer {
       // Delete in batches to avoid blocking Redis with huge DEL commands
       for (let i = 0; i < keys.length; i += BATCH_DELETE_SIZE) {
         const batch = keys.slice(i, i + BATCH_DELETE_SIZE)
-        await this.client.del(...batch)
+        await this.runCommand(`clear-del(${batch.length})`, () => this.client.del(...batch))
       }
     } while (cursor !== '0')
   }
@@ -237,7 +250,9 @@ export class RedisLayer implements CacheLayer {
     let cursor = '0'
 
     do {
-      const [nextCursor, keys] = await this.client.scan(cursor, 'MATCH', pattern, 'COUNT', this.scanCount)
+      const [nextCursor, keys] = await this.runCommand(`scan("${pattern}")`, () =>
+        this.client.scan(cursor, 'MATCH', pattern, 'COUNT', this.scanCount)
+      )
       cursor = nextCursor
 
       for (const key of keys) {
@@ -251,7 +266,9 @@ export class RedisLayer implements CacheLayer {
     let cursor = '0'
 
     do {
-      const [nextCursor, keys] = await this.client.scan(cursor, 'MATCH', pattern, 'COUNT', this.scanCount)
+      const [nextCursor, keys] = await this.runCommand(`scan("${pattern}")`, () =>
+        this.client.scan(cursor, 'MATCH', pattern, 'COUNT', this.scanCount)
+      )
       cursor = nextCursor
       matches.push(...keys)
     } while (cursor !== '0')
@@ -290,7 +307,7 @@ export class RedisLayer implements CacheLayer {
 
   private async deleteCorruptedKey(key: string): Promise<void> {
     try {
-      await this.client.del(this.withPrefix(key))
+      await this.runCommand(`deleteCorrupted("${key}")`, () => this.client.del(this.withPrefix(key)))
     } catch (deleteError) {
       // Log but don't throw — the original deserialization failure is the primary issue.
       // The corrupted key will be retried on next access.
@@ -301,13 +318,15 @@ export class RedisLayer implements CacheLayer {
   private async rewriteWithPrimarySerializer(key: string, value: unknown): Promise<void> {
     const serialized = this.primarySerializer().serialize(value)
     const payload = await this.encodePayload(serialized)
-    const ttl = await this.client.ttl(this.withPrefix(key))
+    const ttl = await this.runCommand(`rewrite-ttl("${key}")`, () => this.client.ttl(this.withPrefix(key)))
     if (ttl > 0) {
-      await this.client.set(this.withPrefix(key), payload as never, 'EX', ttl)
+      await this.runCommand(`rewrite-set("${key}")`, () =>
+        this.client.set(this.withPrefix(key), payload as never, 'EX', ttl)
+      )
       return
     }
 
-    await this.client.set(this.withPrefix(key), payload as never)
+    await this.runCommand(`rewrite-set("${key}")`, () => this.client.set(this.withPrefix(key), payload as never))
   }
 
   private primarySerializer(): CacheSerializer {
@@ -419,6 +438,41 @@ export class RedisLayer implements CacheLayer {
       })
 
       source.pipe(decompressor)
+    })
+  }
+
+  private normalizeCommandTimeoutMs(value: number | undefined): number | undefined {
+    if (value === undefined) {
+      return undefined
+    }
+
+    if (!Number.isFinite(value) || value <= 0) {
+      throw new Error('RedisLayer.commandTimeoutMs must be a positive number.')
+    }
+
+    return value
+  }
+
+  private async runCommand<T>(operation: string, command: () => Promise<T>): Promise<T> {
+    const promise = command()
+    if (!this.commandTimeoutMs) {
+      return promise
+    }
+
+    let timer: ReturnType<typeof setTimeout> | undefined
+
+    return Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(new Error(`RedisLayer command ${operation} timed out after ${this.commandTimeoutMs}ms.`))
+        }, this.commandTimeoutMs)
+        timer.unref?.()
+      })
+    ]).finally(() => {
+      if (timer) {
+        clearTimeout(timer)
+      }
     })
   }
 }

--- a/src/singleflight/RedisSingleFlightCoordinator.ts
+++ b/src/singleflight/RedisSingleFlightCoordinator.ts
@@ -5,6 +5,7 @@ import type { CacheSingleFlightCoordinator, CacheSingleFlightExecutionOptions } 
 interface RedisSingleFlightCoordinatorOptions {
   client: Redis
   prefix?: string
+  commandTimeoutMs?: number
 }
 
 const RELEASE_SCRIPT = `
@@ -24,10 +25,12 @@ return 0
 export class RedisSingleFlightCoordinator implements CacheSingleFlightCoordinator {
   private readonly client: Redis
   private readonly prefix: string
+  private readonly commandTimeoutMs: number | undefined
 
   constructor(options: RedisSingleFlightCoordinatorOptions) {
     this.client = options.client
     this.prefix = options.prefix ?? 'layercache:singleflight'
+    this.commandTimeoutMs = this.normalizeCommandTimeoutMs(options.commandTimeoutMs)
   }
 
   async execute<T>(
@@ -38,7 +41,9 @@ export class RedisSingleFlightCoordinator implements CacheSingleFlightCoordinato
   ): Promise<T> {
     const lockKey = `${this.prefix}:${encodeURIComponent(key)}`
     const token = randomUUID()
-    const acquired = await this.client.set(lockKey, token, 'PX', options.leaseMs, 'NX')
+    const acquired = await this.runCommand(`acquire("${key}")`, () =>
+      this.client.set(lockKey, token, 'PX', options.leaseMs, 'NX')
+    )
 
     if (acquired === 'OK') {
       const renewTimer = this.startLeaseRenewal(lockKey, token, options)
@@ -48,7 +53,7 @@ export class RedisSingleFlightCoordinator implements CacheSingleFlightCoordinato
         if (renewTimer) {
           clearInterval(renewTimer)
         }
-        await this.client.eval(RELEASE_SCRIPT, 1, lockKey, token)
+        await this.runCommand(`release("${key}")`, () => this.client.eval(RELEASE_SCRIPT, 1, lockKey, token))
       }
     }
 
@@ -66,9 +71,48 @@ export class RedisSingleFlightCoordinator implements CacheSingleFlightCoordinato
     }
 
     const timer = setInterval(() => {
-      void this.client.eval(RENEW_SCRIPT, 1, lockKey, token, String(options.leaseMs)).catch(() => undefined)
+      void this.runCommand(`renew("${lockKey}")`, () =>
+        this.client.eval(RENEW_SCRIPT, 1, lockKey, token, String(options.leaseMs))
+      ).catch(() => undefined)
     }, renewIntervalMs)
     timer.unref?.()
     return timer
+  }
+
+  private normalizeCommandTimeoutMs(value: number | undefined): number | undefined {
+    if (value === undefined) {
+      return undefined
+    }
+
+    if (!Number.isFinite(value) || value <= 0) {
+      throw new Error('RedisSingleFlightCoordinator.commandTimeoutMs must be a positive number.')
+    }
+
+    return value
+  }
+
+  private async runCommand<T>(operation: string, command: () => Promise<T>): Promise<T> {
+    const promise = command()
+    if (!this.commandTimeoutMs) {
+      return promise
+    }
+
+    let timer: ReturnType<typeof setTimeout> | undefined
+
+    return Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(
+            new Error(`RedisSingleFlightCoordinator command ${operation} timed out after ${this.commandTimeoutMs}ms.`)
+          )
+        }, this.commandTimeoutMs)
+        timer.unref?.()
+      })
+    ]).finally(() => {
+      if (timer) {
+        clearTimeout(timer)
+      }
+    })
   }
 }

--- a/src/stampede/StampedeGuard.ts
+++ b/src/stampede/StampedeGuard.ts
@@ -1,37 +1,40 @@
-import { Mutex } from 'async-mutex'
-
-interface MutexEntry {
-  mutex: Mutex
+interface InFlightEntry<T = unknown> {
+  promise: Promise<T>
   references: number
 }
 
 export class StampedeGuard {
-  private readonly mutexes = new Map<string, MutexEntry>()
+  private readonly inFlight = new Map<string, InFlightEntry>()
 
   async execute<T>(key: string, task: () => Promise<T>): Promise<T> {
-    const entry = this.getMutexEntry(key)
+    const existing = this.inFlight.get(key) as InFlightEntry<T> | undefined
+    if (existing) {
+      existing.references += 1
+      try {
+        return await existing.promise
+      } finally {
+        this.releaseEntry(key, existing)
+      }
+    }
+
+    const entry: InFlightEntry<T> = {
+      promise: Promise.resolve().then(task),
+      references: 1
+    }
+    this.inFlight.set(key, entry)
 
     try {
-      return await entry.mutex.runExclusive(task)
+      return await entry.promise
     } finally {
-      entry.references -= 1
-      // Re-read from the map to ensure we're operating on the current entry,
-      // not a stale reference that may have been replaced under concurrency.
-      const current = this.mutexes.get(key)
-      if (current === entry && entry.references === 0 && !entry.mutex.isLocked()) {
-        this.mutexes.delete(key)
-      }
+      this.releaseEntry(key, entry)
     }
   }
 
-  private getMutexEntry(key: string): MutexEntry {
-    let entry = this.mutexes.get(key)
-    if (!entry) {
-      entry = { mutex: new Mutex(), references: 0 }
-      this.mutexes.set(key, entry)
+  private releaseEntry(key: string, entry: InFlightEntry): void {
+    entry.references -= 1
+    const current = this.inFlight.get(key)
+    if (current === entry && entry.references === 0) {
+      this.inFlight.delete(key)
     }
-
-    entry.references += 1
-    return entry
   }
 }

--- a/tests/benchmarks/benchmarkUtils.test.ts
+++ b/tests/benchmarks/benchmarkUtils.test.ts
@@ -1,0 +1,92 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { buildPayloadString, normalizeOutageResult } from '../../benchmarks/edge-utils'
+import { buildBenchmarkFixtureCandidates } from '../../benchmarks/paths'
+import { buildConcurrencyLabel, summarizeQueueAmplification } from '../../benchmarks/queue-amplification-utils'
+import { createCountedFetcher, summarizeScenario } from '../../benchmarks/scenario-utils'
+import { buildDelayLabel, summarizeGcMetrics } from '../../benchmarks/slow-redis-utils'
+import { quantile, summarizeDurations } from '../../benchmarks/stats'
+import { buildUserDataset, ensureFixtureFile, findUserById } from '../../benchmarks/workload'
+
+describe('benchmark utils', () => {
+  it('summarizes durations and queue amplification metrics', () => {
+    expect(quantile([12, 4, 30, 18, 6], 0.5)).toBe(12)
+    expect(summarizeDurations('warm-hit', [1, 2, 3, 4, 5])).toEqual({
+      label: 'warm-hit',
+      count: 5,
+      minMs: 1,
+      maxMs: 5,
+      avgMs: 3,
+      medianMs: 3,
+      p95Ms: 5
+    })
+
+    expect(buildConcurrencyLabel(100)).toBe('x100')
+    expect(
+      summarizeQueueAmplification({
+        delayLabel: '100ms',
+        scenario: 'strict-l2-hit',
+        concurrency: 10,
+        totalWallClockMs: 55.5555,
+        requestLatenciesMs: [50.1111, 52.2222, 60.3333, 59.4444, 55.5555],
+        baselineWallClockMs: 10
+      })
+    ).toEqual({
+      label: '100ms-strict-l2-hit-x10',
+      count: 5,
+      minMs: 50.111,
+      maxMs: 60.333,
+      avgMs: 55.533,
+      medianMs: 55.556,
+      p95Ms: 60.333,
+      delayLabel: '100ms',
+      scenario: 'strict-l2-hit',
+      concurrency: 10,
+      concurrencyLabel: 'x10',
+      totalWallClockMs: 55.556,
+      amplificationVsSingle: 5.556,
+      linearityRatio: 0.556
+    })
+  })
+
+  it('tracks fetch counts and workload fixtures deterministically', async () => {
+    const counted = createCountedFetcher(async (key: string) => ({ key }))
+    await expect(counted.run('user:1')).resolves.toEqual({ key: 'user:1' })
+    await expect(counted.run('user:2')).resolves.toEqual({ key: 'user:2' })
+    expect(counted.getCount()).toBe(2)
+    expect(summarizeScenario('stampede', [10, 12, 11], 1).avgMs).toBe(11)
+
+    const users = buildUserDataset(5)
+    expect(users[1]?.email).toBe('user2@example.com')
+    expect(findUserById(users, 4).profile.region).toBe('sa-east')
+
+    const dir = await mkdtemp(join(tmpdir(), 'layercache-bench-fixture-'))
+    const filePath = join(dir, 'users.json')
+    try {
+      await ensureFixtureFile(filePath, 8)
+      const generated = buildBenchmarkFixtureCandidates({ fixturePath: filePath })
+      expect(generated[0]).toBe(filePath)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('formats edge and slow-redis helpers', () => {
+    expect(buildPayloadString(16)).toHaveLength(16)
+    expect(normalizeOutageResult('layered', true, 12.34567)).toEqual({
+      scenario: 'layered',
+      success: true,
+      latencyMs: 12.346,
+      error: null
+    })
+
+    expect(buildDelayLabel(500)).toBe('500ms')
+    expect(summarizeGcMetrics([1.1111, 2.2222, 4.4444])).toEqual({
+      gcCount: 3,
+      gcTotalMs: 7.778,
+      gcMaxMs: 4.444
+    })
+  })
+})

--- a/tests/features/GrowthFeatures.test.ts
+++ b/tests/features/GrowthFeatures.test.ts
@@ -13,6 +13,12 @@ import { MemoryLayer } from '../../src/layers/MemoryLayer'
 import { RedisLayer } from '../../src/layers/RedisLayer'
 import type { CacheLayer } from '../../src/types'
 
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
 class ExplodingLayer implements CacheLayer {
   readonly name = 'exploding'
 
@@ -275,6 +281,27 @@ describe('growth features', () => {
       breakerCache.get('circuit:key', fetcher, { circuitBreaker: { failureThreshold: 1, cooldownMs: 1_000 } })
     ).rejects.toThrow(/Circuit breaker is open/i)
     expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+
+  it('degrades a slow redis layer when command timeouts are enabled', async () => {
+    const memory = new MemoryLayer({ ttl: 60 })
+    await memory.set('user:1', { id: 1 })
+
+    const client = {
+      getBuffer: vi.fn(async () => {
+        await sleep(40)
+        return null
+      }),
+      set: vi.fn(async () => 'OK'),
+      disconnect: vi.fn()
+    } as unknown as Redis
+    const redisLayer = new RedisLayer({ client, commandTimeoutMs: 10 })
+    const cache = new CacheStack([redisLayer, memory], {
+      gracefulDegradation: { retryAfterMs: 1_000 }
+    })
+
+    await expect(cache.get('user:1')).resolves.toEqual({ id: 1 })
+    expect(cache.getStats().layers.find((layer) => layer.name === 'redis')?.degradedUntil).not.toBeNull()
   })
 
   it('supports compressed redis payloads and stats handlers', async () => {

--- a/tests/features/OperationalFeatures.test.ts
+++ b/tests/features/OperationalFeatures.test.ts
@@ -101,6 +101,30 @@ class AlwaysWaitCoordinator implements CacheSingleFlightCoordinator {
   }
 }
 
+class ThrowingCoordinator implements CacheSingleFlightCoordinator {
+  constructor(private readonly error: Error) {}
+
+  async execute<T>(
+    _key: string,
+    _options: CacheSingleFlightExecutionOptions,
+    _worker: () => Promise<T>,
+    _waiter: () => Promise<T>
+  ): Promise<T> {
+    throw this.error
+  }
+}
+
+class ImmediateWorkerCoordinator implements CacheSingleFlightCoordinator {
+  async execute<T>(
+    _key: string,
+    _options: CacheSingleFlightExecutionOptions,
+    worker: () => Promise<T>,
+    _waiter: () => Promise<T>
+  ): Promise<T> {
+    return worker()
+  }
+}
+
 class InMemoryInvalidationBus implements InvalidationBus {
   private readonly handlers = new Set<(message: InvalidationMessage) => Promise<void> | void>()
 
@@ -733,6 +757,65 @@ describe('operational features', () => {
 
     expect(fetcher).toHaveBeenCalledTimes(1)
     expect(cache.getMetrics().singleFlightWaits).toBe(1)
+  })
+
+  it('falls back to local fetching when the single-flight coordinator fails and graceful degradation is enabled', async () => {
+    const fetcher = vi.fn(async () => 'fresh')
+    const cache = new CacheStack([new MemoryLayer({ ttl: 60 })], {
+      gracefulDegradation: true,
+      singleFlightCoordinator: new ThrowingCoordinator(new Error('coordinator offline'))
+    })
+
+    await expect(cache.get('user:1', fetcher)).resolves.toBe('fresh')
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces single-flight coordinator failures when graceful degradation is disabled', async () => {
+    const fetcher = vi.fn(async () => 'fresh')
+    const cache = new CacheStack([new MemoryLayer({ ttl: 60 })], {
+      singleFlightCoordinator: new ThrowingCoordinator(new Error('coordinator offline'))
+    })
+
+    await expect(cache.get('user:1', fetcher)).rejects.toThrow(/coordinator offline/i)
+    expect(fetcher).not.toHaveBeenCalled()
+  })
+
+  it('skips the second cache read on a coordinator-backed cold miss when the worker already owns the fetch', async () => {
+    let reads = 0
+    const layer: CacheLayer = {
+      name: 'single-pass-read',
+      get: async () => {
+        reads += 1
+        return null
+      },
+      set: async () => undefined,
+      delete: async () => undefined,
+      clear: async () => undefined
+    }
+    const fetcher = vi.fn(async () => 'fetched')
+    const cache = new CacheStack([layer], {
+      singleFlightCoordinator: new ImmediateWorkerCoordinator()
+    })
+
+    await expect(cache.get('user:1', fetcher)).resolves.toBe('fetched')
+
+    expect(fetcher).toHaveBeenCalledTimes(1)
+    expect(reads).toBe(1)
+  })
+
+  it('preserves local single-flight collapse for concurrent misses when a coordinator is configured', async () => {
+    const fetcher = vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      return 'fetched'
+    })
+    const cache = new CacheStack([new MemoryLayer({ ttl: 60 })], {
+      singleFlightCoordinator: new ImmediateWorkerCoordinator()
+    })
+
+    const results = await Promise.all(Array.from({ length: 25 }, () => cache.get('user:1', fetcher)))
+
+    expect(results.every((value) => value === 'fetched')).toBe(true)
+    expect(fetcher).toHaveBeenCalledTimes(1)
   })
 
   it('allows duplicate concurrent fetches when stampede prevention is disabled', async () => {

--- a/tests/internal/CacheStackInternals.test.ts
+++ b/tests/internal/CacheStackInternals.test.ts
@@ -587,6 +587,77 @@ describe('CacheStack internals', () => {
     scheduleSpy.mockRestore()
   })
 
+  it('covers tag fallback and sliding-ttl failure handling branches', async () => {
+    const fallbackTagCache = new CacheStack([makeLayer('layer')], {
+      tagIndex: {
+        keysForTag: vi.fn(async () => []),
+        matchPattern: vi.fn(async () => []),
+        track: vi.fn(async () => undefined),
+        touch: vi.fn(async () => undefined),
+        remove: vi.fn(async () => undefined),
+        clear: vi.fn(async () => undefined)
+      } as never
+    })
+
+    await expect(
+      (fallbackTagCache as unknown as { getTagsForKey: (key: string) => Promise<string[]> }).getTagsForKey('user:1')
+    ).resolves.toEqual([])
+
+    const failingSet = vi.fn(async () => {
+      throw new Error('set failed')
+    })
+    const cache = new CacheStack([makeLayer('layer', { set: failingSet })])
+    const handleLayerFailure = vi
+      .spyOn(
+        cache as unknown as {
+          handleLayerFailure: (layer: CacheLayer, operation: string, error: unknown) => Promise<void>
+        },
+        'handleLayerFailure'
+      )
+      .mockResolvedValue(undefined)
+
+    await (
+      cache as unknown as {
+        applyFreshReadPolicies: (
+          key: string,
+          hit: {
+            found: true
+            value: string
+            stored: unknown
+            state: 'fresh'
+            layerIndex: number
+            layerName: string
+          },
+          options: { refreshAhead?: number; slidingTtl?: boolean },
+          fetcher?: () => Promise<string>
+        ) => Promise<void>
+      }
+    ).applyFreshReadPolicies(
+      'user:1',
+      {
+        found: true,
+        value: 'value',
+        stored: createStoredValueEnvelope({
+          kind: 'value',
+          value: 'value',
+          freshTtlSeconds: 30
+        }),
+        state: 'fresh',
+        layerIndex: 0,
+        layerName: 'layer'
+      },
+      { slidingTtl: true }
+    )
+
+    expect(failingSet).toHaveBeenCalled()
+    expect(handleLayerFailure).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'layer' }),
+      'sliding-ttl',
+      expect.any(Error)
+    )
+    handleLayerFailure.mockRestore()
+  })
+
   it('covers circuit recording, error emission, snapshot validation, tag fallback, and export-key branches', async () => {
     const cache = new CacheStack([new MemoryLayer({ ttl: 60 })], {
       circuitBreaker: { failureThreshold: 1, cooldownMs: 50 }

--- a/tests/layers/RedisLayer.test.ts
+++ b/tests/layers/RedisLayer.test.ts
@@ -5,6 +5,12 @@ import { RedisLayer } from '../../src/layers/RedisLayer'
 import { JsonSerializer } from '../../src/serialization/JsonSerializer'
 import { MsgpackSerializer } from '../../src/serialization/MsgpackSerializer'
 
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
 class EchoTransform extends Transform {
   override _transform(
     chunk: Buffer,
@@ -205,6 +211,20 @@ describe('RedisLayer', () => {
 
     const layer = new RedisLayer({ client })
     await expect(layer.ping()).resolves.toBe(false)
+  })
+
+  it('fails slow commands when commandTimeoutMs is configured', async () => {
+    const client = {
+      getBuffer: vi.fn(async () => {
+        await sleep(40)
+        return Buffer.from(JSON.stringify({ ok: true }))
+      }),
+      disconnect: vi.fn()
+    } as unknown as Redis
+
+    const layer = new RedisLayer({ client, commandTimeoutMs: 10 })
+
+    await expect(layer.get('slow')).rejects.toThrow(/timed out after 10ms/i)
   })
 
   it('can clear unprefixed keys when explicitly allowed', async () => {

--- a/tests/layers/RedisLayer.test.ts
+++ b/tests/layers/RedisLayer.test.ts
@@ -227,6 +227,13 @@ describe('RedisLayer', () => {
     await expect(layer.get('slow')).rejects.toThrow(/timed out after 10ms/i)
   })
 
+  it('rejects invalid commandTimeoutMs values', () => {
+    const client = new Redis()
+
+    expect(() => new RedisLayer({ client, commandTimeoutMs: 0 })).toThrow(/positive number/i)
+    expect(() => new RedisLayer({ client, commandTimeoutMs: Number.NaN })).toThrow(/positive number/i)
+  })
+
   it('can clear unprefixed keys when explicitly allowed', async () => {
     const client = new Redis()
     const layer = new RedisLayer({ client, allowUnprefixedClear: true })

--- a/tests/singleflight/RedisSingleFlightCoordinator.test.ts
+++ b/tests/singleflight/RedisSingleFlightCoordinator.test.ts
@@ -9,6 +9,16 @@ async function sleep(ms: number): Promise<void> {
 }
 
 describe('RedisSingleFlightCoordinator', () => {
+  it('rejects invalid commandTimeoutMs values', () => {
+    const client = {
+      set: vi.fn(),
+      eval: vi.fn()
+    } as unknown as Redis
+
+    expect(() => new RedisSingleFlightCoordinator({ client, commandTimeoutMs: 0 })).toThrow(/positive number/i)
+    expect(() => new RedisSingleFlightCoordinator({ client, commandTimeoutMs: Number.NaN })).toThrow(/positive number/i)
+  })
+
   it('times out slow lock acquisition when commandTimeoutMs is configured', async () => {
     const client = {
       set: vi.fn(async () => {

--- a/tests/singleflight/RedisSingleFlightCoordinator.test.ts
+++ b/tests/singleflight/RedisSingleFlightCoordinator.test.ts
@@ -1,0 +1,34 @@
+import type Redis from 'ioredis'
+import { describe, expect, it, vi } from 'vitest'
+import { RedisSingleFlightCoordinator } from '../../src/singleflight/RedisSingleFlightCoordinator'
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+describe('RedisSingleFlightCoordinator', () => {
+  it('times out slow lock acquisition when commandTimeoutMs is configured', async () => {
+    const client = {
+      set: vi.fn(async () => {
+        await sleep(40)
+        return 'OK'
+      }),
+      eval: vi.fn(async () => 1)
+    } as unknown as Redis
+    const coordinator = new RedisSingleFlightCoordinator({
+      client,
+      commandTimeoutMs: 10
+    })
+
+    await expect(
+      coordinator.execute(
+        'user:1',
+        { leaseMs: 1_000, waitTimeoutMs: 100, pollIntervalMs: 10 },
+        async () => 'worker',
+        async () => 'waiter'
+      )
+    ).rejects.toThrow(/timed out after 10ms/i)
+  })
+})

--- a/tests/stampede/StampedeGuard.test.ts
+++ b/tests/stampede/StampedeGuard.test.ts
@@ -33,6 +33,32 @@ describe('Stampede prevention', () => {
       )
     )
 
-    expect((guard as { mutexes: Map<string, unknown> }).mutexes.size).toBe(0)
+    expect((guard as unknown as { inFlight: Map<string, unknown> }).inFlight.size).toBe(0)
+  })
+
+  it('shares the same in-flight promise for concurrent callers', async () => {
+    const guard = new StampedeGuard()
+    let executions = 0
+
+    const [first, second, third] = await Promise.all([
+      guard.execute('shared-key', async () => {
+        executions += 1
+        await new Promise((resolve) => setTimeout(resolve, 5))
+        return 'value'
+      }),
+      guard.execute('shared-key', async () => {
+        executions += 1
+        return 'duplicate'
+      }),
+      guard.execute('shared-key', async () => {
+        executions += 1
+        return 'duplicate'
+      })
+    ])
+
+    expect(first).toBe('value')
+    expect(second).toBe('value')
+    expect(third).toBe('value')
+    expect(executions).toBe(1)
   })
 })


### PR DESCRIPTION
## Summary
- add Redis command timeouts for `RedisLayer` and `RedisSingleFlightCoordinator`, wire coordinator failures into graceful degradation, and fix local single-flight sharing so concurrent misses still collapse correctly
- add a real Redis-backed benchmark harness for direct, HTTP, edge, slow-Redis, queue amplification, and multi-process fan-out scenarios, plus coverage for the new timeout and coordinator behavior
- update README and API/benchmarking docs to document the new benchmark workflow, `commandTimeoutMs`, and large-payload compression guidance

## Test Plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test`
- [x] `npm run bench:direct`
- [x] `npm run bench:http`
- [x] `npm run bench:edge`
- [x] `npm run bench:slow-redis`
- [x] `npm run bench:queue-amplification`
- [x] `npm run bench:multi-process-fanout`

## Notes
- I also regenerated benchmark reports in `/root/cache-test/docs` for the 2026-04-14 run. Those files live outside this repository, so they are not included in this PR.
