### PR TITLE
Harden cache layers and refresh benchmark reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New CLI coverage for `--require-tls`, plus new RedisLayer, DiskLayer, StampedeGuard, and CacheStack stampede-option regression tests.
 
 ### Changed
-- `README.md` now reflects the current validation baseline with **457 passing tests**.
+- `README.md` now reflects the current validation baseline with **463 passing tests**.
 - `README.md` performance docs now include a recent `bench:slow-redis` sample plus the matching `memory-pressure` results.
 - `DiskLayer.maxFiles` now defaults to `50_000`; `Infinity` remains available as an explicit opt-out for bounded file eviction.
 - `StampedeGuard` now supports configurable in-flight limits and entry timeouts, and `CacheStack` now wires those options through its built-in fetch dedupe path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New CLI coverage for `--require-tls`, plus new RedisLayer, DiskLayer, StampedeGuard, and CacheStack stampede-option regression tests.
 
 ### Changed
-- `README.md` now reflects the current validation baseline with **465 passing tests**.
+- `README.md` now reflects the current validation baseline with **467 passing tests**.
 - `README.md` performance docs now include a recent `bench:slow-redis` sample plus the matching `memory-pressure` results.
 - `DiskLayer.maxFiles` now defaults to `50_000`; `Infinity` remains available as an explicit opt-out for bounded file eviction.
 - `StampedeGuard` now supports configurable in-flight limits and entry timeouts, and `CacheStack` now wires those options through its built-in fetch dedupe path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1] — 2026-04-17
+
 ### Added
 - `PayloadProtection` for optional DiskLayer at-rest protection with AES-256-GCM encryption or HMAC-SHA256 signing.
 - `DiskLayer` options `encryptionKey` and `signingKey` for protected on-disk payloads, plus regression coverage for encrypted, signed, tampered, wrong-key, and MessagePack-backed disk entries.
@@ -14,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New CLI coverage for `--require-tls`, plus new RedisLayer, DiskLayer, StampedeGuard, and CacheStack stampede-option regression tests.
 
 ### Changed
+- Version bumped from `1.3.0` to `1.3.1`.
 - `README.md` now reflects the current validation baseline with **467 passing tests**.
 - `README.md` performance docs now include a recent `bench:slow-redis` sample plus the matching `memory-pressure` results.
 - `DiskLayer.maxFiles` now defaults to `50_000`; `Infinity` remains available as an explicit opt-out for bounded file eviction.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `PayloadProtection` for optional DiskLayer at-rest protection with AES-256-GCM encryption or HMAC-SHA256 signing.
+- `DiskLayer` options `encryptionKey` and `signingKey` for protected on-disk payloads, plus regression coverage for encrypted, signed, tampered, wrong-key, and MessagePack-backed disk entries.
+- `CacheStackOptions.stampedeMaxInFlight` and `CacheStackOptions.stampedeEntryTimeoutMs` so stampede-guard limits and per-entry timeouts can be configured from the main `CacheStack` API.
+- New CLI coverage for `--require-tls`, plus new RedisLayer, DiskLayer, StampedeGuard, and CacheStack stampede-option regression tests.
+
+### Changed
+- `README.md` now reflects the current validation baseline with **457 passing tests**.
+- `README.md` performance docs now include a recent `bench:slow-redis` sample plus the matching `memory-pressure` results.
+- `DiskLayer.maxFiles` now defaults to `50_000`; `Infinity` remains available as an explicit opt-out for bounded file eviction.
+- `StampedeGuard` now supports configurable in-flight limits and entry timeouts, and `CacheStack` now wires those options through its built-in fetch dedupe path.
+- Error messages that include cache keys now truncate long keys across `CacheStack`, `CircuitBreakerManager`, `MemcachedLayer`, `RedisLayer`, and `StampedeGuard`.
+
+### Fixed
+- `DiskLayer` now preserves `Buffer` serializer payloads while applying optional payload protection, so MessagePack-backed disk entries continue to round-trip correctly.
+- `RedisLayer` key validation now applies consistently to batch operations (`getMany`, `setMany`, `deleteMany`) as well as single-key operations.
+- `JsonSerializer.deserialize()` now wraps `JSON.parse` failures with a clearer serializer-specific error message.
+- `createInstanceId()` no longer falls back to `Math.random()` and now requires a cryptographic random source.
+- CLI Redis handling now warns on plaintext `redis://` URLs and can reject them outright with `--require-tls`.
+
+### Security
+- Disk-backed cache payloads can now be encrypted or signed at rest, with tampering and wrong-key reads treated as cache misses.
+- Stats endpoint helpers now emit explicit warnings when public access is enabled without authorization callbacks.
+- `RedisLayer` now rejects empty keys, overly long keys, control characters, and surrogate code points even when used directly outside `CacheStack`.
+
 ## [1.3.0] — 2026-04-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New CLI coverage for `--require-tls`, plus new RedisLayer, DiskLayer, StampedeGuard, and CacheStack stampede-option regression tests.
 
 ### Changed
-- `README.md` now reflects the current validation baseline with **463 passing tests**.
+- `README.md` now reflects the current validation baseline with **465 passing tests**.
 - `README.md` performance docs now include a recent `bench:slow-redis` sample plus the matching `memory-pressure` results.
 - `DiskLayer.maxFiles` now defaults to `50_000`; `Infinity` remains available as an explicit opt-out for bounded file eviction.
 - `StampedeGuard` now supports configurable in-flight limits and entry timeouts, and `CacheStack` now wires those options through its built-in fetch dedupe path.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-Apache_2.0-green" alt="license"></a>
   <a href="https://www.typescriptlang.org/"><img src="https://img.shields.io/badge/TypeScript-first-3178C6?logo=typescript&logoColor=white" alt="TypeScript"></a>
   <img src="https://img.shields.io/badge/Node.js-%E2%89%A5_20-339933?logo=nodedotjs&logoColor=white" alt="Node.js >= 20">
-  <img src="https://img.shields.io/badge/tests-463_passing-brightgreen" alt="tests">
+  <img src="https://img.shields.io/badge/tests-465_passing-brightgreen" alt="tests">
   <a href="https://coveralls.io/github/flyingsquirrel0419/layercache?branch=main"><img src="https://coveralls.io/repos/github/flyingsquirrel0419/layercache/badge.svg?branch=main&t=20260410" alt="Coveralls"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-Apache_2.0-green" alt="license"></a>
   <a href="https://www.typescriptlang.org/"><img src="https://img.shields.io/badge/TypeScript-first-3178C6?logo=typescript&logoColor=white" alt="TypeScript"></a>
   <img src="https://img.shields.io/badge/Node.js-%E2%89%A5_20-339933?logo=nodedotjs&logoColor=white" alt="Node.js >= 20">
-  <img src="https://img.shields.io/badge/tests-431_passing-brightgreen" alt="tests">
+  <img src="https://img.shields.io/badge/tests-457_passing-brightgreen" alt="tests">
   <a href="https://coveralls.io/github/flyingsquirrel0419/layercache?branch=main"><img src="https://coveralls.io/repos/github/flyingsquirrel0419/layercache/badge.svg?branch=main&t=20260410" alt="Coveralls"></a>
 </p>
 
@@ -338,6 +338,29 @@ npm run bench:multi-process-fanout
 ```
 
 The benchmark harness defaults to `/root/cache-test/data/users.json` so the in-repo scripts stay aligned with the external reproduction workspace. Set `LAYERCACHE_BENCH_FIXTURE_PATH` if you want to point at a different workload fixture.
+
+Recent `npm run bench:slow-redis` sample:
+
+| Scenario | Result |
+|---|---|
+| 100ms RTT, strict L2 hit | ~100.932 ms |
+| 100ms RTT, strict cold miss | ~404.867 ms |
+| 500ms RTT, graceful L2 hit | ~199.988 ms |
+| 500ms RTT, graceful cold miss | ~201.243 ms |
+| 500ms RTT, strict L2 hit | timed out at 200 ms |
+| Dead Redis, graceful cold miss | ~401.625 ms |
+
+Recent `memory-pressure` sample from the same run:
+
+| Metric | Result |
+|---|---|
+| L1 max size / unique keys | 25 / 180 |
+| Evictions / retained L1 keys | 180 / 25 |
+| Revisit avg / p95 | 1.665 ms / 4.598 ms |
+| Revisit origin fetches | 0 |
+| GC count / total / max | 36 / 74.948 ms / 6.243 ms |
+| Event-loop max lag | 16.72 ms |
+| Heap delta | 10.631 MB |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-Apache_2.0-green" alt="license"></a>
   <a href="https://www.typescriptlang.org/"><img src="https://img.shields.io/badge/TypeScript-first-3178C6?logo=typescript&logoColor=white" alt="TypeScript"></a>
   <img src="https://img.shields.io/badge/Node.js-%E2%89%A5_20-339933?logo=nodedotjs&logoColor=white" alt="Node.js >= 20">
-  <img src="https://img.shields.io/badge/tests-457_passing-brightgreen" alt="tests">
+  <img src="https://img.shields.io/badge/tests-463_passing-brightgreen" alt="tests">
   <a href="https://coveralls.io/github/flyingsquirrel0419/layercache?branch=main"><img src="https://coveralls.io/repos/github/flyingsquirrel0419/layercache/badge.svg?branch=main&t=20260410" alt="Coveralls"></a>
 </p>
 
@@ -326,41 +326,7 @@ const cache = new CacheStack(
 └─────────────────────┴────────┘
 ```
 
-Run benchmarks locally:
-
-```bash
-npm run bench:direct
-npm run bench:edge
-npm run bench:slow-redis
-npm run bench:queue-amplification
-npm run bench:http
-npm run bench:multi-process-fanout
-```
-
-The benchmark harness defaults to `/root/cache-test/data/users.json` so the in-repo scripts stay aligned with the external reproduction workspace. Set `LAYERCACHE_BENCH_FIXTURE_PATH` if you want to point at a different workload fixture.
-
-Recent `npm run bench:slow-redis` sample:
-
-| Scenario | Result |
-|---|---|
-| 100ms RTT, strict L2 hit | ~100.932 ms |
-| 100ms RTT, strict cold miss | ~404.867 ms |
-| 500ms RTT, graceful L2 hit | ~199.988 ms |
-| 500ms RTT, graceful cold miss | ~201.243 ms |
-| 500ms RTT, strict L2 hit | timed out at 200 ms |
-| Dead Redis, graceful cold miss | ~401.625 ms |
-
-Recent `memory-pressure` sample from the same run:
-
-| Metric | Result |
-|---|---|
-| L1 max size / unique keys | 25 / 180 |
-| Evictions / retained L1 keys | 180 / 25 |
-| Revisit avg / p95 | 1.665 ms / 4.598 ms |
-| Revisit origin fetches | 0 |
-| GC count / total / max | 36 / 74.948 ms / 6.243 ms |
-| Event-loop max lag | 16.72 ms |
-| Heap delta | 10.631 MB |
+Benchmark commands, fixtures, and scenario notes live in [docs/benchmarking.md](./docs/benchmarking.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-Apache_2.0-green" alt="license"></a>
   <a href="https://www.typescriptlang.org/"><img src="https://img.shields.io/badge/TypeScript-first-3178C6?logo=typescript&logoColor=white" alt="TypeScript"></a>
   <img src="https://img.shields.io/badge/Node.js-%E2%89%A5_20-339933?logo=nodedotjs&logoColor=white" alt="Node.js >= 20">
-  <img src="https://img.shields.io/badge/tests-465_passing-brightgreen" alt="tests">
+  <img src="https://img.shields.io/badge/tests-467_passing-brightgreen" alt="tests">
   <a href="https://coveralls.io/github/flyingsquirrel0419/layercache?branch=main"><img src="https://coveralls.io/repos/github/flyingsquirrel0419/layercache/badge.svg?branch=main&t=20260410" alt="Coveralls"></a>
 </p>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "layercache",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "layercache",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/nestjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "layercache",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Production-ready multi-layer caching for Node.js. Stack memory + Redis + disk behind one API with stampede prevention, tag invalidation, stale serving, and full observability.",
   "keywords": [
     "cache",

--- a/src/CacheStack.ts
+++ b/src/CacheStack.ts
@@ -144,7 +144,7 @@ export interface CacheStack {
 }
 
 export class CacheStack extends EventEmitter {
-  private readonly stampedeGuard = new StampedeGuard()
+  private readonly stampedeGuard: StampedeGuard
   private readonly metricsCollector = new MetricsCollector()
   private readonly instanceId = createInstanceId()
   private readonly startup: Promise<void>
@@ -183,6 +183,10 @@ export class CacheStack extends EventEmitter {
     const maxProfileEntries = options.maxProfileEntries ?? DEFAULT_MAX_PROFILE_ENTRIES
     this.ttlResolver = new TtlResolver({ maxProfileEntries })
     this.circuitBreakerManager = new CircuitBreakerManager({ maxEntries: maxProfileEntries })
+    this.stampedeGuard = new StampedeGuard({
+      maxInFlight: options.stampedeMaxInFlight,
+      entryTimeoutMs: options.stampedeEntryTimeoutMs
+    })
     this.currentGeneration = options.generation
 
     if (options.publishSetInvalidation !== undefined) {
@@ -517,7 +521,8 @@ export class CacheStack extends EventEmitter {
             }
 
             if (existing.fetch !== entry.fetch || existing.optionsSignature !== optionsSignature) {
-              throw new Error(`mget received conflicting entries for key "${entry.key}".`)
+              const displayKey = entry.key.length > 64 ? `${entry.key.slice(0, 64)}...` : entry.key
+              throw new Error(`mget received conflicting entries for key "${displayKey}".`)
             }
 
             return existing.promise

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ interface ParsedArgs {
   tag?: string
   key?: string
   tagIndexPrefix?: string
+  requireTls?: boolean
 }
 
 export async function main(argv = process.argv.slice(2)): Promise<void> {
@@ -27,6 +28,21 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     process.stderr.write('Error: invalid Redis URL. Expected format: redis://[user:password@]host[:port][/db]\n')
     process.exitCode = 1
     return
+  }
+
+  if (isPlaintextRedisUrl(redisUrl)) {
+    if (args.requireTls) {
+      process.stderr.write(
+        'Error: --require-tls is set but the URL uses redis:// (plaintext). ' +
+          'Use rediss:// for TLS-encrypted connections.\n'
+      )
+      process.exitCode = 1
+      return
+    }
+    process.stderr.write(
+      'Warning: connecting to Redis without TLS (redis://). All data including cached values and credentials ' +
+        'will be transmitted in plaintext. Use rediss:// in production environments, or set --require-tls.\n'
+    )
   }
 
   const redis = new Redis(redisUrl, {
@@ -158,6 +174,8 @@ function parseArgs(argv: string[]): ParsedArgs {
     } else if (token === '--tag-index-prefix') {
       parsed.tagIndexPrefix = value
       index += 1
+    } else if (token === '--require-tls') {
+      parsed.requireTls = true
     }
   }
 
@@ -206,7 +224,8 @@ function printUsage(): void {
       '  --pattern <glob>            Glob pattern to filter keys (default: *)\n' +
       '  --key <key>                 Exact cache key to inspect\n' +
       '  --tag <tag>                 Invalidate by tag name\n' +
-      '  --tag-index-prefix <prefix> Redis key prefix for tag index (default: layercache:tag-index)\n'
+      '  --tag-index-prefix <prefix> Redis key prefix for tag index (default: layercache:tag-index)\n' +
+      '  --require-tls               Reject non-TLS (redis://) connections\n'
   )
 }
 
@@ -235,6 +254,16 @@ function summarizeInspectableValue(value: unknown): unknown {
   }
 
   return value
+}
+
+function isPlaintextRedisUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === 'redis:'
+  } catch {
+    // Bare host:port — no TLS
+    return true
+  }
 }
 
 function maskRedisUrl(url: string): string {

--- a/src/http/createCacheStatsHandler.ts
+++ b/src/http/createCacheStatsHandler.ts
@@ -1,12 +1,24 @@
 import type { CacheStack } from '../CacheStack'
 
 interface CacheStatsHandlerOptions {
+  /**
+   * @deprecated Exposing cache stats without authentication is a security risk.
+   * Provide an `authorize` callback instead. This option will be removed in a
+   * future release.
+   */
   allowPublicAccess?: boolean
   authorize?: (request: unknown) => boolean | Promise<boolean>
   unauthorizedStatusCode?: number
 }
 
 export function createCacheStatsHandler(cache: CacheStack, options: CacheStatsHandlerOptions = {}) {
+  if (options.allowPublicAccess === true) {
+    console.warn(
+      '[layercache] WARNING: Stats endpoint is publicly accessible without authentication. ' +
+        'Set allowPublicAccess: false (or provide an authorize callback) before deploying to production.'
+    )
+  }
+
   return async (
     request: unknown,
     response: {

--- a/src/integrations/fastify.ts
+++ b/src/integrations/fastify.ts
@@ -14,12 +14,24 @@ interface FastifyLikeReply {
 interface FastifyLayercachePluginOptions {
   exposeStatsRoute?: boolean
   statsPath?: string
+  /**
+   * @deprecated Exposing cache stats without authentication is a security risk.
+   * Provide an `authorizeStatsRoute` callback instead. This option will be
+   * removed in a future release.
+   */
   allowPublicStatsRoute?: boolean
   authorizeStatsRoute?: (request: unknown) => boolean | Promise<boolean>
   unauthorizedStatusCode?: number
 }
 
 export function createFastifyLayercachePlugin(cache: CacheStack, options: FastifyLayercachePluginOptions = {}) {
+  if (options.exposeStatsRoute === true && options.allowPublicStatsRoute === true) {
+    console.warn(
+      '[layercache] WARNING: Cache stats route is publicly accessible without authentication. ' +
+        'Set allowPublicStatsRoute: false (or provide an authorizeStatsRoute callback) before deploying to production.'
+    )
+  }
+
   return async (fastify: FastifyLike): Promise<void> => {
     fastify.decorate('cache', cache)
 

--- a/src/internal/CacheKeySerialization.ts
+++ b/src/internal/CacheKeySerialization.ts
@@ -47,13 +47,14 @@ export function createInstanceId(): string {
     return globalThis.crypto.randomUUID()
   }
 
-  const bytes = new Uint8Array(16)
   if (globalThis.crypto?.getRandomValues) {
+    const bytes = new Uint8Array(16)
     globalThis.crypto.getRandomValues(bytes)
-  } else {
-    for (let i = 0; i < bytes.length; i += 1) {
-      bytes[i] = Math.floor(Math.random() * 256)
-    }
+    return `layercache-${Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')}`
   }
-  return `layercache-${Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')}`
+
+  throw new Error(
+    'layercache requires a cryptographic random source. ' +
+      'Neither crypto.randomUUID nor crypto.getRandomValues is available in this runtime.'
+  )
 }

--- a/src/internal/CircuitBreakerManager.ts
+++ b/src/internal/CircuitBreakerManager.ts
@@ -36,7 +36,8 @@ export class CircuitBreakerManager {
 
     const remainingMs = state.openUntil - now
     const remainingSecs = Math.ceil(remainingMs / 1_000)
-    throw new Error(`Circuit breaker is open for key "${key}" (resets in ${remainingSecs}s).`)
+    const displayKey = key.length > 64 ? `${key.slice(0, 64)}...` : key
+    throw new Error(`Circuit breaker is open for key "${displayKey}" (resets in ${remainingSecs}s).`)
   }
 
   recordFailure(key: string, options: CacheCircuitBreakerOptions | undefined): void {

--- a/src/internal/PayloadProtection.ts
+++ b/src/internal/PayloadProtection.ts
@@ -1,0 +1,180 @@
+import { createCipheriv, createDecipheriv, createHash, createHmac, randomBytes, timingSafeEqual } from 'node:crypto'
+
+const MAGIC_ENCRYPTED = Buffer.from('LCP1:')
+const MAGIC_SIGNED = Buffer.from('LCS1:')
+const ALGORITHM = 'aes-256-gcm'
+const IV_LENGTH = 12
+const AUTH_TAG_LENGTH = 16
+const HMAC_LENGTH = 32
+
+export interface PayloadProtectionOptions {
+  /**
+   * Key used to encrypt cached data at rest (AES-256-GCM).
+   * Accepts a string (UTF-8 encoded) or a Buffer. The raw key material is
+   * hashed with SHA-256 to produce the actual cipher key.
+   */
+  encryptionKey?: string | Buffer
+  /**
+   * Key used to sign cached data for integrity verification (HMAC-SHA256).
+   * Accepts a string (UTF-8 encoded) or a Buffer. The raw key material is
+   * hashed with SHA-256 to produce the actual HMAC key.
+   *
+   * Ignored when `encryptionKey` is also provided — AES-GCM already provides
+   * integrity via its authentication tag.
+   */
+  signingKey?: string | Buffer
+}
+
+/**
+ * Encrypts and/or signs byte payloads to protect cache data at rest.
+ *
+ * - When only `encryptionKey` is set: payloads are encrypted with AES-256-GCM
+ *   (which also provides authenticated encryption / integrity).
+ * - When only `signingKey` is set: payloads are signed with HMAC-SHA256.
+ * - When both are set: `encryptionKey` takes precedence (GCM auth tag
+ *   covers integrity).
+ * - When neither is set: payloads pass through unchanged.
+ *
+ * The binary format uses a short magic header so that readers can distinguish
+ * protected from legacy plaintext payloads without external metadata:
+ *
+ * - Encrypted: `LCP1:` (5 bytes) ‖ IV (12) ‖ authTag (16) ‖ ciphertext
+ * - Signed:    `LCS1:` (4 bytes) ‖ HMAC (32) ‖ plaintext
+ */
+export class PayloadProtection {
+  private readonly encryptionKey: Buffer | undefined
+  private readonly signingKey: Buffer | undefined
+
+  constructor(options: PayloadProtectionOptions) {
+    if (options.encryptionKey) {
+      const raw = Buffer.isBuffer(options.encryptionKey)
+        ? options.encryptionKey
+        : Buffer.from(options.encryptionKey, 'utf8')
+      this.encryptionKey = createHash('sha256').update(raw).digest()
+    }
+
+    if (options.signingKey && !options.encryptionKey) {
+      const raw = Buffer.isBuffer(options.signingKey) ? options.signingKey : Buffer.from(options.signingKey, 'utf8')
+      this.signingKey = createHash('sha256').update(raw).digest()
+    }
+  }
+
+  /** Returns `true` when any protection (encryption or signing) is configured. */
+  get isEnabled(): boolean {
+    return this.encryptionKey !== undefined || this.signingKey !== undefined
+  }
+
+  /**
+   * Applies the configured protection (encryption or signing) to a payload.
+   * Returns the input unchanged when no protection is configured.
+   */
+  protect(payload: Buffer): Buffer {
+    if (this.encryptionKey) {
+      return this.encrypt(payload, this.encryptionKey)
+    }
+    if (this.signingKey) {
+      return this.sign(payload, this.signingKey)
+    }
+    return payload
+  }
+
+  /**
+   * Removes the protection layer from a payload.
+   *
+   * - Protected payloads are decrypted/verified using the configured keys.
+   * - Legacy unprotected payloads pass through unchanged when **no** protection
+   *   is configured.
+   * - If protection **is** configured but the payload is not protected, the
+   *   payload is treated as a legacy entry. Callers can handle this case by
+   *   checking `isEnabled` separately.
+   */
+  unprotect(payload: Buffer): Buffer {
+    if (this.startsWith(payload, MAGIC_ENCRYPTED)) {
+      if (!this.encryptionKey) {
+        throw new PayloadProtectionError('Encrypted payload but no encryptionKey configured.')
+      }
+      return this.decrypt(payload, this.encryptionKey)
+    }
+
+    if (this.startsWith(payload, MAGIC_SIGNED)) {
+      if (!this.signingKey) {
+        throw new PayloadProtectionError('Signed payload but no signingKey configured.')
+      }
+      return this.verify(payload, this.signingKey)
+    }
+
+    return payload
+  }
+
+  // ── Encryption (AES-256-GCM) ──────────────────────────────────────────
+
+  private encrypt(plaintext: Buffer, key: Buffer): Buffer {
+    const iv = randomBytes(IV_LENGTH)
+    const cipher = createCipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH })
+    const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()])
+    const authTag = cipher.getAuthTag()
+    return Buffer.concat([MAGIC_ENCRYPTED, iv, authTag, encrypted])
+  }
+
+  private decrypt(payload: Buffer, key: Buffer): Buffer {
+    const headerEnd = MAGIC_ENCRYPTED.length
+    const iv = payload.subarray(headerEnd, headerEnd + IV_LENGTH)
+    const authTag = payload.subarray(headerEnd + IV_LENGTH, headerEnd + IV_LENGTH + AUTH_TAG_LENGTH)
+    const ciphertext = payload.subarray(headerEnd + IV_LENGTH + AUTH_TAG_LENGTH)
+
+    try {
+      const decipher = createDecipheriv(ALGORITHM, key, iv, {
+        authTagLength: AUTH_TAG_LENGTH
+      })
+      decipher.setAuthTag(authTag)
+      return Buffer.concat([decipher.update(ciphertext), decipher.final()])
+    } catch {
+      throw new PayloadProtectionError(
+        'Decryption failed. The data may have been tampered with or the encryptionKey is incorrect.'
+      )
+    }
+  }
+
+  // ── Signing (HMAC-SHA256) ─────────────────────────────────────────────
+
+  private sign(payload: Buffer, key: Buffer): Buffer {
+    const hmac = createHmac('sha256', key).update(payload).digest()
+    return Buffer.concat([MAGIC_SIGNED, hmac, payload])
+  }
+
+  private verify(payload: Buffer, key: Buffer): Buffer {
+    const headerEnd = MAGIC_SIGNED.length
+    const receivedHmac = payload.subarray(headerEnd, headerEnd + HMAC_LENGTH)
+    const data = payload.subarray(headerEnd + HMAC_LENGTH)
+    const expectedHmac = createHmac('sha256', key).update(data).digest()
+
+    if (receivedHmac.length !== HMAC_LENGTH || !timingSafeEqual(receivedHmac, expectedHmac)) {
+      throw new PayloadProtectionError(
+        'HMAC verification failed. The data may have been tampered with or the signingKey is incorrect.'
+      )
+    }
+
+    return data
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────
+
+  private startsWith(buffer: Buffer, prefix: Buffer): boolean {
+    if (buffer.length < prefix.length) {
+      return false
+    }
+    return buffer.subarray(0, prefix.length).equals(prefix)
+  }
+}
+
+/**
+ * Error thrown when payload protection operations (encrypt/decrypt/sign/verify) fail.
+ * Extending `Error` rather than throwing plain strings ensures callers can use
+ * `instanceof` checks to distinguish protection errors from other failures.
+ */
+export class PayloadProtectionError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'PayloadProtectionError'
+  }
+}

--- a/src/layers/DiskLayer.ts
+++ b/src/layers/DiskLayer.ts
@@ -1,6 +1,7 @@
 import { createHash, randomBytes } from 'node:crypto'
 import { promises as fs } from 'node:fs'
 import { join, resolve } from 'node:path'
+import { PayloadProtection, type PayloadProtectionOptions } from '../internal/PayloadProtection'
 import { unwrapStoredValue } from '../internal/StoredValue'
 import { JsonSerializer } from '../serialization/JsonSerializer'
 import type { CacheLayer, CacheLayerSetManyEntry, CacheSerializer } from '../types'
@@ -13,7 +14,8 @@ interface DiskLayerOptions {
   /**
    * Maximum number of cache files to store on disk. When exceeded, the oldest
    * entries (by file mtime) are evicted to keep the directory bounded.
-   * Defaults to unlimited.
+   * Defaults to 50 000. Set to `Infinity` to disable the limit (not recommended
+   * in production — unbounded growth will eventually exhaust disk space).
    */
   maxFiles?: number
   /**
@@ -22,6 +24,19 @@ interface DiskLayerOptions {
    * Set to `false` to disable the limit.
    */
   maxEntryBytes?: number | false
+  /**
+   * Encrypt cached data at rest using AES-256-GCM. Accepts a string or Buffer.
+   * The key material is hashed with SHA-256 to derive the actual cipher key.
+   * Encryption also provides authenticated integrity — a separate signingKey
+   * is unnecessary when encryption is enabled.
+   */
+  encryptionKey?: string | Buffer
+  /**
+   * Sign cached data at rest using HMAC-SHA256 for integrity verification.
+   * Accepts a string or Buffer. Ignored when `encryptionKey` is also provided
+   * (AES-GCM already provides integrity).
+   */
+  signingKey?: string | Buffer
 }
 
 interface DiskEntry {
@@ -53,6 +68,7 @@ export class DiskLayer implements CacheLayer {
   private readonly serializer: CacheSerializer
   private readonly maxFiles: number | undefined
   private readonly maxEntryBytes: number | false
+  private readonly protection: PayloadProtection
   private writeQueue = Promise.resolve()
 
   constructor(options: DiskLayerOptions) {
@@ -62,6 +78,10 @@ export class DiskLayer implements CacheLayer {
     this.serializer = options.serializer ?? new JsonSerializer()
     this.maxFiles = this.normalizeMaxFiles(options.maxFiles)
     this.maxEntryBytes = this.normalizeMaxEntryBytes(options.maxEntryBytes)
+    this.protection = new PayloadProtection({
+      encryptionKey: options.encryptionKey,
+      signingKey: options.signingKey
+    })
   }
 
   async get<T>(key: string): Promise<T | null> {
@@ -100,10 +120,12 @@ export class DiskLayer implements CacheLayer {
         expiresAt: ttl && ttl > 0 ? Date.now() + ttl * 1_000 : null
       }
       const payload = this.serializer.serialize(entry)
+      const raw = Buffer.isBuffer(payload) ? payload : Buffer.from(payload as string, 'utf8')
+      const protectedPayload = this.protection.protect(raw)
       const targetPath = this.keyToPath(key)
       const tempPath = `${targetPath}.${process.pid}.${Date.now()}.${randomBytes(8).toString('hex')}.tmp`
       try {
-        await fs.writeFile(tempPath, payload)
+        await fs.writeFile(tempPath, protectedPayload)
         await fs.rename(tempPath, targetPath)
       } catch (error) {
         await this.safeDelete(tempPath)
@@ -237,11 +259,15 @@ export class DiskLayer implements CacheLayer {
 
   private normalizeMaxFiles(maxFiles: number | undefined): number | undefined {
     if (maxFiles === undefined) {
+      return 50_000
+    }
+
+    if (maxFiles === Number.POSITIVE_INFINITY) {
       return undefined
     }
 
     if (!Number.isInteger(maxFiles) || maxFiles <= 0) {
-      throw new Error('DiskLayer.maxFiles must be a positive integer.')
+      throw new Error('DiskLayer.maxFiles must be a positive integer or Infinity.')
     }
 
     return maxFiles
@@ -376,7 +402,8 @@ export class DiskLayer implements CacheLayer {
   }
 
   private deserializeEntry(raw: Buffer): DiskEntry {
-    const entry = this.serializer.deserialize<unknown>(raw)
+    const unprotected = this.protection.unprotect(raw)
+    const entry = this.serializer.deserialize<unknown>(unprotected)
     if (!isDiskEntry(entry)) {
       throw new Error('Invalid disk cache entry.')
     }

--- a/src/layers/MemcachedLayer.ts
+++ b/src/layers/MemcachedLayer.ts
@@ -119,7 +119,10 @@ export class MemcachedLayer implements CacheLayer {
   private validateKey(key: string): void {
     const fullKey = this.withPrefix(key)
     if (Buffer.byteLength(fullKey, 'utf8') > 250) {
-      throw new Error(`MemcachedLayer: key exceeds 250-byte Memcached limit: "${fullKey.slice(0, 60)}..."`)
+      const displayKey = fullKey.slice(0, 64)
+      throw new Error(
+        `MemcachedLayer: key exceeds 250-byte Memcached limit: "${displayKey}${fullKey.length > 64 ? '...' : ''}"`
+      )
     }
     if (/[\s\x00-\x1f\x7f]/.test(fullKey)) {
       throw new Error(

--- a/src/layers/RedisLayer.ts
+++ b/src/layers/RedisLayer.ts
@@ -75,7 +75,10 @@ export class RedisLayer implements CacheLayer {
   }
 
   async getEntry<T = unknown>(key: string): Promise<T | null> {
-    const payload = await this.runCommand(`get("${key}")`, () => this.client.getBuffer(this.withPrefix(key)))
+    this.validateKey(key)
+    const payload = await this.runCommand(`get(${this.displayKey(key)})`, () =>
+      this.client.getBuffer(this.withPrefix(key))
+    )
     if (payload === null) {
       return null
     }
@@ -86,6 +89,10 @@ export class RedisLayer implements CacheLayer {
   async getMany<T>(keys: string[]): Promise<Array<T | null>> {
     if (keys.length === 0) {
       return []
+    }
+
+    for (const key of keys) {
+      this.validateKey(key)
     }
 
     const pipeline = this.client.pipeline()
@@ -115,6 +122,10 @@ export class RedisLayer implements CacheLayer {
       return
     }
 
+    for (const entry of entries) {
+      this.validateKey(entry.key)
+    }
+
     const pipeline = this.client.pipeline()
     for (const entry of entries) {
       const serialized = this.primarySerializer().serialize(entry.value)
@@ -131,25 +142,32 @@ export class RedisLayer implements CacheLayer {
   }
 
   async set(key: string, value: unknown, ttl = this.defaultTtl): Promise<void> {
+    this.validateKey(key)
     const serialized = this.primarySerializer().serialize(value)
     const payload = await this.encodePayload(serialized)
     const normalizedKey = this.withPrefix(key)
 
     if (ttl && ttl > 0) {
-      await this.runCommand(`set("${key}")`, () => this.client.set(normalizedKey, payload as never, 'EX', ttl))
+      await this.runCommand(`set(${this.displayKey(key)})`, () =>
+        this.client.set(normalizedKey, payload as never, 'EX', ttl)
+      )
       return
     }
 
-    await this.runCommand(`set("${key}")`, () => this.client.set(normalizedKey, payload as never))
+    await this.runCommand(`set(${this.displayKey(key)})`, () => this.client.set(normalizedKey, payload as never))
   }
 
   async delete(key: string): Promise<void> {
-    await this.runCommand(`delete("${key}")`, () => this.client.del(this.withPrefix(key)))
+    this.validateKey(key)
+    await this.runCommand(`delete(${this.displayKey(key)})`, () => this.client.del(this.withPrefix(key)))
   }
 
   async deleteMany(keys: string[]): Promise<void> {
     if (keys.length === 0) {
       return
+    }
+    for (const key of keys) {
+      this.validateKey(key)
     }
     await this.runCommand(`deleteMany(${keys.length})`, () =>
       this.client.del(...keys.map((key) => this.withPrefix(key)))
@@ -157,12 +175,14 @@ export class RedisLayer implements CacheLayer {
   }
 
   async has(key: string): Promise<boolean> {
-    const exists = await this.runCommand(`has("${key}")`, () => this.client.exists(this.withPrefix(key)))
+    this.validateKey(key)
+    const exists = await this.runCommand(`has(${this.displayKey(key)})`, () => this.client.exists(this.withPrefix(key)))
     return exists > 0
   }
 
   async ttl(key: string): Promise<number | null> {
-    const remaining = await this.runCommand(`ttl("${key}")`, () => this.client.ttl(this.withPrefix(key)))
+    this.validateKey(key)
+    const remaining = await this.runCommand(`ttl(${this.displayKey(key)})`, () => this.client.ttl(this.withPrefix(key)))
     // -2 = key does not exist, -1 = key exists but no TTL
     if (remaining < 0) {
       return null
@@ -280,6 +300,28 @@ export class RedisLayer implements CacheLayer {
     return `${this.prefix}${key}`
   }
 
+  private validateKey(key: string): void {
+    if (key.length === 0) {
+      throw new Error('RedisLayer: key must not be empty.')
+    }
+
+    if (key.length > 1_024) {
+      throw new Error(`RedisLayer: key length must be at most 1 024 characters (got ${key.length}).`)
+    }
+
+    if (/[\u0000-\u001F\u007F]/.test(key)) {
+      throw new Error('RedisLayer: key contains unsupported control characters.')
+    }
+
+    if (/[\uD800-\uDFFF]/.test(key)) {
+      throw new Error('RedisLayer: key contains unsupported surrogate code points.')
+    }
+  }
+
+  private displayKey(key: string): string {
+    return key.length > 64 ? `${key.slice(0, 64)}...` : key
+  }
+
   private async deserializeOrDelete<T>(key: string, payload: string | Buffer): Promise<T | null> {
     let decodedPayload: string | Buffer
     try {
@@ -307,26 +349,31 @@ export class RedisLayer implements CacheLayer {
 
   private async deleteCorruptedKey(key: string): Promise<void> {
     try {
-      await this.runCommand(`deleteCorrupted("${key}")`, () => this.client.del(this.withPrefix(key)))
+      await this.runCommand(`deleteCorrupted(${this.displayKey(key)})`, () => this.client.del(this.withPrefix(key)))
     } catch (deleteError) {
       // Log but don't throw — the original deserialization failure is the primary issue.
       // The corrupted key will be retried on next access.
-      console.warn(`[layercache] RedisLayer: failed to delete corrupted key "${key}"`, deleteError)
+      const displayKey = key.length > 64 ? `${key.slice(0, 64)}...` : key
+      console.warn(`[layercache] RedisLayer: failed to delete corrupted key "${displayKey}"`, deleteError)
     }
   }
 
   private async rewriteWithPrimarySerializer(key: string, value: unknown): Promise<void> {
     const serialized = this.primarySerializer().serialize(value)
     const payload = await this.encodePayload(serialized)
-    const ttl = await this.runCommand(`rewrite-ttl("${key}")`, () => this.client.ttl(this.withPrefix(key)))
+    const ttl = await this.runCommand(`rewrite-ttl(${this.displayKey(key)})`, () =>
+      this.client.ttl(this.withPrefix(key))
+    )
     if (ttl > 0) {
-      await this.runCommand(`rewrite-set("${key}")`, () =>
+      await this.runCommand(`rewrite-set(${this.displayKey(key)})`, () =>
         this.client.set(this.withPrefix(key), payload as never, 'EX', ttl)
       )
       return
     }
 
-    await this.runCommand(`rewrite-set("${key}")`, () => this.client.set(this.withPrefix(key), payload as never))
+    await this.runCommand(`rewrite-set(${this.displayKey(key)})`, () =>
+      this.client.set(this.withPrefix(key), payload as never)
+    )
   }
 
   private primarySerializer(): CacheSerializer {

--- a/src/serialization/JsonSerializer.ts
+++ b/src/serialization/JsonSerializer.ts
@@ -8,7 +8,14 @@ export class JsonSerializer implements CacheSerializer {
 
   deserialize<T>(payload: string | Buffer): T {
     const normalized = Buffer.isBuffer(payload) ? payload.toString('utf8') : payload
-    return sanitizeStructuredData(JSON.parse(normalized), {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(normalized)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      throw new Error(`JsonSerializer: failed to parse JSON payload: ${message}`)
+    }
+    return sanitizeStructuredData(parsed, {
       label: 'JSON payload',
       maxDepth: 200,
       maxNodes: 10_000

--- a/src/stampede/StampedeGuard.ts
+++ b/src/stampede/StampedeGuard.ts
@@ -3,8 +3,30 @@ interface InFlightEntry<T = unknown> {
   references: number
 }
 
+interface StampedeGuardOptions {
+  /**
+   * Maximum number of concurrent in-flight keys. When exceeded, new `execute`
+   * calls for keys that are not already in-flight will throw immediately.
+   * Defaults to 10 000.
+   */
+  maxInFlight?: number
+  /**
+   * Maximum milliseconds to wait for a single in-flight task before rejecting
+   * with a timeout error. When a timeout fires the entry is released so
+   * subsequent callers can retry. Defaults to no timeout.
+   */
+  entryTimeoutMs?: number
+}
+
 export class StampedeGuard {
   private readonly inFlight = new Map<string, InFlightEntry>()
+  private readonly maxInFlight: number
+  private readonly entryTimeoutMs: number | undefined
+
+  constructor(options: StampedeGuardOptions = {}) {
+    this.maxInFlight = options.maxInFlight ?? 10_000
+    this.entryTimeoutMs = options.entryTimeoutMs
+  }
 
   async execute<T>(key: string, task: () => Promise<T>): Promise<T> {
     const existing = this.inFlight.get(key) as InFlightEntry<T> | undefined
@@ -17,8 +39,17 @@ export class StampedeGuard {
       }
     }
 
+    if (this.inFlight.size >= this.maxInFlight) {
+      throw new Error(
+        `StampedeGuard: in-flight limit of ${this.maxInFlight} exceeded. Rejecting new key to prevent memory exhaustion.`
+      )
+    }
+
+    const taskPromise = Promise.resolve().then(task)
+    const guardedPromise = this.entryTimeoutMs ? this.withTimeout(key, taskPromise, this.entryTimeoutMs) : taskPromise
+
     const entry: InFlightEntry<T> = {
-      promise: Promise.resolve().then(task),
+      promise: guardedPromise,
       references: 1
     }
     this.inFlight.set(key, entry)
@@ -28,6 +59,29 @@ export class StampedeGuard {
     } finally {
       this.releaseEntry(key, entry)
     }
+  }
+
+  private withTimeout<T>(key: string, promise: Promise<T>, timeoutMs: number): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(
+          new Error(
+            `StampedeGuard: task for key "${key.slice(0, 64)}${key.length > 64 ? '...' : ''}" timed out after ${timeoutMs}ms.`
+          )
+        )
+      }, timeoutMs)
+
+      promise.then(
+        (value) => {
+          clearTimeout(timer)
+          resolve(value)
+        },
+        (error: unknown) => {
+          clearTimeout(timer)
+          reject(error)
+        }
+      )
+    })
   }
 
   private releaseEntry(key: string, entry: InFlightEntry): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -213,6 +213,8 @@ export interface CacheStackOptions {
   logger?: CacheLogger | boolean
   metrics?: boolean
   stampedePrevention?: boolean
+  stampedeMaxInFlight?: number
+  stampedeEntryTimeoutMs?: number
   invalidationBus?: InvalidationBus
   tagIndex?: CacheTagIndex
   generation?: number

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -123,4 +123,25 @@ describe('CLI — main()', () => {
     expect(stderrOutput.join('')).toContain('redis://default:***@localhost:6379')
     expect(stderrOutput.join('')).not.toContain('secret')
   })
+
+  it('rejects plaintext redis:// when --require-tls is set', async () => {
+    const { main } = await import('../src/cli')
+    await main(['stats', '--redis', 'redis://localhost:6379', '--require-tls'])
+    expect(process.exitCode).toBe(1)
+    expect(stderrOutput.join('')).toContain('--require-tls')
+  })
+
+  it('allows rediss:// when --require-tls is set', async () => {
+    const { main } = await import('../src/cli')
+    await main(['stats', '--redis', 'rediss://localhost:6379', '--require-tls'])
+    expect(process.exitCode).toBeUndefined()
+    expect(stdoutOutput.join('')).toContain('totalKeys')
+  })
+
+  it('warns about plaintext redis:// without --require-tls', async () => {
+    const { main } = await import('../src/cli')
+    await main(['stats', '--redis', 'redis://localhost:6379'])
+    expect(stderrOutput.join('')).toContain('Warning')
+    expect(stderrOutput.join('')).toContain('redis://')
+  })
 })

--- a/tests/features/StampedeOptions.test.ts
+++ b/tests/features/StampedeOptions.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { CacheStack } from '../../src/CacheStack'
+import { MemoryLayer } from '../../src/layers/MemoryLayer'
+
+describe('stampede options passthrough', () => {
+  it('applies stampedeMaxInFlight to CacheStack fetches', async () => {
+    const cache = new CacheStack([new MemoryLayer({ ttl: 60 })], {
+      stampedeMaxInFlight: 1
+    })
+
+    let release!: () => void
+    const first = cache.get('user:1', async () => {
+      await new Promise<void>((resolve) => {
+        release = resolve
+      })
+      return { id: 1 }
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    await expect(
+      cache.get('user:2', async () => ({
+        id: 2
+      }))
+    ).rejects.toThrow(/in-flight limit/)
+
+    release()
+    await expect(first).resolves.toEqual({ id: 1 })
+  })
+
+  it('applies stampedeEntryTimeoutMs to CacheStack fetches and allows retry after timeout', async () => {
+    const cache = new CacheStack([new MemoryLayer({ ttl: 60 })], {
+      stampedeEntryTimeoutMs: 20
+    })
+
+    await expect(
+      cache.get('slow:key', async () => {
+        await new Promise((resolve) => setTimeout(resolve, 200))
+        return 'late'
+      })
+    ).rejects.toThrow(/timed out/)
+
+    await expect(cache.get('slow:key', async () => 'fresh')).resolves.toBe('fresh')
+  })
+})

--- a/tests/internal/CacheKeySerialization.test.ts
+++ b/tests/internal/CacheKeySerialization.test.ts
@@ -34,9 +34,8 @@ describe('CacheKeySerialization', () => {
     expect(serializeOptions({ tags: ['users'], shouldCache: undefined })).toContain('"tags":["users"]')
   })
 
-  it('creates instance ids using randomUUID, getRandomValues, or Math.random fallbacks', () => {
+  it('creates instance ids using randomUUID or getRandomValues, and throws when neither is available', () => {
     const originalCrypto = globalThis.crypto
-    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5)
 
     try {
       vi.stubGlobal('crypto', {
@@ -53,9 +52,8 @@ describe('CacheKeySerialization', () => {
       expect(createInstanceId()).toBe(`layercache-${'ab'.repeat(16)}`)
 
       vi.stubGlobal('crypto', undefined)
-      expect(createInstanceId()).toBe(`layercache-${'80'.repeat(16)}`)
+      expect(() => createInstanceId()).toThrow('layercache requires a cryptographic random source.')
     } finally {
-      randomSpy.mockRestore()
       vi.unstubAllGlobals()
       vi.stubGlobal('crypto', originalCrypto)
     }

--- a/tests/internal/PayloadProtection.test.ts
+++ b/tests/internal/PayloadProtection.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { PayloadProtection, PayloadProtectionError } from '../../src/internal/PayloadProtection'
+
+describe('PayloadProtection', () => {
+  it('reports whether protection is enabled', () => {
+    expect(new PayloadProtection({}).isEnabled).toBe(false)
+    expect(new PayloadProtection({ encryptionKey: 'secret' }).isEnabled).toBe(true)
+    expect(new PayloadProtection({ signingKey: 'secret' }).isEnabled).toBe(true)
+  })
+
+  it('returns short unprotected payloads unchanged', () => {
+    const protection = new PayloadProtection({})
+    const payload = Buffer.from('LCP')
+    expect(protection.unprotect(payload)).toEqual(payload)
+  })
+
+  it('throws when decrypting an encrypted payload without an encryption key', () => {
+    const writer = new PayloadProtection({ encryptionKey: 'enc-key' })
+    const reader = new PayloadProtection({})
+
+    const payload = writer.protect(Buffer.from('secret'))
+
+    expect(() => reader.unprotect(payload)).toThrow(PayloadProtectionError)
+    expect(() => reader.unprotect(payload)).toThrow(/no encryptionKey configured/)
+  })
+
+  it('throws when verifying a signed payload without a signing key', () => {
+    const writer = new PayloadProtection({ signingKey: 'sig-key' })
+    const reader = new PayloadProtection({})
+
+    const payload = writer.protect(Buffer.from('signed'))
+
+    expect(() => reader.unprotect(payload)).toThrow(PayloadProtectionError)
+    expect(() => reader.unprotect(payload)).toThrow(/no signingKey configured/)
+  })
+
+  it('prefers encryption when both encryptionKey and signingKey are provided', () => {
+    const protection = new PayloadProtection({
+      encryptionKey: 'enc-key',
+      signingKey: 'sig-key'
+    })
+
+    const payload = protection.protect(Buffer.from('secret'))
+
+    expect(payload.subarray(0, 5).toString()).toBe('LCP1:')
+  })
+})

--- a/tests/internal/PayloadProtection.test.ts
+++ b/tests/internal/PayloadProtection.test.ts
@@ -44,4 +44,19 @@ describe('PayloadProtection', () => {
 
     expect(payload.subarray(0, 5).toString()).toBe('LCP1:')
   })
+
+  it('accepts Buffer key material for encryption and signing', () => {
+    const encrypted = new PayloadProtection({
+      encryptionKey: Buffer.from('enc-key')
+    })
+    const signed = new PayloadProtection({
+      signingKey: Buffer.from('sig-key')
+    })
+
+    const encryptedPayload = encrypted.protect(Buffer.from('secret'))
+    const signedPayload = signed.protect(Buffer.from('signed'))
+
+    expect(encrypted.unprotect(encryptedPayload).toString()).toBe('secret')
+    expect(signed.unprotect(signedPayload).toString()).toBe('signed')
+  })
 })

--- a/tests/layers/DiskLayer.test.ts
+++ b/tests/layers/DiskLayer.test.ts
@@ -299,6 +299,32 @@ describe('DiskLayer', () => {
     await expect(fs.stat(invalidFile)).rejects.toThrow()
   })
 
+  it('treats missing directories as empty scans', async () => {
+    const missingDir = join(dir, 'missing')
+    const missingLayer = new DiskLayer({ directory: missingDir, ttl: 60 })
+
+    const visited: string[] = []
+    await expect(missingLayer.keys()).resolves.toEqual([])
+    await expect(missingLayer.size()).resolves.toBe(0)
+    await expect(
+      missingLayer.forEachKey(async (key) => {
+        visited.push(key)
+      })
+    ).resolves.toBeUndefined()
+    expect(visited).toEqual([])
+  })
+
+  it('treats primitive disk payloads as invalid entries and removes them', async () => {
+    await fs.mkdir(dir, { recursive: true })
+    const { createHash } = await import('node:crypto')
+    const hash = createHash('sha256').update('primitive-bad').digest('hex')
+    const filePath = join(dir, `${hash}.lc`)
+    await fs.writeFile(filePath, JSON.stringify('oops'))
+
+    await expect(layer.get('primitive-bad')).resolves.toBeNull()
+    await expect(fs.stat(filePath)).rejects.toThrow()
+  })
+
   describe('encryption (encryptionKey)', () => {
     it('round-trips values with AES-256-GCM encryption', async () => {
       const encrypted = new DiskLayer({ directory: dir, ttl: 60, encryptionKey: 'test-secret-key' })

--- a/tests/layers/DiskLayer.test.ts
+++ b/tests/layers/DiskLayer.test.ts
@@ -3,10 +3,30 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { DiskLayer } from '../../src/layers/DiskLayer'
+import { MsgpackSerializer } from '../../src/serialization/MsgpackSerializer'
 
 describe('DiskLayer', () => {
   let dir: string
   let layer: DiskLayer
+
+  async function readLcFile(directory: string): Promise<Buffer> {
+    const files = await fs.readdir(directory)
+    const lcFile = files.find((f) => f.endsWith('.lc'))
+    if (!lcFile) throw new Error('No .lc file found in directory')
+    return fs.readFile(join(directory, lcFile))
+  }
+
+  async function tamperLastByte(directory: string): Promise<void> {
+    const files = await fs.readdir(directory)
+    const lcFile = files.find((f) => f.endsWith('.lc'))
+    if (!lcFile) throw new Error('No .lc file found in directory')
+    const filePath = join(directory, lcFile)
+    const raw = await fs.readFile(filePath)
+    const last = raw.length - 1
+    const byte = raw[last] ?? 0
+    raw.set([byte ^ 0xff], last)
+    await fs.writeFile(filePath, raw)
+  }
 
   beforeEach(async () => {
     dir = join(tmpdir(), `layercache-disk-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
@@ -277,5 +297,106 @@ describe('DiskLayer', () => {
 
     await expect(layer.keys()).resolves.toEqual([])
     await expect(fs.stat(invalidFile)).rejects.toThrow()
+  })
+
+  describe('encryption (encryptionKey)', () => {
+    it('round-trips values with AES-256-GCM encryption', async () => {
+      const encrypted = new DiskLayer({ directory: dir, ttl: 60, encryptionKey: 'test-secret-key' })
+      await encrypted.set('secret', { token: 'abc123' })
+      const result = await encrypted.get<{ token: string }>('secret')
+      expect(result).toEqual({ token: 'abc123' })
+    })
+
+    it('round-trips with encryption using MsgpackSerializer (Buffer serializer)', async () => {
+      const encrypted = new DiskLayer({
+        directory: dir,
+        ttl: 60,
+        serializer: new MsgpackSerializer(),
+        encryptionKey: 'msgpack-secret'
+      })
+      await encrypted.set('binary-key', { nums: [1, 2, 3], flag: true })
+      const result = await encrypted.get<{ nums: number[]; flag: boolean }>('binary-key')
+      expect(result).toEqual({ nums: [1, 2, 3], flag: true })
+    })
+
+    it('writes encrypted bytes that are not plaintext JSON', async () => {
+      const encrypted = new DiskLayer({ directory: dir, ttl: 60, encryptionKey: 'test-key' })
+      await encrypted.set('data', { secret: 'value' })
+      const raw = await readLcFile(dir)
+      const asText = raw.toString('utf8')
+      expect(asText).not.toContain('"secret"')
+      expect(asText).not.toContain('"value"')
+    })
+
+    it('rejects reading tampered encrypted files', async () => {
+      const encrypted = new DiskLayer({ directory: dir, ttl: 60, encryptionKey: 'original-key' })
+      await encrypted.set('tamper-test', { important: true })
+      await tamperLastByte(dir)
+
+      const result = await encrypted.get('tamper-test')
+      expect(result).toBeNull()
+    })
+
+    it('rejects encrypted data with the wrong key', async () => {
+      const writer = new DiskLayer({ directory: dir, ttl: 60, encryptionKey: 'correct-key' })
+      await writer.set('locked', { data: 42 })
+
+      const reader = new DiskLayer({ directory: dir, ttl: 60, encryptionKey: 'wrong-key' })
+      const result = await reader.get('locked')
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('signing (signingKey)', () => {
+    it('round-trips values with HMAC-SHA256 signing', async () => {
+      const signed = new DiskLayer({ directory: dir, ttl: 60, signingKey: 'hmac-secret' })
+      await signed.set('signed-key', { payload: 'data' })
+      const result = await signed.get<{ payload: string }>('signed-key')
+      expect(result).toEqual({ payload: 'data' })
+    })
+
+    it('round-trips with signing using MsgpackSerializer (Buffer serializer)', async () => {
+      const signed = new DiskLayer({
+        directory: dir,
+        ttl: 60,
+        serializer: new MsgpackSerializer(),
+        signingKey: 'msgpack-hmac-key'
+      })
+      await signed.set('signed-binary', [1, 2, 3])
+      const result = await signed.get<number[]>('signed-binary')
+      expect(result).toEqual([1, 2, 3])
+    })
+
+    it('rejects tampered signed files', async () => {
+      const signed = new DiskLayer({ directory: dir, ttl: 60, signingKey: 'sign-key' })
+      await signed.set('verify-me', { val: 1 })
+      await tamperLastByte(dir)
+
+      const result = await signed.get('verify-me')
+      expect(result).toBeNull()
+    })
+
+    it('ignores signingKey when encryptionKey is also provided', async () => {
+      const both = new DiskLayer({ directory: dir, ttl: 60, encryptionKey: 'enc-key', signingKey: 'sig-key' })
+      await both.set('both', { x: 1 })
+      const result = await both.get<{ x: number }>('both')
+      expect(result).toEqual({ x: 1 })
+
+      const raw = await readLcFile(dir)
+      expect(raw.subarray(0, 5).toString()).toBe('LCP1:')
+    })
+  })
+
+  describe('MsgpackSerializer without protection', () => {
+    it('round-trips values using binary serializer without encryption or signing', async () => {
+      const msgpackLayer = new DiskLayer({
+        directory: dir,
+        ttl: 60,
+        serializer: new MsgpackSerializer()
+      })
+      await msgpackLayer.set('binary', { arr: [1, 2, 3], nested: { a: true } })
+      const result = await msgpackLayer.get<{ arr: number[]; nested: { a: boolean } }>('binary')
+      expect(result).toEqual({ arr: [1, 2, 3], nested: { a: true } })
+    })
   })
 })

--- a/tests/layers/RedisLayer.test.ts
+++ b/tests/layers/RedisLayer.test.ts
@@ -326,4 +326,60 @@ describe('RedisLayer', () => {
       ).decompressWithLimit(new ErrorTransform(), Buffer.from('payload'))
     ).rejects.toThrow('boom')
   })
+
+  describe('key validation', () => {
+    it('rejects empty keys in single operations', async () => {
+      const client = new Redis()
+      const layer = new RedisLayer({ client })
+      await expect(layer.get('')).rejects.toThrow(/must not be empty/)
+      await expect(layer.set('', 'x')).rejects.toThrow(/must not be empty/)
+      await expect(layer.delete('')).rejects.toThrow(/must not be empty/)
+      await expect(layer.has('')).rejects.toThrow(/must not be empty/)
+      await expect(layer.ttl('')).rejects.toThrow(/must not be empty/)
+    })
+
+    it('rejects keys exceeding 1024 characters in single operations', async () => {
+      const client = new Redis()
+      const layer = new RedisLayer({ client })
+      const longKey = 'x'.repeat(1_025)
+      await expect(layer.get(longKey)).rejects.toThrow(/at most 1 024/)
+      await expect(layer.set(longKey, 'x')).rejects.toThrow(/at most 1 024/)
+    })
+
+    it('rejects keys with control characters in single operations', async () => {
+      const client = new Redis()
+      const layer = new RedisLayer({ client })
+      await expect(layer.get('bad\x00key')).rejects.toThrow(/control characters/)
+      await expect(layer.set('bad\x01key', 'x')).rejects.toThrow(/control characters/)
+    })
+
+    it('rejects empty keys in getMany', async () => {
+      const client = new Redis()
+      const layer = new RedisLayer({ client })
+      await expect(layer.getMany(['valid', ''])).rejects.toThrow(/must not be empty/)
+    })
+
+    it('rejects keys exceeding 1024 characters in setMany', async () => {
+      const client = new Redis()
+      const layer = new RedisLayer({ client })
+      await expect(layer.setMany([{ key: 'x'.repeat(1_025), value: 1 }])).rejects.toThrow(/at most 1 024/)
+    })
+
+    it('rejects keys with control characters in deleteMany', async () => {
+      const client = new Redis()
+      const layer = new RedisLayer({ client })
+      await expect(layer.deleteMany(['bad\x00key'])).rejects.toThrow(/control characters/)
+    })
+
+    it('accepts valid keys in batch operations', async () => {
+      const client = new Redis()
+      const layer = new RedisLayer({ client, ttl: 60 })
+      await layer.setMany([
+        { key: 'a', value: 1, ttl: 10 },
+        { key: 'b', value: 2 }
+      ])
+      await expect(layer.getMany(['a', 'b'])).resolves.toEqual([1, 2])
+      await expect(layer.deleteMany(['a'])).resolves.toBeUndefined()
+    })
+  })
 })

--- a/tests/serialization/Serializers.test.ts
+++ b/tests/serialization/Serializers.test.ts
@@ -1,10 +1,14 @@
 import { encode } from '@msgpack/msgpack'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { JsonSerializer } from '../../src/serialization/JsonSerializer'
 import { MsgpackSerializer } from '../../src/serialization/MsgpackSerializer'
 
 describe('JsonSerializer', () => {
   const serializer = new JsonSerializer()
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
 
   it('round-trips plain objects', () => {
     const value = { id: 1, name: 'alice', active: true }
@@ -51,6 +55,16 @@ describe('JsonSerializer', () => {
   it('rejects excessively wide payloads during deserialize', () => {
     const wide = Array.from({ length: 10_500 }, (_, index) => ({ [`k${index}`]: index }))
     expect(() => serializer.deserialize(JSON.stringify(wide))).toThrow(/max node count/i)
+  })
+
+  it('surfaces non-Error JSON.parse failures with a stringified message', () => {
+    vi.spyOn(JSON, 'parse').mockImplementation(() => {
+      throw 'parse failed'
+    })
+
+    expect(() => serializer.deserialize('{"ok":true}')).toThrow(
+      'JsonSerializer: failed to parse JSON payload: parse failed'
+    )
   })
 })
 

--- a/tests/stampede/StampedeGuard.test.ts
+++ b/tests/stampede/StampedeGuard.test.ts
@@ -61,4 +61,72 @@ describe('Stampede prevention', () => {
     expect(third).toBe('value')
     expect(executions).toBe(1)
   })
+
+  it('rejects new keys when maxInFlight is exceeded', async () => {
+    const guard = new StampedeGuard({ maxInFlight: 2 })
+    let resolve1!: () => void
+    let resolve2!: () => void
+    const p1 = new Promise<void>((resolve) => {
+      resolve1 = resolve
+    })
+    const p2 = new Promise<void>((resolve) => {
+      resolve2 = resolve
+    })
+
+    const t1 = guard.execute('k1', async () => {
+      await p1
+      return 'a'
+    })
+    const t2 = guard.execute('k2', async () => {
+      await p2
+      return 'b'
+    })
+
+    await expect(guard.execute('k3', async () => 'c')).rejects.toThrow(/in-flight limit/)
+
+    resolve1()
+    resolve2()
+    await Promise.all([t1, t2])
+  })
+
+  it('rejects with a timeout when entryTimeoutMs elapses', async () => {
+    const guard = new StampedeGuard({ entryTimeoutMs: 20 })
+
+    await expect(
+      guard.execute('slow-key', async () => {
+        await new Promise((resolve) => setTimeout(resolve, 200))
+        return 'late'
+      })
+    ).rejects.toThrow(/timed out/)
+  })
+
+  it('releases the entry after a timeout so subsequent calls can retry', async () => {
+    const guard = new StampedeGuard({ entryTimeoutMs: 30 })
+
+    await expect(
+      guard.execute('retry-key', async () => {
+        await new Promise((resolve) => setTimeout(resolve, 200))
+      })
+    ).rejects.toThrow(/timed out/)
+
+    const result = await guard.execute('retry-key', async () => 'success')
+    expect(result).toBe('success')
+  })
+
+  it('truncates keys in timeout error messages', async () => {
+    const guard = new StampedeGuard({ entryTimeoutMs: 10 })
+    const longKey = 'x'.repeat(200)
+
+    try {
+      await guard.execute(longKey, async () => {
+        await new Promise((resolve) => setTimeout(resolve, 200))
+      })
+      expect.unreachable('should have thrown')
+    } catch (error) {
+      const message = (error as Error).message
+      expect(message).toContain('timed out')
+      expect(message.length).toBeLessThan(200)
+      expect(message).toContain('...')
+    }
+  })
 })

--- a/tests/stampede/StampedeGuard.test.ts
+++ b/tests/stampede/StampedeGuard.test.ts
@@ -129,4 +129,17 @@ describe('Stampede prevention', () => {
       expect(message).toContain('...')
     }
   })
+
+  it('propagates task rejections before the timeout fires and releases the entry', async () => {
+    const guard = new StampedeGuard({ entryTimeoutMs: 100 })
+
+    await expect(
+      guard.execute('reject-key', async () => {
+        throw new Error('fetch failed')
+      })
+    ).rejects.toThrow('fetch failed')
+
+    const result = await guard.execute('reject-key', async () => 'recovered')
+    expect(result).toBe('recovered')
+  })
 })


### PR DESCRIPTION
## Summary
- harden cache storage and runtime behavior with DiskLayer payload protection, Redis key validation, TLS-aware CLI warnings, and safer instance-id / JSON parsing paths
- add configurable StampedeGuard limits and timeouts, wire them through CacheStack, and cover the behavior with CacheStack-level and unit tests
- refresh benchmark documentation and changelog entries, including the latest slow Redis and memory-pressure results, and update the README test badge to 457 passing tests

## Test Plan
- [x] `npm run lint`
- [x] `npm test`
