### PR TITLE
refactor: extract CacheStackReader from CacheStack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/autocannon": "^7.12.7",
         "@types/node": "^22.15.2",
         "@vitest/coverage-v8": "^4.1.2",
-        "autocannon": "^8.0.0",
+        "autocannon": "^2.0.1",
         "ioredis": "^5.6.1",
         "ioredis-mock": "^8.13.0",
         "tsup": "^8.5.0",
@@ -37,11 +37,6 @@
       "peerDependencies": {
         "ioredis": ">=5.0.0"
       }
-    },
-    "node_modules/@assemblyscript/loader": {
-      "version": "0.19.23",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
@@ -149,13 +144,38 @@
         "node": ">=14.21.3"
       }
     },
-    "node_modules/@colors/colors": {
-      "version": "1.5.0",
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "engines": {
-        "node": ">=0.1.90"
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/linux-x64": {
@@ -214,14 +234,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@minimistjs/subarg": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.1.0"
-      }
-    },
     "node_modules/@msgpack/msgpack": {
       "version": "3.1.3",
       "license": "ISC",
@@ -229,16 +241,192 @@
         "node": ">= 18"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@oxc-project/types": {
-      "version": "0.122.0",
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.12",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
       "cpu": [
         "x64"
       ],
@@ -253,7 +441,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.12",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
       "cpu": [
         "x64"
       ],
@@ -267,8 +457,80 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.12",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "dev": true,
       "license": "MIT"
     },
@@ -300,6 +562,17 @@
       "version": "1.1.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/autocannon": {
       "version": "7.12.7",
@@ -484,26 +757,54 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       },
       "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/any-promise": {
@@ -536,39 +837,29 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/autocannon": {
-      "version": "8.0.0",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/autocannon/-/autocannon-2.0.1.tgz",
+      "integrity": "sha512-cp/wM/fGJ4nnXBXXEdtaUqNu6vW9OS8w60OEKx1eDqUQP7bCFKe4+MdF7sqbzTHd/AqASVKG/o4bS4yk70YiIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@minimistjs/subarg": "^1.0.0",
-        "chalk": "^4.1.0",
-        "char-spinner": "^1.0.1",
-        "cli-table3": "^0.6.0",
+        "chalk": "^2.0.0",
+        "clone": "^2.1.1",
         "color-support": "^1.1.1",
-        "cross-argv": "^2.0.0",
-        "form-data": "^4.0.0",
-        "has-async-hooks": "^1.0.0",
-        "hdr-histogram-js": "^3.0.0",
-        "hdr-histogram-percentiles-obj": "^3.0.0",
-        "http-parser-js": "^0.5.2",
-        "hyperid": "^3.0.0",
-        "lodash.chunk": "^4.2.0",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.flatten": "^4.4.0",
-        "manage-path": "^2.0.0",
-        "on-net-listen": "^1.1.1",
-        "pretty-bytes": "^5.4.1",
-        "progress": "^2.0.3",
+        "deep-extend": "^0.5.0",
+        "hdr-histogram-js": "^1.0.0",
+        "hdr-histogram-percentiles-obj": "^1.2.0",
+        "http-parser-js": "^0.4.2",
+        "hyperid": "^1.1.0",
+        "minimist": "^1.2.0",
+        "pretty-bytes": "^4.0.2",
+        "progress": "^2.0.0",
         "reinterval": "^1.1.0",
-        "retimer": "^3.0.0",
-        "semver": "^7.3.2",
-        "timestring": "^6.0.0"
+        "retimer": "^1.0.1",
+        "table": "^4.0.1",
+        "timestring": "^5.0.0",
+        "xtend": "^4.0.1"
       },
       "bin": {
         "autocannon": "autocannon.js"
@@ -576,6 +867,8 @@
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true,
       "funding": [
         {
@@ -592,29 +885,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
     },
     "node_modules/bundle-require": {
       "version": "5.1.0",
@@ -638,18 +908,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/chai": {
       "version": "6.2.2",
       "dev": true,
@@ -659,24 +917,42 @@
       }
     },
     "node_modules/chalk": {
-      "version": "4.1.2",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
+        "node": ">=4"
       }
     },
-    "node_modules/char-spinner": {
-      "version": "1.0.1",
+    "node_modules/chalk/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
-      "license": "ISC"
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
@@ -692,18 +968,14 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/cli-table3": {
-      "version": "0.6.5",
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "string-width": "^4.2.0"
-      },
       "engines": {
-        "node": "10.* || >= 12.*"
-      },
-      "optionalDependencies": {
-        "@colors/colors": "1.5.0"
+        "node": ">=0.8"
       }
     },
     "node_modules/cluster-key-slot": {
@@ -715,18 +987,19 @@
       }
     },
     "node_modules/color-convert": {
-      "version": "2.0.1",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
+        "color-name": "1.1.3"
       }
     },
     "node_modules/color-name": {
-      "version": "1.1.4",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true,
       "license": "MIT"
     },
@@ -736,17 +1009,6 @@
       "license": "ISC",
       "bin": {
         "color-support": "bin.js"
-      }
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/commander": {
@@ -775,11 +1037,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cross-argv": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "dev": true,
@@ -796,12 +1053,15 @@
         }
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
+    "node_modules/deep-extend": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+      "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=0.4.0"
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
       }
     },
     "node_modules/denque": {
@@ -820,69 +1080,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/esbuild": {
       "version": "0.27.5",
@@ -924,6 +1125,16 @@
         "@esbuild/win32-x64": "0.27.5"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "dev": true,
@@ -939,6 +1150,20 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -984,62 +1209,19 @@
         "rollup": "^4.34.8"
       }
     },
-    "node_modules/form-data": {
-      "version": "4.0.5",
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
+      "hasInstallScript": true,
       "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
       "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/get-tsconfig": {
@@ -1053,22 +1235,6 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-async-hooks": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "dev": true,
@@ -1077,59 +1243,26 @@
         "node": ">=8"
       }
     },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/hdr-histogram-js": {
-      "version": "3.0.1",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hdr-histogram-js/-/hdr-histogram-js-1.2.0.tgz",
+      "integrity": "sha512-h0YToJ3ewqsaZ3nFTTa6dLOD7sqx+EgdC4+OcJ9Ou7zZDlT0sXSPHHr3cyenQsPqqbVHGn/oFY6zjfEKXGvzmQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@assemblyscript/loader": "^0.19.21",
         "base64-js": "^1.2.0",
         "pako": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/hdr-histogram-percentiles-obj": {
-      "version": "3.0.0",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hdr-histogram-percentiles-obj/-/hdr-histogram-percentiles-obj-1.2.0.tgz",
+      "integrity": "sha512-SI/vCNnkfTObd4gkxVtM/DulrqvEfxsj/UnYfEK/c2cKXT7PIJ9SvdEtnk8VBkpbKpR2DnyWloTXk/1V9f2P5Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "hdr-histogram-js": "^1.0.0"
+      }
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -1137,38 +1270,21 @@
       "license": "MIT"
     },
     "node_modules/http-parser-js": {
-      "version": "0.5.10",
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.13.tgz",
+      "integrity": "sha512-u8u5ZaG0Tr/VvHlucK2ufMuOp4/5bvwgneXle+y228K5rMbJOlVjThONcaAw3ikAy8b2OO9RfEucdMHFz3UWMA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/hyperid": {
-      "version": "3.3.0",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/hyperid/-/hyperid-1.3.0.tgz",
+      "integrity": "sha512-cdup71pr2iesJcBFNeuYoxVQ+czgTw5Z/u+jbrWLrzd0gzFxzVumabftSbl9CqdK8YZu9Cl/91EOUu0iqBypBw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "buffer": "^5.2.1",
-        "uuid": "^8.3.2",
-        "uuid-parse": "^1.1.0"
+        "uuid-parse": "^1.0.0"
       }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/ioredis": {
       "version": "5.10.1",
@@ -1213,11 +1329,13 @@
       }
     },
     "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
     },
     "node_modules/istanbul-lib-coverage": {
@@ -1263,6 +1381,13 @@
     },
     "node_modules/js-tokens": {
       "version": "10.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1356,23 +1481,15 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
-    "node_modules/lodash.chunk": {
-      "version": "4.2.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.flatten": {
-      "version": "4.4.0",
       "dev": true,
       "license": "MIT"
     },
@@ -1413,40 +1530,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/manage-path": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/minimist": {
       "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1513,16 +1600,10 @@
       ],
       "license": "MIT"
     },
-    "node_modules/on-net-listen": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=9.4.0 || ^8.9.4"
-      }
-    },
     "node_modules/pako": {
       "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "dev": true,
       "license": "(MIT AND Zlib)"
     },
@@ -1566,7 +1647,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {
@@ -1634,14 +1717,13 @@
       }
     },
     "node_modules/pretty-bytes": {
-      "version": "5.6.0",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+      "integrity": "sha512-yJAF+AjbHKlxQ8eezMd/34Mnj/YTQ3i6kLzvVsH4l/BfIFtp444n0wVbnsn66JimZ9uBofv815aRp1zCppxlWw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=4"
       }
     },
     "node_modules/progress": {
@@ -1650,6 +1732,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/readdirp": {
@@ -1713,17 +1805,21 @@
       }
     },
     "node_modules/retimer": {
-      "version": "3.0.0",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/retimer/-/retimer-1.1.0.tgz",
+      "integrity": "sha512-+Tjoa47XqpO+cmNObvmK6UPFmUTzQPtr4MqMS7ZJKPKYAnryCxG2FXT8/SEgPsEghQQgXFPZEdILNxJkvXtjUw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.12",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.122.0",
-        "@rolldown/pluginutils": "1.0.0-rc.12"
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -1732,21 +1828,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
     "node_modules/rollup": {
@@ -1808,6 +1904,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/slice-ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "dev": true,
@@ -1845,27 +1954,30 @@
       "license": "MIT"
     },
     "node_modules/string-width": {
-      "version": "4.2.3",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
     },
     "node_modules/strip-ansi": {
-      "version": "6.0.1",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^5.0.1"
+        "ansi-regex": "^3.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
     },
     "node_modules/sucrase": {
@@ -1900,6 +2012,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/table": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
+      "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^6.0.1",
+        "ajv-keywords": "^3.0.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
+        "slice-ansi": "1.0.0",
+        "string-width": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "dev": true,
@@ -1920,11 +2050,13 @@
       }
     },
     "node_modules/timestring": {
-      "version": "6.0.0",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/timestring/-/timestring-5.0.1.tgz",
+      "integrity": "sha512-0VfOVpaTYqBMTEpjwcY5mB+72YYjFI44Z5F2q80ZiIyDn5pRJm+rEV1OEM8xfnf5/FdtckcrTERTp9TbrlMMHw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
     },
     "node_modules/tinybench": {
@@ -1938,12 +2070,14 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -2076,29 +2210,35 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/uuid": {
-      "version": "8.3.2",
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/uuid-parse": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/uuid-parse/-/uuid-parse-1.1.0.tgz",
+      "integrity": "sha512-OdmXxA8rDsQ7YpNVbKSJkNzTw2I+S5WsbMDnCtIWSQaosNAcWtFuI/YK1TjzUI6nbkgiqEyh8gWngfcv8Asd9A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.0.3",
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.12",
-        "tinyglobby": "^0.2.15"
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -2115,7 +2255,7 @@
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
         "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",
@@ -2266,6 +2406,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "layercache",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "layercache",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@types/autocannon": "^7.12.7",
     "@types/node": "^22.15.2",
     "@vitest/coverage-v8": "^4.1.2",
-    "autocannon": "^8.0.0",
+    "autocannon": "^2.0.1",
     "ioredis": "^5.6.1",
     "ioredis-mock": "^8.13.0",
     "tsup": "^8.5.0",

--- a/src/CacheStack.ts
+++ b/src/CacheStack.ts
@@ -18,11 +18,10 @@ import {
 import { CacheStackInvalidationSupport } from './internal/CacheStackInvalidationSupport'
 import { CacheStackLayerWriter, type CacheWriteKind } from './internal/CacheStackLayerWriter'
 import { CacheStackMaintenance } from './internal/CacheStackMaintenance'
+import { CacheStackReader } from './internal/CacheStackReader'
 import {
-  planFreshReadPolicies,
   resolveRecoverableLayerFailure,
-  shouldSkipLayer as shouldSkipDegradedLayer,
-  shouldStartBackgroundRefresh
+  shouldSkipLayer as shouldSkipDegradedLayer
 } from './internal/CacheStackRuntimePolicy'
 import { CacheStackSnapshotManager } from './internal/CacheStackSnapshotManager'
 import {
@@ -41,7 +40,7 @@ import {
 import { CircuitBreakerManager } from './internal/CircuitBreakerManager'
 import { FetchRateLimiter } from './internal/FetchRateLimiter'
 import { MetricsCollector } from './internal/MetricsCollector'
-import { isStoredValueEnvelope, remainingStoredTtlSeconds, resolveStoredValue } from './internal/StoredValue'
+import { resolveStoredValue } from './internal/StoredValue'
 import { TtlResolver } from './internal/TtlResolver'
 import { TagIndex } from './invalidation/TagIndex'
 import { JsonSerializer } from './serialization/JsonSerializer'
@@ -60,7 +59,6 @@ import {
   type CacheMSetEntry,
   type CacheMetricsSnapshot,
   CacheMissError,
-  type CacheSingleFlightExecutionOptions,
   type CacheSnapshotEntry,
   type CacheStackEvents,
   type CacheStackOptions,
@@ -77,27 +75,10 @@ import {
   type LayerTtlMap
 } from './types'
 
-const DEFAULT_SINGLE_FLIGHT_LEASE_MS = 30_000
-const DEFAULT_SINGLE_FLIGHT_TIMEOUT_MS = 5_000
-const DEFAULT_SINGLE_FLIGHT_POLL_MS = 50
-const DEFAULT_BACKGROUND_REFRESH_TIMEOUT_MS = 30_000
 const DEFAULT_SNAPSHOT_MAX_BYTES = 16 * 1_024 * 1_024
 const DEFAULT_SNAPSHOT_MAX_ENTRIES = 10_000
 const DEFAULT_INVALIDATION_MAX_KEYS = 10_000
 const DEFAULT_MAX_PROFILE_ENTRIES = 100_000
-
-type ReadMode = 'allow-stale' | 'fresh-only'
-
-type ReadHit<T> =
-  | {
-      found: true
-      value: T | null
-      stored: unknown
-      state: 'fresh' | 'stale-while-revalidate' | 'stale-if-error'
-      layerIndex: number
-      layerName: string
-    }
-  | { found: false; value: null; stored: null; state: 'miss' }
 
 class DebugLogger implements CacheLogger {
   private readonly enabled: boolean
@@ -157,8 +138,6 @@ export class CacheStack extends EventEmitter {
   private readonly invalidation: CacheStackInvalidationSupport
   private readonly layerWriter: CacheStackLayerWriter
   private readonly snapshots: CacheStackSnapshotManager
-  private readonly backgroundRefreshes = new Map<string, Promise<void>>()
-  private readonly backgroundRefreshAbort = new Map<string, boolean>()
   private readonly layerDegradedUntil = new Map<string, number>()
   private readonly maintenance = new CacheStackMaintenance()
   private readonly ttlResolver: TtlResolver
@@ -166,6 +145,7 @@ export class CacheStack extends EventEmitter {
   private nextOperationId = 0
   private currentGeneration?: number
   private isDisconnecting = false
+  private readonly reader: CacheStackReader
   private disconnectPromise?: Promise<void>
 
   constructor(
@@ -259,13 +239,50 @@ export class CacheStack extends EventEmitter {
       layers: this.layers,
       tagIndex: this.tagIndex,
       snapshotSerializer: this.snapshotSerializer,
-      readLayerEntry: this.readLayerEntry.bind(this),
+      readLayerEntry: (layer, key) => this.reader.readLayerEntry(layer, key),
       shouldSkipLayer: (layer) => this.shouldSkipLayer(layer),
       handleLayerFailure: async (layer, operation, error) => this.handleLayerFailure(layer, operation, error),
       qualifyKey: this.qualifyKey.bind(this),
       stripQualifiedKey: this.stripQualifiedKey.bind(this),
       validateCacheKey,
       formatError: this.formatError.bind(this)
+    })
+    this.reader = new CacheStackReader({
+      layers: this.layers,
+      metricsCollector: this.metricsCollector,
+      maintenance: this.maintenance,
+      tagIndex: this.tagIndex,
+      circuitBreakerManager: this.circuitBreakerManager,
+      fetchRateLimiter: this.fetchRateLimiter,
+      stampedeGuard: this.stampedeGuard,
+      ttlResolver: this.ttlResolver,
+      logger: this.logger,
+      shouldSkipLayer: (layer) => this.shouldSkipLayer(layer),
+      handleLayerFailure: async (layer, operation, error) => this.handleLayerFailure(layer, operation, error),
+      emit: (event, data) => this.emit(event, data as never),
+      emitError: (operation, context) => this.emitError(operation, context),
+      formatError: (error) => this.formatError(error),
+      storeEntry: (key, kind, value, options) => this.storeEntry(key, kind, value, options),
+      recordCircuitFailure: (key, options, error) => this.recordCircuitFailure(key, options, error),
+      resolveLayerSeconds: (layerName, override, globalDefault, fallback) =>
+        this.resolveLayerSeconds(layerName, override, globalDefault, fallback),
+      sleep: (ms) => this.sleep(ms),
+      withTimeout: (promise, ms, createError) => this.withTimeout(promise, ms, createError),
+      isDisconnecting: () => this.isDisconnecting,
+      isGracefulDegradationEnabled: () => this.isGracefulDegradationEnabled(),
+      scheduleBackgroundRefreshDispatch: <T>(key: string, fetcher: () => Promise<T>, options?: CacheGetOptions) =>
+        this.scheduleBackgroundRefresh(key, fetcher, options),
+      stampedePrevention: options.stampedePrevention,
+      singleFlightCoordinator: options.singleFlightCoordinator,
+      singleFlightLeaseMs: options.singleFlightLeaseMs,
+      singleFlightTimeoutMs: options.singleFlightTimeoutMs,
+      singleFlightPollMs: options.singleFlightPollMs,
+      singleFlightRenewIntervalMs: options.singleFlightRenewIntervalMs,
+      backgroundRefreshTimeoutMs: options.backgroundRefreshTimeoutMs,
+      negativeCaching: options.negativeCaching,
+      refreshAhead: options.refreshAhead,
+      circuitBreaker: options.circuitBreaker,
+      fetcherRateLimit: options.fetcherRateLimit
     })
     this.initializeWriteBehind(options.writeBehind)
     this.startup = this.initialize()
@@ -282,61 +299,8 @@ export class CacheStack extends EventEmitter {
       const normalizedKey = this.qualifyKey(validateCacheKey(key))
       this.validateWriteOptions(options)
       await this.awaitStartup('get')
-      return this.getPrepared(normalizedKey, fetcher, options)
+      return this.reader.getPrepared(normalizedKey, fetcher, options)
     })
-  }
-
-  private async getPrepared<T>(
-    normalizedKey: string,
-    fetcher?: () => Promise<T>,
-    options?: CacheGetOptions
-  ): Promise<T | null> {
-    const hit = await this.readFromLayers<T>(normalizedKey, options, 'allow-stale')
-    if (hit.found) {
-      this.ttlResolver.recordAccess(normalizedKey)
-      if (this.isNegativeStoredValue(hit.stored)) {
-        this.metricsCollector.increment('negativeCacheHits')
-      }
-
-      if (hit.state === 'fresh') {
-        this.metricsCollector.increment('hits')
-        await this.applyFreshReadPolicies(normalizedKey, hit, options, fetcher)
-        return hit.value
-      }
-
-      if (hit.state === 'stale-while-revalidate') {
-        this.metricsCollector.increment('hits')
-        this.metricsCollector.increment('staleHits')
-        this.emit('stale-serve', { key: normalizedKey, state: hit.state, layer: hit.layerName })
-        if (fetcher) {
-          this.scheduleBackgroundRefresh(normalizedKey, fetcher, options)
-        }
-        return hit.value
-      }
-
-      if (!fetcher) {
-        this.metricsCollector.increment('hits')
-        this.metricsCollector.increment('staleHits')
-        this.emit('stale-serve', { key: normalizedKey, state: hit.state, layer: hit.layerName })
-        return hit.value
-      }
-
-      try {
-        return await this.fetchWithGuards(normalizedKey, fetcher, options)
-      } catch (error) {
-        this.metricsCollector.increment('staleHits')
-        this.metricsCollector.increment('refreshErrors')
-        this.logger.debug?.('stale-if-error', { key: normalizedKey, error: this.formatError(error) })
-        return hit.value
-      }
-    }
-
-    this.metricsCollector.increment('misses')
-    if (!fetcher) {
-      return null
-    }
-
-    return this.fetchWithGuards(normalizedKey, fetcher, options, undefined, undefined, true)
   }
 
   /**
@@ -511,7 +475,7 @@ export class CacheStack extends EventEmitter {
             const optionsSignature = serializeOptions(entry.options)
             const existing = pendingReads.get(entry.key)
             if (!existing) {
-              const promise = this.getPrepared(entry.key, entry.fetch, entry.options)
+              const promise = this.reader.getPrepared(entry.key, entry.fetch, entry.options)
               pendingReads.set(entry.key, {
                 promise,
                 fetch: entry.fetch,
@@ -555,7 +519,7 @@ export class CacheStack extends EventEmitter {
 
         const values = layer.getMany
           ? await layer.getMany(keys)
-          : await Promise.all(keys.map((key) => this.readLayerEntry(layer, key)))
+          : await Promise.all(keys.map((key) => this.reader.readLayerEntry(layer, key)))
 
         for (let offset = 0; offset < values.length; offset += 1) {
           const key = keys[offset]
@@ -575,7 +539,7 @@ export class CacheStack extends EventEmitter {
           }
 
           await this.tagIndex.touch(key)
-          await this.backfill(key, stored, layerIndex - 1)
+          await this.reader.backfill(key, stored, layerIndex - 1)
           resultsByKey.set(key, resolved.value)
           pending.delete(key)
           this.metricsCollector.increment('hits', indexesByKey.get(key)?.length ?? 1)
@@ -731,7 +695,7 @@ export class CacheStack extends EventEmitter {
         isLocal: Boolean(layer.isLocal),
         degradedUntil: this.layerDegradedUntil.get(layer.name) ?? null
       })),
-      backgroundRefreshes: this.backgroundRefreshes.size
+      backgroundRefreshes: this.reader.activeRefreshCount
     }
   }
 
@@ -882,12 +846,9 @@ export class CacheStack extends EventEmitter {
         await this.unsubscribeInvalidation?.()
         await this.flushWriteBehindQueue()
         await this.maintenance.waitForGenerationCleanup()
-        // Signal all background refreshes to abort, then wait with a timeout
-        for (const key of this.backgroundRefreshAbort.keys()) {
-          this.backgroundRefreshAbort.set(key, true)
-        }
+        this.reader.abortAllRefreshes()
         await Promise.allSettled(
-          [...this.backgroundRefreshes.values()].map((promise) => {
+          this.reader.getAllRefreshPromises().map((promise) => {
             let timer: ReturnType<typeof setTimeout> | undefined
             return Promise.race([
               promise,
@@ -900,8 +861,6 @@ export class CacheStack extends EventEmitter {
             })
           })
         )
-        this.backgroundRefreshes.clear()
-        this.backgroundRefreshAbort.clear()
         this.maintenance.disposeWriteBehindTimer()
         this.fetchRateLimiter.dispose()
         await Promise.allSettled(this.layers.map((layer) => layer.dispose?.() ?? Promise.resolve()))
@@ -919,155 +878,6 @@ export class CacheStack extends EventEmitter {
     this.unsubscribeInvalidation = await this.options.invalidationBus.subscribe(async (message) => {
       await this.handleInvalidationMessage(message)
     })
-  }
-
-  private async fetchWithGuards<T>(
-    key: string,
-    fetcher: () => Promise<T>,
-    options?: CacheGetOptions,
-    expectedClearEpoch?: number,
-    expectedKeyEpoch?: number,
-    initialMissConfirmed = false
-  ): Promise<T | null> {
-    const fetchTask = async (): Promise<T | null> => {
-      const shouldRecheckFreshLayers = !(initialMissConfirmed && this.options.singleFlightCoordinator)
-      if (shouldRecheckFreshLayers) {
-        const secondHit = await this.readFromLayers<T>(key, options, 'fresh-only')
-        if (secondHit.found) {
-          this.metricsCollector.increment('hits')
-          return secondHit.value
-        }
-      }
-
-      return this.fetchAndPopulate(key, fetcher, options, expectedClearEpoch, expectedKeyEpoch)
-    }
-
-    const singleFlightTask = async (): Promise<T | null> => {
-      if (!this.options.singleFlightCoordinator) {
-        return fetchTask()
-      }
-
-      try {
-        return await this.options.singleFlightCoordinator.execute(
-          key,
-          this.resolveSingleFlightOptions(),
-          fetchTask,
-          () => this.waitForFreshValue(key, fetcher, options, expectedClearEpoch, expectedKeyEpoch)
-        )
-      } catch (error) {
-        if (!this.isGracefulDegradationEnabled()) {
-          throw error
-        }
-
-        this.metricsCollector.increment('degradedOperations')
-        this.logger.warn?.('single-flight-coordinator-degraded', { key, error: this.formatError(error) })
-        this.emitError('single-flight', { key, degraded: true, error: this.formatError(error) })
-        return fetchTask()
-      }
-    }
-
-    if (this.options.stampedePrevention === false) {
-      return singleFlightTask()
-    }
-
-    return this.stampedeGuard.execute(key, singleFlightTask)
-  }
-
-  private async waitForFreshValue<T>(
-    key: string,
-    fetcher: () => Promise<T>,
-    options?: CacheGetOptions,
-    expectedClearEpoch?: number,
-    expectedKeyEpoch?: number
-  ): Promise<T | null> {
-    const timeoutMs = this.options.singleFlightTimeoutMs ?? DEFAULT_SINGLE_FLIGHT_TIMEOUT_MS
-    const pollIntervalMs = this.options.singleFlightPollMs ?? DEFAULT_SINGLE_FLIGHT_POLL_MS
-    const deadline = Date.now() + timeoutMs
-
-    this.metricsCollector.increment('singleFlightWaits')
-    this.emit('stampede-dedupe', { key })
-
-    while (Date.now() < deadline) {
-      const hit = await this.readFromLayers<T>(key, options, 'fresh-only')
-      if (hit.found) {
-        this.metricsCollector.increment('hits')
-        return hit.value
-      }
-      await this.sleep(pollIntervalMs)
-    }
-
-    return this.fetchAndPopulate(key, fetcher, options, expectedClearEpoch, expectedKeyEpoch)
-  }
-
-  private async fetchAndPopulate<T>(
-    key: string,
-    fetcher: () => Promise<T>,
-    options?: CacheGetOptions,
-    expectedClearEpoch?: number,
-    expectedKeyEpoch?: number
-  ): Promise<T | null> {
-    this.circuitBreakerManager.assertClosed(key, options?.circuitBreaker ?? this.options.circuitBreaker)
-    this.metricsCollector.increment('fetches')
-    const fetchStart = Date.now()
-    let fetched: T
-
-    try {
-      fetched = await this.fetchRateLimiter.schedule(
-        options?.fetcherRateLimit ?? this.options.fetcherRateLimit,
-        { key, fetcher },
-        fetcher
-      )
-      this.circuitBreakerManager.recordSuccess(key)
-      this.logger.debug?.('fetch', { key, durationMs: Date.now() - fetchStart })
-    } catch (error) {
-      this.recordCircuitFailure(key, options?.circuitBreaker ?? this.options.circuitBreaker, error)
-      throw error
-    }
-
-    if (fetched === null || fetched === undefined) {
-      if (!this.shouldNegativeCache(options)) {
-        return null
-      }
-
-      if (this.maintenance.isWriteOutdated(key, expectedClearEpoch, expectedKeyEpoch)) {
-        this.logger.debug?.('skip-negative-store-after-invalidation', {
-          key,
-          expectedClearEpoch,
-          clearEpoch: this.maintenance.currentClearEpoch(),
-          expectedKeyEpoch,
-          keyEpoch: this.maintenance.currentKeyEpoch(key)
-        })
-        return null
-      }
-
-      await this.storeEntry(key, 'empty', null, options)
-      return null
-    }
-
-    // Conditional caching: skip storage if shouldCache returns false
-    if (options?.shouldCache) {
-      try {
-        if (!options.shouldCache(fetched)) {
-          return fetched
-        }
-      } catch (error) {
-        this.logger.warn?.('shouldCache-error', { key, error: this.formatError(error) })
-      }
-    }
-
-    if (this.maintenance.isWriteOutdated(key, expectedClearEpoch, expectedKeyEpoch)) {
-      this.logger.debug?.('skip-store-after-invalidation', {
-        key,
-        expectedClearEpoch,
-        clearEpoch: this.maintenance.currentClearEpoch(),
-        expectedKeyEpoch,
-        keyEpoch: this.maintenance.currentKeyEpoch(key)
-      })
-      return fetched
-    }
-
-    await this.storeEntry(key, 'value', fetched, options)
-    return fetched
   }
 
   private async storeEntry(
@@ -1129,107 +939,6 @@ export class CacheStack extends EventEmitter {
     }
   }
 
-  private async readFromLayers<T>(
-    key: string,
-    options: CacheGetOptions | undefined,
-    mode: ReadMode
-  ): Promise<ReadHit<T>> {
-    let sawRetainableValue = false
-
-    for (let index = 0; index < this.layers.length; index += 1) {
-      const layer = this.layers[index]
-      if (!layer) continue
-      const readStart = performance.now()
-      const stored = await this.readLayerEntry(layer, key)
-      const readDuration = performance.now() - readStart
-      this.metricsCollector.recordLatency(layer.name, readDuration)
-      if (stored === null) {
-        this.metricsCollector.incrementLayer('missesByLayer', layer.name)
-        continue
-      }
-
-      const resolved = resolveStoredValue<T>(stored)
-      if (resolved.state === 'expired') {
-        await layer.delete(key)
-        continue
-      }
-
-      sawRetainableValue = true
-
-      if (mode === 'fresh-only' && resolved.state !== 'fresh') {
-        continue
-      }
-
-      await this.tagIndex.touch(key)
-      await this.backfill(key, stored, index - 1, options)
-      this.metricsCollector.incrementLayer('hitsByLayer', layer.name)
-      this.logger.debug?.('hit', { key, layer: layer.name, state: resolved.state })
-      this.emit('hit', { key, layer: layer.name, state: resolved.state as CacheStackEvents['hit']['state'] })
-      return {
-        found: true,
-        value: resolved.value,
-        stored,
-        state: resolved.state,
-        layerIndex: index,
-        layerName: layer.name
-      }
-    }
-
-    if (!sawRetainableValue) {
-      await this.tagIndex.remove(key)
-    }
-
-    this.logger.debug?.('miss', { key, mode })
-    this.emit('miss', { key, mode })
-    return { found: false, value: null, stored: null, state: 'miss' }
-  }
-
-  private async readLayerEntry(layer: CacheLayer, key: string): Promise<unknown | null> {
-    if (this.shouldSkipLayer(layer)) {
-      return null
-    }
-
-    if (layer.getEntry) {
-      try {
-        return await layer.getEntry(key)
-      } catch (error) {
-        return this.handleLayerFailure(layer, 'read', error)
-      }
-    }
-
-    try {
-      return await layer.get(key)
-    } catch (error) {
-      return this.handleLayerFailure(layer, 'read', error)
-    }
-  }
-
-  private async backfill(key: string, stored: unknown, upToIndex: number, options?: CacheGetOptions): Promise<void> {
-    if (upToIndex < 0) {
-      return
-    }
-
-    for (let index = 0; index <= upToIndex; index += 1) {
-      const layer = this.layers[index]
-      if (!layer || this.shouldSkipLayer(layer)) {
-        continue
-      }
-
-      const ttl =
-        remainingStoredTtlSeconds(stored) ??
-        this.resolveLayerSeconds(layer.name, options?.ttl, undefined, layer.defaultTtl)
-      try {
-        await layer.set(key, stored, ttl)
-      } catch (error) {
-        await this.handleLayerFailure(layer, 'backfill', error)
-        continue
-      }
-      this.metricsCollector.increment('backfills')
-      this.logger.debug?.('backfill', { key, layer: layer.name })
-      this.emit('backfill', { key, layer: layer.name })
-    }
-  }
-
   private resolveFreshTtl(
     key: string,
     layerName: string,
@@ -1257,70 +966,6 @@ export class CacheStack extends EventEmitter {
     fallback?: number
   ): number | undefined {
     return this.ttlResolver.resolveLayerSeconds(layerName, override, globalDefault, fallback)
-  }
-
-  private shouldNegativeCache(options?: CacheGetOptions): boolean {
-    return options?.negativeCache ?? this.options.negativeCaching ?? false
-  }
-
-  private scheduleBackgroundRefresh<T>(key: string, fetcher: () => Promise<T>, options?: CacheGetOptions): void {
-    if (
-      !shouldStartBackgroundRefresh({
-        isDisconnecting: this.isDisconnecting,
-        hasRefreshInFlight: this.backgroundRefreshes.has(key)
-      })
-    ) {
-      return
-    }
-
-    const clearEpoch = this.maintenance.currentClearEpoch()
-    const keyEpoch = this.maintenance.currentKeyEpoch(key)
-    this.backgroundRefreshAbort.set(key, false)
-    const refresh = (async () => {
-      this.metricsCollector.increment('refreshes')
-      try {
-        if (this.backgroundRefreshAbort.get(key)) return
-        await this.runBackgroundRefresh(key, fetcher, options, clearEpoch, keyEpoch)
-      } catch (error) {
-        if (this.backgroundRefreshAbort.get(key)) return
-        this.metricsCollector.increment('refreshErrors')
-        this.logger.warn?.('background-refresh-error', { key, error: this.formatError(error) })
-      } finally {
-        this.backgroundRefreshes.delete(key)
-        this.backgroundRefreshAbort.delete(key)
-      }
-    })()
-
-    this.backgroundRefreshes.set(key, refresh)
-  }
-
-  private async runBackgroundRefresh<T>(
-    key: string,
-    fetcher: () => Promise<T>,
-    options?: CacheGetOptions,
-    expectedClearEpoch?: number,
-    expectedKeyEpoch?: number
-  ): Promise<void> {
-    const timeoutMs = this.options.backgroundRefreshTimeoutMs ?? DEFAULT_BACKGROUND_REFRESH_TIMEOUT_MS
-    await this.fetchWithGuards(
-      key,
-      () =>
-        this.withTimeout(fetcher(), timeoutMs, () => {
-          return new Error(`Background refresh timed out after ${timeoutMs}ms for key "${key}".`)
-        }),
-      options,
-      expectedClearEpoch,
-      expectedKeyEpoch
-    )
-  }
-
-  private resolveSingleFlightOptions(): CacheSingleFlightExecutionOptions {
-    return {
-      leaseMs: this.options.singleFlightLeaseMs ?? DEFAULT_SINGLE_FLIGHT_LEASE_MS,
-      waitTimeoutMs: this.options.singleFlightTimeoutMs ?? DEFAULT_SINGLE_FLIGHT_TIMEOUT_MS,
-      pollIntervalMs: this.options.singleFlightPollMs ?? DEFAULT_SINGLE_FLIGHT_POLL_MS,
-      renewIntervalMs: this.options.singleFlightRenewIntervalMs
-    }
   }
 
   private async deleteKeys(keys: string[]): Promise<void> {
@@ -1613,38 +1258,28 @@ export class CacheStack extends EventEmitter {
     this.assertActive(operation)
   }
 
+  private async readLayerEntry(layer: CacheLayer, key: string): Promise<unknown | null> {
+    return this.reader.readLayerEntry(layer, key)
+  }
+
+  private scheduleBackgroundRefresh<T>(key: string, fetcher: () => Promise<T>, options?: CacheGetOptions): void {
+    this.reader.runScheduleBackgroundRefresh(key, fetcher, options)
+  }
+
   private async applyFreshReadPolicies<T>(
     key: string,
-    hit: Extract<ReadHit<T>, { found: true }>,
+    hit: {
+      found: true
+      value: T | null
+      stored: unknown
+      state: 'fresh' | 'stale-while-revalidate' | 'stale-if-error'
+      layerIndex: number
+      layerName: string
+    },
     options: CacheGetOptions | undefined,
     fetcher?: () => Promise<T>
   ): Promise<void> {
-    const plan = planFreshReadPolicies({
-      stored: hit.stored,
-      hasFetcher: Boolean(fetcher),
-      slidingTtl: options?.slidingTtl ?? false,
-      refreshAheadSeconds:
-        this.resolveLayerSeconds(hit.layerName, options?.refreshAhead, this.options.refreshAhead, 0) ?? 0
-    })
-
-    if (plan.refreshedStored) {
-      for (let index = 0; index <= hit.layerIndex; index += 1) {
-        const layer = this.layers[index]
-        if (!layer || this.shouldSkipLayer(layer)) {
-          continue
-        }
-
-        try {
-          await layer.set(key, plan.refreshedStored, plan.refreshedStoredTtl)
-        } catch (error) {
-          await this.handleLayerFailure(layer, 'sliding-ttl', error)
-        }
-      }
-    }
-
-    if (fetcher && plan.shouldScheduleBackgroundRefresh) {
-      this.scheduleBackgroundRefresh(key, fetcher, options)
-    }
+    return this.reader.runApplyFreshReadPolicies(key, hit, options, fetcher)
   }
 
   private shouldSkipLayer(layer: CacheLayer): boolean {
@@ -1693,10 +1328,6 @@ export class CacheStack extends EventEmitter {
       this.metricsCollector.increment('circuitBreakerTrips')
     }
     this.emitError('fetch', { key, error: this.formatError(error) })
-  }
-
-  private isNegativeStoredValue(stored: unknown): boolean {
-    return isStoredValueEnvelope(stored) && stored.kind === 'empty'
   }
 
   private emitError(operation: string, context: Record<string, unknown>): void {

--- a/src/internal/CacheStackReader.ts
+++ b/src/internal/CacheStackReader.ts
@@ -1,0 +1,552 @@
+import type { StampedeGuard } from '../stampede/StampedeGuard'
+import type {
+  CacheCircuitBreakerOptions,
+  CacheGetOptions,
+  CacheLayer,
+  CacheLogger,
+  CacheRateLimitOptions,
+  CacheSingleFlightCoordinator,
+  CacheSingleFlightExecutionOptions,
+  CacheStackEvents,
+  CacheTagIndex,
+  CacheWriteOptions,
+  LayerTtlMap
+} from '../types'
+import type { CacheWriteKind } from './CacheStackLayerWriter'
+import type { CacheStackMaintenance } from './CacheStackMaintenance'
+import { planFreshReadPolicies, shouldStartBackgroundRefresh } from './CacheStackRuntimePolicy'
+import type { CircuitBreakerManager } from './CircuitBreakerManager'
+import type { FetchRateLimiter } from './FetchRateLimiter'
+import type { MetricsCollector } from './MetricsCollector'
+import { isStoredValueEnvelope, remainingStoredTtlSeconds, resolveStoredValue } from './StoredValue'
+import type { TtlResolver } from './TtlResolver'
+
+const DEFAULT_SINGLE_FLIGHT_LEASE_MS = 30_000
+const DEFAULT_SINGLE_FLIGHT_TIMEOUT_MS = 5_000
+const DEFAULT_SINGLE_FLIGHT_POLL_MS = 50
+const DEFAULT_BACKGROUND_REFRESH_TIMEOUT_MS = 30_000
+
+type ReadMode = 'allow-stale' | 'fresh-only'
+
+type ReadHit<T> =
+  | {
+      found: true
+      value: T | null
+      stored: unknown
+      state: 'fresh' | 'stale-while-revalidate' | 'stale-if-error'
+      layerIndex: number
+      layerName: string
+    }
+  | { found: false; value: null; stored: null; state: 'miss' }
+
+interface CacheStackReaderOptions {
+  // Direct service objects
+  layers: CacheLayer[]
+  metricsCollector: MetricsCollector
+  maintenance: CacheStackMaintenance
+  tagIndex: CacheTagIndex
+  circuitBreakerManager: CircuitBreakerManager
+  fetchRateLimiter: FetchRateLimiter
+  stampedeGuard: StampedeGuard
+  ttlResolver: TtlResolver
+  logger: CacheLogger
+
+  // CacheStack method callbacks
+  shouldSkipLayer: (layer: CacheLayer) => boolean
+  handleLayerFailure: (layer: CacheLayer, operation: string, error: unknown) => Promise<null>
+  emit: <K extends keyof CacheStackEvents>(event: K, data: CacheStackEvents[K]) => boolean
+  emitError: (operation: string, context: Record<string, unknown>) => void
+  formatError: (error: unknown) => string
+  storeEntry: (key: string, kind: CacheWriteKind, value: unknown, options?: CacheWriteOptions) => Promise<void>
+  recordCircuitFailure: (key: string, options: CacheCircuitBreakerOptions | undefined, error: unknown) => void
+  resolveLayerSeconds: (
+    layerName: string,
+    override: number | LayerTtlMap | undefined,
+    globalDefault?: number | LayerTtlMap,
+    fallback?: number
+  ) => number | undefined
+  sleep: (ms: number) => Promise<void>
+  withTimeout: <T>(promise: Promise<T>, timeoutMs: number, createError: () => Error) => Promise<T>
+  isDisconnecting: () => boolean
+  isGracefulDegradationEnabled: () => boolean
+  scheduleBackgroundRefreshDispatch: <T>(key: string, fetcher: () => Promise<T>, options?: CacheGetOptions) => void
+
+  // Config values
+  stampedePrevention?: boolean
+  singleFlightCoordinator?: CacheSingleFlightCoordinator
+  singleFlightLeaseMs?: number
+  singleFlightTimeoutMs?: number
+  singleFlightPollMs?: number
+  singleFlightRenewIntervalMs?: number
+  backgroundRefreshTimeoutMs?: number
+  negativeCaching?: boolean
+  refreshAhead?: number | LayerTtlMap
+  circuitBreaker?: CacheCircuitBreakerOptions
+  fetcherRateLimit?: CacheRateLimitOptions
+}
+
+export class CacheStackReader {
+  private readonly backgroundRefreshes = new Map<string, Promise<void>>()
+  private readonly backgroundRefreshAbort = new Map<string, boolean>()
+
+  constructor(private readonly options: CacheStackReaderOptions) {}
+
+  get activeRefreshCount(): number {
+    return this.backgroundRefreshes.size
+  }
+
+  async getPrepared<T>(
+    normalizedKey: string,
+    fetcher?: () => Promise<T>,
+    options?: CacheGetOptions
+  ): Promise<T | null> {
+    const hit = await this.readFromLayers<T>(normalizedKey, options, 'allow-stale')
+    if (hit.found) {
+      this.options.ttlResolver.recordAccess(normalizedKey)
+      if (this.isNegativeStoredValue(hit.stored)) {
+        this.options.metricsCollector.increment('negativeCacheHits')
+      }
+
+      if (hit.state === 'fresh') {
+        this.options.metricsCollector.increment('hits')
+        await this.applyFreshReadPolicies(normalizedKey, hit, options, fetcher)
+        return hit.value
+      }
+
+      if (hit.state === 'stale-while-revalidate') {
+        this.options.metricsCollector.increment('hits')
+        this.options.metricsCollector.increment('staleHits')
+        this.options.emit('stale-serve', { key: normalizedKey, state: hit.state, layer: hit.layerName })
+        if (fetcher) {
+          this.scheduleBackgroundRefresh(normalizedKey, fetcher, options)
+        }
+        return hit.value
+      }
+
+      if (!fetcher) {
+        this.options.metricsCollector.increment('hits')
+        this.options.metricsCollector.increment('staleHits')
+        this.options.emit('stale-serve', { key: normalizedKey, state: hit.state, layer: hit.layerName })
+        return hit.value
+      }
+
+      try {
+        return await this.fetchWithGuards(normalizedKey, fetcher, options)
+      } catch (error) {
+        this.options.metricsCollector.increment('staleHits')
+        this.options.metricsCollector.increment('refreshErrors')
+        this.options.logger.debug?.('stale-if-error', {
+          key: normalizedKey,
+          error: this.options.formatError(error)
+        })
+        return hit.value
+      }
+    }
+
+    this.options.metricsCollector.increment('misses')
+    if (!fetcher) {
+      return null
+    }
+
+    return this.fetchWithGuards(normalizedKey, fetcher, options, undefined, undefined, true)
+  }
+
+  async readLayerEntry(layer: CacheLayer, key: string): Promise<unknown | null> {
+    if (this.options.shouldSkipLayer(layer)) {
+      return null
+    }
+
+    if (layer.getEntry) {
+      try {
+        return await layer.getEntry(key)
+      } catch (error) {
+        return this.options.handleLayerFailure(layer, 'read', error)
+      }
+    }
+
+    try {
+      return await layer.get(key)
+    } catch (error) {
+      return this.options.handleLayerFailure(layer, 'read', error)
+    }
+  }
+
+  async backfill(key: string, stored: unknown, upToIndex: number, options?: CacheGetOptions): Promise<void> {
+    if (upToIndex < 0) {
+      return
+    }
+
+    for (let index = 0; index <= upToIndex; index += 1) {
+      const layer = this.options.layers[index]
+      if (!layer || this.options.shouldSkipLayer(layer)) {
+        continue
+      }
+
+      const ttl =
+        remainingStoredTtlSeconds(stored) ??
+        this.options.resolveLayerSeconds(layer.name, options?.ttl, undefined, layer.defaultTtl)
+      try {
+        await layer.set(key, stored, ttl)
+      } catch (error) {
+        await this.options.handleLayerFailure(layer, 'backfill', error)
+        continue
+      }
+      this.options.metricsCollector.increment('backfills')
+      this.options.logger.debug?.('backfill', { key, layer: layer.name })
+      this.options.emit('backfill', { key, layer: layer.name })
+    }
+  }
+
+  abortAllRefreshes(): void {
+    for (const key of this.backgroundRefreshAbort.keys()) {
+      this.backgroundRefreshAbort.set(key, true)
+    }
+  }
+
+  getAllRefreshPromises(): Promise<void>[] {
+    return [...this.backgroundRefreshes.values()]
+  }
+
+  private async readFromLayers<T>(
+    key: string,
+    options: CacheGetOptions | undefined,
+    mode: ReadMode
+  ): Promise<ReadHit<T>> {
+    let sawRetainableValue = false
+
+    for (let index = 0; index < this.options.layers.length; index += 1) {
+      const layer = this.options.layers[index]
+      if (!layer) continue
+      const readStart = performance.now()
+      const stored = await this.readLayerEntry(layer, key)
+      const readDuration = performance.now() - readStart
+      this.options.metricsCollector.recordLatency(layer.name, readDuration)
+      if (stored === null) {
+        this.options.metricsCollector.incrementLayer('missesByLayer', layer.name)
+        continue
+      }
+
+      const resolved = resolveStoredValue<T>(stored)
+      if (resolved.state === 'expired') {
+        await layer.delete(key)
+        continue
+      }
+
+      sawRetainableValue = true
+
+      if (mode === 'fresh-only' && resolved.state !== 'fresh') {
+        continue
+      }
+
+      await this.options.tagIndex.touch(key)
+      await this.backfill(key, stored, index - 1, options)
+      this.options.metricsCollector.incrementLayer('hitsByLayer', layer.name)
+      this.options.logger.debug?.('hit', { key, layer: layer.name, state: resolved.state })
+      this.options.emit('hit', {
+        key,
+        layer: layer.name,
+        state: resolved.state as CacheStackEvents['hit']['state']
+      })
+      return {
+        found: true,
+        value: resolved.value,
+        stored,
+        state: resolved.state,
+        layerIndex: index,
+        layerName: layer.name
+      }
+    }
+
+    if (!sawRetainableValue) {
+      await this.options.tagIndex.remove(key)
+    }
+
+    this.options.logger.debug?.('miss', { key, mode })
+    this.options.emit('miss', { key, mode })
+    return { found: false, value: null, stored: null, state: 'miss' }
+  }
+
+  private async fetchWithGuards<T>(
+    key: string,
+    fetcher: () => Promise<T>,
+    options?: CacheGetOptions,
+    expectedClearEpoch?: number,
+    expectedKeyEpoch?: number,
+    initialMissConfirmed = false
+  ): Promise<T | null> {
+    const fetchTask = async (): Promise<T | null> => {
+      const shouldRecheckFreshLayers = !(initialMissConfirmed && this.options.singleFlightCoordinator)
+      if (shouldRecheckFreshLayers) {
+        const secondHit = await this.readFromLayers<T>(key, options, 'fresh-only')
+        if (secondHit.found) {
+          this.options.metricsCollector.increment('hits')
+          return secondHit.value
+        }
+      }
+
+      return this.fetchAndPopulate(key, fetcher, options, expectedClearEpoch, expectedKeyEpoch)
+    }
+
+    const singleFlightTask = async (): Promise<T | null> => {
+      if (!this.options.singleFlightCoordinator) {
+        return fetchTask()
+      }
+
+      try {
+        return await this.options.singleFlightCoordinator.execute(
+          key,
+          this.resolveSingleFlightOptions(),
+          fetchTask,
+          () => this.waitForFreshValue(key, fetcher, options, expectedClearEpoch, expectedKeyEpoch)
+        )
+      } catch (error) {
+        if (!this.options.isGracefulDegradationEnabled()) {
+          throw error
+        }
+
+        this.options.metricsCollector.increment('degradedOperations')
+        this.options.logger.warn?.('single-flight-coordinator-degraded', {
+          key,
+          error: this.options.formatError(error)
+        })
+        this.options.emitError('single-flight', {
+          key,
+          degraded: true,
+          error: this.options.formatError(error)
+        })
+        return fetchTask()
+      }
+    }
+
+    if (this.options.stampedePrevention === false) {
+      return singleFlightTask()
+    }
+
+    return this.options.stampedeGuard.execute(key, singleFlightTask)
+  }
+
+  private async waitForFreshValue<T>(
+    key: string,
+    fetcher: () => Promise<T>,
+    options?: CacheGetOptions,
+    expectedClearEpoch?: number,
+    expectedKeyEpoch?: number
+  ): Promise<T | null> {
+    const timeoutMs = this.options.singleFlightTimeoutMs ?? DEFAULT_SINGLE_FLIGHT_TIMEOUT_MS
+    const pollIntervalMs = this.options.singleFlightPollMs ?? DEFAULT_SINGLE_FLIGHT_POLL_MS
+    const deadline = Date.now() + timeoutMs
+
+    this.options.metricsCollector.increment('singleFlightWaits')
+    this.options.emit('stampede-dedupe', { key })
+
+    while (Date.now() < deadline) {
+      const hit = await this.readFromLayers<T>(key, options, 'fresh-only')
+      if (hit.found) {
+        this.options.metricsCollector.increment('hits')
+        return hit.value
+      }
+      await this.options.sleep(pollIntervalMs)
+    }
+
+    return this.fetchAndPopulate(key, fetcher, options, expectedClearEpoch, expectedKeyEpoch)
+  }
+
+  private async fetchAndPopulate<T>(
+    key: string,
+    fetcher: () => Promise<T>,
+    options?: CacheGetOptions,
+    expectedClearEpoch?: number,
+    expectedKeyEpoch?: number
+  ): Promise<T | null> {
+    this.options.circuitBreakerManager.assertClosed(key, options?.circuitBreaker ?? this.options.circuitBreaker)
+    this.options.metricsCollector.increment('fetches')
+    const fetchStart = Date.now()
+    let fetched: T
+
+    try {
+      fetched = await this.options.fetchRateLimiter.schedule(
+        options?.fetcherRateLimit ?? this.options.fetcherRateLimit,
+        { key, fetcher },
+        fetcher
+      )
+      this.options.circuitBreakerManager.recordSuccess(key)
+      this.options.logger.debug?.('fetch', { key, durationMs: Date.now() - fetchStart })
+    } catch (error) {
+      this.options.recordCircuitFailure(key, options?.circuitBreaker ?? this.options.circuitBreaker, error)
+      throw error
+    }
+
+    if (fetched === null || fetched === undefined) {
+      if (!this.shouldNegativeCache(options)) {
+        return null
+      }
+
+      if (this.options.maintenance.isWriteOutdated(key, expectedClearEpoch, expectedKeyEpoch)) {
+        this.options.logger.debug?.('skip-negative-store-after-invalidation', {
+          key,
+          expectedClearEpoch,
+          clearEpoch: this.options.maintenance.currentClearEpoch(),
+          expectedKeyEpoch,
+          keyEpoch: this.options.maintenance.currentKeyEpoch(key)
+        })
+        return null
+      }
+
+      await this.options.storeEntry(key, 'empty', null, options)
+      return null
+    }
+
+    // Conditional caching: skip storage if shouldCache returns false
+    if (options?.shouldCache) {
+      try {
+        if (!options.shouldCache(fetched)) {
+          return fetched
+        }
+      } catch (error) {
+        this.options.logger.warn?.('shouldCache-error', {
+          key,
+          error: this.options.formatError(error)
+        })
+      }
+    }
+
+    if (this.options.maintenance.isWriteOutdated(key, expectedClearEpoch, expectedKeyEpoch)) {
+      this.options.logger.debug?.('skip-store-after-invalidation', {
+        key,
+        expectedClearEpoch,
+        clearEpoch: this.options.maintenance.currentClearEpoch(),
+        expectedKeyEpoch,
+        keyEpoch: this.options.maintenance.currentKeyEpoch(key)
+      })
+      return fetched
+    }
+
+    await this.options.storeEntry(key, 'value', fetched, options)
+    return fetched
+  }
+
+  runScheduleBackgroundRefresh<T>(key: string, fetcher: () => Promise<T>, options?: CacheGetOptions): void {
+    this.scheduleBackgroundRefresh(key, fetcher, options)
+  }
+
+  private scheduleBackgroundRefresh<T>(key: string, fetcher: () => Promise<T>, options?: CacheGetOptions): void {
+    if (
+      !shouldStartBackgroundRefresh({
+        isDisconnecting: this.options.isDisconnecting(),
+        hasRefreshInFlight: this.backgroundRefreshes.has(key)
+      })
+    ) {
+      return
+    }
+
+    const clearEpoch = this.options.maintenance.currentClearEpoch()
+    const keyEpoch = this.options.maintenance.currentKeyEpoch(key)
+    this.backgroundRefreshAbort.set(key, false)
+    const refresh = (async () => {
+      this.options.metricsCollector.increment('refreshes')
+      try {
+        if (this.backgroundRefreshAbort.get(key)) return
+        await this.runBackgroundRefresh(key, fetcher, options, clearEpoch, keyEpoch)
+      } catch (error) {
+        if (this.backgroundRefreshAbort.get(key)) return
+        this.options.metricsCollector.increment('refreshErrors')
+        this.options.logger.warn?.('background-refresh-error', {
+          key,
+          error: this.options.formatError(error)
+        })
+      } finally {
+        this.backgroundRefreshes.delete(key)
+        this.backgroundRefreshAbort.delete(key)
+      }
+    })()
+
+    this.backgroundRefreshes.set(key, refresh)
+  }
+
+  private async runBackgroundRefresh<T>(
+    key: string,
+    fetcher: () => Promise<T>,
+    options?: CacheGetOptions,
+    expectedClearEpoch?: number,
+    expectedKeyEpoch?: number
+  ): Promise<void> {
+    const timeoutMs = this.options.backgroundRefreshTimeoutMs ?? DEFAULT_BACKGROUND_REFRESH_TIMEOUT_MS
+    await this.fetchWithGuards(
+      key,
+      () =>
+        this.options.withTimeout(fetcher(), timeoutMs, () => {
+          return new Error(`Background refresh timed out after ${timeoutMs}ms for key "${key}".`)
+        }),
+      options,
+      expectedClearEpoch,
+      expectedKeyEpoch
+    )
+  }
+
+  async runApplyFreshReadPolicies<T>(
+    key: string,
+    hit: {
+      found: true
+      value: T | null
+      stored: unknown
+      state: 'fresh' | 'stale-while-revalidate' | 'stale-if-error'
+      layerIndex: number
+      layerName: string
+    },
+    options: CacheGetOptions | undefined,
+    fetcher?: () => Promise<T>
+  ): Promise<void> {
+    return this.applyFreshReadPolicies(key, hit as Extract<ReadHit<T>, { found: true }>, options, fetcher)
+  }
+
+  private async applyFreshReadPolicies<T>(
+    key: string,
+    hit: Extract<ReadHit<T>, { found: true }>,
+    options: CacheGetOptions | undefined,
+    fetcher?: () => Promise<T>
+  ): Promise<void> {
+    const plan = planFreshReadPolicies({
+      stored: hit.stored,
+      hasFetcher: Boolean(fetcher),
+      slidingTtl: options?.slidingTtl ?? false,
+      refreshAheadSeconds:
+        this.options.resolveLayerSeconds(hit.layerName, options?.refreshAhead, this.options.refreshAhead, 0) ?? 0
+    })
+
+    if (plan.refreshedStored) {
+      for (let index = 0; index <= hit.layerIndex; index += 1) {
+        const layer = this.options.layers[index]
+        if (!layer || this.options.shouldSkipLayer(layer)) {
+          continue
+        }
+
+        try {
+          await layer.set(key, plan.refreshedStored, plan.refreshedStoredTtl)
+        } catch (error) {
+          await this.options.handleLayerFailure(layer, 'sliding-ttl', error)
+        }
+      }
+    }
+
+    if (fetcher && plan.shouldScheduleBackgroundRefresh) {
+      this.options.scheduleBackgroundRefreshDispatch(key, fetcher, options)
+    }
+  }
+
+  private resolveSingleFlightOptions(): CacheSingleFlightExecutionOptions {
+    return {
+      leaseMs: this.options.singleFlightLeaseMs ?? DEFAULT_SINGLE_FLIGHT_LEASE_MS,
+      waitTimeoutMs: this.options.singleFlightTimeoutMs ?? DEFAULT_SINGLE_FLIGHT_TIMEOUT_MS,
+      pollIntervalMs: this.options.singleFlightPollMs ?? DEFAULT_SINGLE_FLIGHT_POLL_MS,
+      renewIntervalMs: this.options.singleFlightRenewIntervalMs
+    }
+  }
+
+  private shouldNegativeCache(options?: CacheGetOptions): boolean {
+    return options?.negativeCache ?? this.options.negativeCaching ?? false
+  }
+
+  private isNegativeStoredValue(stored: unknown): boolean {
+    return isStoredValueEnvelope(stored) && stored.kind === 'empty'
+  }
+}

--- a/tests/internal/CacheStackInternals.test.ts
+++ b/tests/internal/CacheStackInternals.test.ts
@@ -819,4 +819,54 @@ describe('CacheStack internals', () => {
     expect(skip).toBe(false)
     expect(map.has('cleanup-layer')).toBe(false)
   })
+
+  it('broadcasts L1 invalidation after mset when broadcastL1Invalidation is true', async () => {
+    const bus = {
+      subscribe: vi.fn(async () => vi.fn()),
+      publish: vi.fn(async () => {})
+    }
+    const cache = new CacheStack([new MemoryLayer({ ttl: 60 })], {
+      invalidationBus: bus,
+      broadcastL1Invalidation: true
+    })
+    await cache.mset([
+      { key: 'a', value: 1 },
+      { key: 'b', value: 2 }
+    ])
+    expect(bus.publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: 'keys',
+        operation: 'write'
+      })
+    )
+  })
+
+  it('withTimeout returns raw value when result is not wrapped in {kind, value}', async () => {
+    const cache = new CacheStack([new MemoryLayer({ ttl: 60 })])
+    const withTimeout = (
+      cache as unknown as {
+        withTimeout: <T>(promise: Promise<T>, timeoutMs: number, onTimeout: () => Error) => Promise<T>
+      }
+    ).withTimeout.bind(cache)
+
+    const result = await withTimeout(Promise.resolve(42), 1000, () => new Error('timeout'))
+    expect(result).toBe(42)
+  })
+
+  it('scheduleBackgroundRefresh delegates to reader', async () => {
+    const cache = new CacheStack([new MemoryLayer({ ttl: 60 })])
+    const scheduleSpy = vi.fn()
+    ;(
+      cache as unknown as {
+        reader: { runScheduleBackgroundRefresh: (...args: unknown[]) => void }
+      }
+    ).reader.runScheduleBackgroundRefresh = scheduleSpy
+    ;(
+      cache as unknown as {
+        scheduleBackgroundRefresh: (key: string, fetcher: () => Promise<string>, options?: unknown) => void
+      }
+    ).scheduleBackgroundRefresh('key1', async () => 'val', { ttl: 30 })
+
+    expect(scheduleSpy).toHaveBeenCalledWith('key1', expect.any(Function), { ttl: 30 })
+  })
 })

--- a/tests/internal/CacheStackLayerWriter.test.ts
+++ b/tests/internal/CacheStackLayerWriter.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it, vi } from 'vitest'
+import { CacheStackLayerWriter } from '../../src/internal/CacheStackLayerWriter'
+import { CacheStackMaintenance } from '../../src/internal/CacheStackMaintenance'
+import type { CacheLayer, CacheLayerSetManyEntry, LayerTtlMap } from '../../src/types'
+
+function createMockLayer(name: string, overrides: Partial<CacheLayer> = {}): CacheLayer {
+  return {
+    name,
+    isLocal: true,
+    get: vi.fn(async () => null),
+    set: vi.fn(async () => {}),
+    delete: vi.fn(async () => {}),
+    clear: vi.fn(async () => {}),
+    ...overrides
+  }
+}
+
+function createWriterOptions(overrides: Partial<Parameters<typeof CacheStackLayerWriter>[0]> = {}) {
+  const maintenance = new CacheStackMaintenance()
+  return {
+    layers: [] as CacheLayer[],
+    maintenance,
+    shouldSkipLayer: vi.fn(() => false),
+    shouldWriteBehind: vi.fn(() => false),
+    handleLayerFailure: vi.fn(async () => {}),
+    enqueueWriteBehind: vi.fn(async (op: () => Promise<void>) => {
+      await op()
+    }),
+    resolveFreshTtl: vi.fn(() => 60),
+    resolveLayerSeconds: vi.fn(() => undefined),
+    globalStaleWhileRevalidate: undefined as number | LayerTtlMap | undefined,
+    globalStaleIfError: undefined as number | LayerTtlMap | undefined,
+    writePolicy: undefined as 'strict' | 'best-effort' | undefined,
+    onWriteFailures: vi.fn(),
+    ...overrides
+  }
+}
+
+describe('CacheStackLayerWriter', () => {
+  describe('writeAcrossLayers', () => {
+    it('writes to all layers, skips degraded, delegates to write-behind for non-local layers', async () => {
+      const localLayer = createMockLayer('local', { isLocal: true })
+      const remoteLayer = createMockLayer('remote', { isLocal: false })
+      const degradedLayer = createMockLayer('degraded')
+
+      const options = createWriterOptions({
+        layers: [localLayer, remoteLayer, degradedLayer],
+        shouldSkipLayer: vi.fn((layer) => layer.name === 'degraded'),
+        shouldWriteBehind: vi.fn((layer) => !layer.isLocal),
+        enqueueWriteBehind: vi.fn(async (op) => {
+          await op()
+        })
+      })
+
+      const writer = new CacheStackLayerWriter(options)
+      await writer.writeAcrossLayers('key1', 'value', { data: true })
+
+      expect(localLayer.set).toHaveBeenCalledTimes(1)
+      expect(remoteLayer.set).toHaveBeenCalledTimes(1)
+      expect(degradedLayer.set).not.toHaveBeenCalled()
+      expect(options.enqueueWriteBehind).toHaveBeenCalledTimes(1)
+      expect(options.shouldWriteBehind).toHaveBeenCalledWith(remoteLayer)
+    })
+  })
+
+  describe('writeBatch', () => {
+    it('uses layer.setMany() when available', async () => {
+      const setManyMock = vi.fn(async (_entries: CacheLayerSetManyEntry[]) => {})
+      const layer = createMockLayer('bulk-layer', { setMany: setManyMock })
+
+      const options = createWriterOptions({ layers: [layer] })
+      const writer = new CacheStackLayerWriter(options)
+
+      await writer.writeBatch([
+        { key: 'a', value: 1 },
+        { key: 'b', value: 2 }
+      ])
+
+      expect(setManyMock).toHaveBeenCalledTimes(1)
+      const entries = setManyMock.mock.calls[0][0] as CacheLayerSetManyEntry[]
+      expect(entries).toHaveLength(2)
+      expect(entries.map((e: CacheLayerSetManyEntry) => e.key)).toEqual(['a', 'b'])
+      expect(layer.set).not.toHaveBeenCalled()
+    })
+
+    it('skips operation when clear epoch changes mid-write (line 109)', async () => {
+      const layer = createMockLayer('test-layer')
+      const maintenance = new CacheStackMaintenance()
+
+      const options = createWriterOptions({
+        layers: [layer],
+        maintenance
+      })
+      const writer = new CacheStackLayerWriter(options)
+
+      const originalSet = layer.set as ReturnType<typeof vi.fn>
+      originalSet.mockImplementation(async () => {
+        maintenance.beginClearEpoch()
+      })
+
+      await writer.writeBatch([{ key: 'a', value: 1 }])
+
+      expect(originalSet).toHaveBeenCalled()
+    })
+
+    it('skips operation when key epoch changes making activeEntries empty (line 115)', async () => {
+      const layer = createMockLayer('epoch-layer')
+      const maintenance = new CacheStackMaintenance()
+      const deferredOps: Array<() => Promise<void>> = []
+
+      maintenance.bumpKeyEpochs(['x', 'y'])
+
+      const options = createWriterOptions({
+        layers: [layer],
+        maintenance,
+        shouldWriteBehind: vi.fn(() => true),
+        enqueueWriteBehind: vi.fn(async (op) => {
+          deferredOps.push(op)
+        })
+      })
+      const writer = new CacheStackLayerWriter(options)
+
+      await writer.writeBatch([
+        { key: 'x', value: 1 },
+        { key: 'y', value: 2 }
+      ])
+
+      maintenance.bumpKeyEpochs(['x', 'y'])
+
+      expect(deferredOps).toHaveLength(1)
+      await deferredOps[0]()
+
+      expect(layer.set).not.toHaveBeenCalled()
+    })
+
+    it('defers to write-behind queue for non-local layers (line 130)', async () => {
+      const localLayer = createMockLayer('local-layer', { isLocal: true })
+      const remoteLayer = createMockLayer('remote-layer', { isLocal: false })
+      const writeBehindOps: Array<() => Promise<void>> = []
+
+      const options = createWriterOptions({
+        layers: [localLayer, remoteLayer],
+        shouldWriteBehind: vi.fn((layer) => layer.name === 'remote-layer'),
+        enqueueWriteBehind: vi.fn(async (op) => {
+          writeBehindOps.push(op)
+        })
+      })
+      const writer = new CacheStackLayerWriter(options)
+
+      await writer.writeBatch([{ key: 'a', value: 1 }])
+
+      expect(localLayer.set).toHaveBeenCalledTimes(1)
+      expect(options.enqueueWriteBehind).toHaveBeenCalledTimes(1)
+      expect(remoteLayer.set).not.toHaveBeenCalled()
+
+      expect(writeBehindOps).toHaveLength(1)
+      await writeBehindOps[0]()
+      expect(remoteLayer.set).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('executeLayerOperations - best-effort mode', () => {
+    it('handles partial failure with onWriteFailures called and no throw', async () => {
+      const failLayer = createMockLayer('fail-layer', {
+        set: vi.fn(async () => {
+          throw new Error('layer down')
+        })
+      })
+      const okLayer = createMockLayer('ok-layer')
+
+      const options = createWriterOptions({
+        layers: [failLayer, okLayer],
+        writePolicy: 'best-effort',
+        handleLayerFailure: vi.fn(async (_layer: CacheLayer, _op: string, error: unknown) => {
+          throw error
+        })
+      })
+      const writer = new CacheStackLayerWriter(options)
+
+      await writer.writeAcrossLayers('key1', 'value', 'data')
+      expect(options.onWriteFailures).toHaveBeenCalledWith({ key: 'key1', action: 'set' }, [expect.any(Error)])
+    })
+
+    it('throws AggregateError when all layers fail (line 164-168)', async () => {
+      const failLayer1 = createMockLayer('fail1', {
+        set: vi.fn(async () => {
+          throw new Error('fail1')
+        })
+      })
+      const failLayer2 = createMockLayer('fail2', {
+        set: vi.fn(async () => {
+          throw new Error('fail2')
+        })
+      })
+
+      const options = createWriterOptions({
+        layers: [failLayer1, failLayer2],
+        writePolicy: 'best-effort',
+        handleLayerFailure: vi.fn(async (_layer: CacheLayer, _op: string, error: unknown) => {
+          throw error
+        })
+      })
+      const writer = new CacheStackLayerWriter(options)
+
+      await expect(writer.writeAcrossLayers('key1', 'value', 'data')).rejects.toThrow(AggregateError)
+
+      expect(options.onWriteFailures).toHaveBeenCalled()
+    })
+  })
+
+  describe('executeLayerOperations - strict mode', () => {
+    it('propagates failures immediately without Promise.allSettled', async () => {
+      const failLayer = createMockLayer('fail-strict', {
+        set: vi.fn(async () => {
+          throw new Error('strict fail')
+        })
+      })
+      const okLayer = createMockLayer('ok-strict')
+
+      const options = createWriterOptions({
+        layers: [failLayer, okLayer],
+        writePolicy: 'strict',
+        handleLayerFailure: vi.fn(async (_layer: CacheLayer, _op: string, error: unknown) => {
+          throw error
+        })
+      })
+      const writer = new CacheStackLayerWriter(options)
+
+      // Strict mode: error propagates immediately, onWriteFailures not called
+      await expect(writer.writeAcrossLayers('key1', 'value', 'data')).rejects.toThrow('strict fail')
+
+      expect(options.onWriteFailures).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/tests/internal/CacheStackReader.test.ts
+++ b/tests/internal/CacheStackReader.test.ts
@@ -1,0 +1,863 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { CacheWriteKind } from '../../src/internal/CacheStackLayerWriter'
+import { CacheStackMaintenance } from '../../src/internal/CacheStackMaintenance'
+import { CacheStackReader } from '../../src/internal/CacheStackReader'
+import { CircuitBreakerManager } from '../../src/internal/CircuitBreakerManager'
+import { FetchRateLimiter } from '../../src/internal/FetchRateLimiter'
+import { MetricsCollector } from '../../src/internal/MetricsCollector'
+import { createStoredValueEnvelope } from '../../src/internal/StoredValue'
+import { TtlResolver } from '../../src/internal/TtlResolver'
+import { TagIndex } from '../../src/invalidation/TagIndex'
+import { StampedeGuard } from '../../src/stampede/StampedeGuard'
+import type { CacheGetOptions, CacheLayer } from '../../src/types'
+
+// --- Mock helpers ---
+
+function createMockLayer(name: string, overrides: Partial<CacheLayer> = {}): CacheLayer {
+  return {
+    name,
+    get: vi.fn(async () => null),
+    set: vi.fn(async () => {}),
+    delete: vi.fn(async () => {}),
+    clear: vi.fn(async () => {}),
+    isLocal: true,
+    ...overrides
+  }
+}
+
+interface MockOptions {
+  layers: CacheLayer[]
+  metricsCollector: MetricsCollector
+  maintenance: CacheStackMaintenance
+  tagIndex: TagIndex
+  circuitBreakerManager: CircuitBreakerManager
+  fetchRateLimiter: FetchRateLimiter
+  stampedeGuard: StampedeGuard
+  ttlResolver: TtlResolver
+  logger: {
+    debug: ReturnType<typeof vi.fn>
+    info: ReturnType<typeof vi.fn>
+    warn: ReturnType<typeof vi.fn>
+    error: ReturnType<typeof vi.fn>
+  }
+  shouldSkipLayer: ReturnType<typeof vi.fn>
+  handleLayerFailure: ReturnType<typeof vi.fn>
+  emit: ReturnType<typeof vi.fn>
+  emitError: ReturnType<typeof vi.fn>
+  formatError: ReturnType<typeof vi.fn>
+  storeEntry: ReturnType<typeof vi.fn>
+  recordCircuitFailure: ReturnType<typeof vi.fn>
+  resolveLayerSeconds: ReturnType<typeof vi.fn>
+  sleep: ReturnType<typeof vi.fn>
+  withTimeout: ReturnType<typeof vi.fn>
+  isDisconnecting: ReturnType<typeof vi.fn>
+  isGracefulDegradationEnabled: ReturnType<typeof vi.fn>
+  scheduleBackgroundRefreshDispatch: ReturnType<typeof vi.fn>
+  stampedePrevention?: boolean
+  singleFlightCoordinator?: unknown
+  singleFlightLeaseMs?: number
+  singleFlightTimeoutMs?: number
+  singleFlightPollMs?: number
+  singleFlightRenewIntervalMs?: number
+  backgroundRefreshTimeoutMs?: number
+  negativeCaching?: boolean
+  refreshAhead?: number
+  circuitBreaker?: unknown
+  fetcherRateLimit?: unknown
+}
+
+function createMockOptions(overrides: Partial<MockOptions> = {}): MockOptions {
+  return {
+    layers: [],
+    metricsCollector: new MetricsCollector(),
+    maintenance: new CacheStackMaintenance(),
+    tagIndex: new TagIndex(),
+    circuitBreakerManager: new CircuitBreakerManager({ maxEntries: 100 }),
+    fetchRateLimiter: new FetchRateLimiter(),
+    stampedeGuard: new StampedeGuard(),
+    ttlResolver: new TtlResolver({ maxProfileEntries: 100 }),
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    shouldSkipLayer: vi.fn(() => false),
+    handleLayerFailure: vi.fn(async () => null),
+    emit: vi.fn(() => true),
+    emitError: vi.fn(),
+    formatError: vi.fn((e: unknown) => String(e)),
+    storeEntry: vi.fn(async () => {}),
+    recordCircuitFailure: vi.fn(),
+    resolveLayerSeconds: vi.fn(() => undefined),
+    sleep: vi.fn(async () => {}),
+    withTimeout: vi.fn(async <T>(promise: Promise<T>) => promise),
+    isDisconnecting: vi.fn(() => false),
+    isGracefulDegradationEnabled: vi.fn(() => false),
+    scheduleBackgroundRefreshDispatch: vi.fn(),
+    ...overrides
+  }
+}
+
+function createReader(overrides: Partial<MockOptions> = {}): {
+  reader: CacheStackReader
+  options: MockOptions
+} {
+  const options = createMockOptions(overrides)
+  const reader = new CacheStackReader(options as unknown as ConstructorParameters<typeof CacheStackReader>[0])
+  return { reader, options }
+}
+
+describe('CacheStackReader', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // --- readLayerEntry ---
+
+  describe('readLayerEntry', () => {
+    it('returns null when layer is skipped', async () => {
+      const { reader, options } = createReader()
+      const layer = createMockLayer('L1')
+      options.shouldSkipLayer.mockReturnValue(true)
+
+      const result = await reader.readLayerEntry(layer, 'key:1')
+      expect(result).toBeNull()
+      expect(layer.get).not.toHaveBeenCalled()
+    })
+
+    it('returns raw value when layer has no getEntry (uses get)', async () => {
+      const { reader } = createReader()
+      const layer = createMockLayer('L1', {
+        get: vi.fn(async () => 'plain-value')
+      })
+
+      const result = await reader.readLayerEntry(layer, 'key:1')
+      expect(result).toBe('plain-value')
+    })
+
+    it('returns getEntry value when available', async () => {
+      const { reader } = createReader()
+      const envelope = createStoredValueEnvelope({
+        kind: 'value',
+        value: 'envelope-value',
+        freshTtlSeconds: 60
+      })
+      const layer = createMockLayer('L1', {
+        getEntry: vi.fn(async () => envelope)
+      })
+
+      const result = await reader.readLayerEntry(layer, 'key:1')
+      expect(result).toBe(envelope)
+      expect(layer.get).not.toHaveBeenCalled()
+    })
+
+    it('calls handleLayerFailure and returns null on read error', async () => {
+      const { reader, options } = createReader()
+      const error = new Error('read fail')
+      const layer = createMockLayer('L1', {
+        get: vi.fn(async () => {
+          throw error
+        })
+      })
+
+      const result = await reader.readLayerEntry(layer, 'key:1')
+      expect(result).toBeNull()
+      expect(options.handleLayerFailure).toHaveBeenCalledWith(layer, 'read', error)
+    })
+  })
+
+  // --- backfill ---
+
+  describe('backfill', () => {
+    it('does nothing when upToIndex < 0', async () => {
+      const { reader, options } = createReader()
+      const layer = createMockLayer('L1')
+      options.layers = [layer]
+
+      await reader.backfill('key:1', 'stored', -1)
+      expect(layer.set).not.toHaveBeenCalled()
+    })
+
+    it('skips degraded layers', async () => {
+      const { reader, options } = createReader()
+      const layer0 = createMockLayer('L0')
+      const layer1 = createMockLayer('L1')
+      options.layers = [layer0, layer1]
+      options.shouldSkipLayer.mockImplementation((l: CacheLayer) => l.name === 'L0')
+
+      await reader.backfill('key:1', 'stored', 1)
+      expect(layer0.set).not.toHaveBeenCalled()
+      expect(layer1.set).toHaveBeenCalledWith('key:1', 'stored', undefined)
+    })
+
+    it('sets value on each layer from 0 to upToIndex', async () => {
+      const { reader, options } = createReader()
+      const layer0 = createMockLayer('L0')
+      const layer1 = createMockLayer('L1')
+      const layer2 = createMockLayer('L2')
+      options.layers = [layer0, layer1, layer2]
+      options.resolveLayerSeconds.mockReturnValue(60)
+
+      await reader.backfill('key:1', 'stored', 1)
+      expect(layer0.set).toHaveBeenCalledWith('key:1', 'stored', 60)
+      expect(layer1.set).toHaveBeenCalledWith('key:1', 'stored', 60)
+      expect(layer2.set).not.toHaveBeenCalled()
+    })
+
+    it('handles layer.set error gracefully (calls handleLayerFailure)', async () => {
+      const { reader, options } = createReader()
+      const error = new Error('set fail')
+      const layer0 = createMockLayer('L0', {
+        set: vi.fn(async () => {
+          throw error
+        })
+      })
+      const layer1 = createMockLayer('L1')
+      options.layers = [layer0, layer1]
+      options.resolveLayerSeconds.mockReturnValue(60)
+
+      await reader.backfill('key:1', 'stored', 1)
+      expect(options.handleLayerFailure).toHaveBeenCalledWith(layer0, 'backfill', error)
+      expect(layer1.set).toHaveBeenCalled()
+    })
+
+    it('increments backfill metrics and emits backfill event per layer', async () => {
+      const { reader, options } = createReader()
+      const layer0 = createMockLayer('L0')
+      options.layers = [layer0]
+      options.resolveLayerSeconds.mockReturnValue(30)
+
+      await reader.backfill('key:1', 'stored', 0)
+      expect(options.metricsCollector.snapshot.backfills).toBe(1)
+      expect(options.emit).toHaveBeenCalledWith('backfill', { key: 'key:1', layer: 'L0' })
+    })
+  })
+
+  // --- readFromLayers (tested via getPrepared which calls it) ---
+
+  describe('readFromLayers', () => {
+    it('returns miss when all layers return null', async () => {
+      const { reader, options } = createReader()
+      options.layers = [createMockLayer('L0'), createMockLayer('L1')]
+
+      const result = await reader.getPrepared('key:1')
+      expect(result).toBeNull()
+      expect(options.metricsCollector.snapshot.misses).toBe(1)
+    })
+
+    it('returns fresh hit from first layer with value', async () => {
+      const { reader, options } = createReader()
+      const envelope = createStoredValueEnvelope({
+        kind: 'value',
+        value: 'hello',
+        freshTtlSeconds: 60
+      })
+      options.layers = [createMockLayer('L0', { get: vi.fn(async () => envelope) }), createMockLayer('L1')]
+
+      const result = await reader.getPrepared('key:1')
+      expect(result).toBe('hello')
+      expect(options.metricsCollector.snapshot.hits).toBe(1)
+    })
+
+    it('falls through to second layer on miss from first', async () => {
+      const { reader, options } = createReader()
+      const envelope = createStoredValueEnvelope({
+        kind: 'value',
+        value: 'from-L1',
+        freshTtlSeconds: 60
+      })
+      options.layers = [
+        createMockLayer('L0', { get: vi.fn(async () => null) }),
+        createMockLayer('L1', { get: vi.fn(async () => envelope) })
+      ]
+
+      const result = await reader.getPrepared('key:1')
+      expect(result).toBe('from-L1')
+      expect(options.metricsCollector.snapshot.hits).toBe(1)
+    })
+
+    it('skips expired values (deletes them)', async () => {
+      const { reader, options } = createReader()
+      const expired = createStoredValueEnvelope({
+        kind: 'value',
+        value: 'old',
+        freshTtlSeconds: 1,
+        staleWhileRevalidateSeconds: 1,
+        staleIfErrorSeconds: 1,
+        now: Date.now() - 5_000
+      })
+      options.layers = [createMockLayer('L0', { get: vi.fn(async () => expired) })]
+
+      const result = await reader.getPrepared('key:1')
+      expect(result).toBeNull()
+      expect(options.metricsCollector.snapshot.misses).toBe(1)
+    })
+
+    it('removes tag index entry when no retainable value found', async () => {
+      const { reader, options } = createReader()
+      const expired = createStoredValueEnvelope({
+        kind: 'value',
+        value: 'expired',
+        freshTtlSeconds: 1,
+        staleWhileRevalidateSeconds: 1,
+        staleIfErrorSeconds: 1,
+        now: Date.now() - 5_000
+      })
+      const removeSpy = vi.spyOn(options.tagIndex, 'remove')
+      options.layers = [createMockLayer('L0', { get: vi.fn(async () => expired) })]
+
+      await reader.getPrepared('key:1')
+      expect(removeSpy).toHaveBeenCalledWith('key:1')
+    })
+
+    it('records latency per layer', async () => {
+      const { reader, options } = createReader()
+      options.layers = [
+        createMockLayer('L0', { get: vi.fn(async () => null) }),
+        createMockLayer('L1', { get: vi.fn(async () => 'hit') })
+      ]
+
+      await reader.getPrepared('key:1')
+      const snapshot = options.metricsCollector.snapshot
+      expect(snapshot.latencyByLayer.L0).toBeDefined()
+      expect(snapshot.latencyByLayer.L0.count).toBe(1)
+      expect(snapshot.latencyByLayer.L1.count).toBe(1)
+    })
+  })
+
+  // --- getPrepared — fresh hit path ---
+
+  describe('getPrepared — fresh hit path', () => {
+    it('returns cached value on fresh hit, increments hits', async () => {
+      const { reader, options } = createReader()
+      const envelope = createStoredValueEnvelope({
+        kind: 'value',
+        value: 42,
+        freshTtlSeconds: 60
+      })
+      options.layers = [createMockLayer('L0', { get: vi.fn(async () => envelope) })]
+
+      const result = await reader.getPrepared('key:1')
+      expect(result).toBe(42)
+      expect(options.metricsCollector.snapshot.hits).toBe(1)
+    })
+
+    it('records access via ttlResolver', async () => {
+      const { reader, options } = createReader()
+      const envelope = createStoredValueEnvelope({
+        kind: 'value',
+        value: 'data',
+        freshTtlSeconds: 60
+      })
+      options.layers = [createMockLayer('L0', { get: vi.fn(async () => envelope) })]
+      const spy = vi.spyOn(options.ttlResolver, 'recordAccess')
+
+      await reader.getPrepared('key:1')
+      expect(spy).toHaveBeenCalledWith('key:1')
+    })
+
+    it('applies fresh read policies (sliding TTL)', async () => {
+      const { reader, options } = createReader()
+      const envelope = createStoredValueEnvelope({
+        kind: 'value',
+        value: 'sliding',
+        freshTtlSeconds: 60
+      })
+      const layer = createMockLayer('L0', { get: vi.fn(async () => envelope) })
+      options.layers = [layer]
+
+      await reader.getPrepared<string>('key:1', undefined, { slidingTtl: true })
+      // Sliding TTL writes refreshed envelope back to layers up to hit index
+      expect(layer.set).toHaveBeenCalled()
+    })
+  })
+
+  // --- getPrepared — stale paths ---
+
+  describe('getPrepared — stale paths', () => {
+    it('stale-while-revalidate: returns value, schedules background refresh if fetcher exists', async () => {
+      const { reader, options } = createReader()
+      const stale = createStoredValueEnvelope({
+        kind: 'value',
+        value: 'stale-data',
+        freshTtlSeconds: 1,
+        staleWhileRevalidateSeconds: 60,
+        now: Date.now() - 2_000
+      })
+      options.layers = [createMockLayer('L0', { get: vi.fn(async () => stale) })]
+      const fetcher = vi.fn(async () => 'fresh-data')
+
+      const result = await reader.getPrepared('key:1', fetcher)
+      expect(result).toBe('stale-data')
+      expect(options.metricsCollector.snapshot.hits).toBe(1)
+      expect(options.metricsCollector.snapshot.staleHits).toBe(1)
+      expect(options.emit).toHaveBeenCalledWith('stale-serve', expect.objectContaining({ key: 'key:1' }))
+    })
+
+    it('stale-while-revalidate without fetcher: returns value, no refresh', async () => {
+      const { reader, options } = createReader()
+      const stale = createStoredValueEnvelope({
+        kind: 'value',
+        value: 'stale-no-fetcher',
+        freshTtlSeconds: 1,
+        staleWhileRevalidateSeconds: 60,
+        now: Date.now() - 2_000
+      })
+      options.layers = [createMockLayer('L0', { get: vi.fn(async () => stale) })]
+
+      const result = await reader.getPrepared('key:1')
+      expect(result).toBe('stale-no-fetcher')
+      expect(options.metricsCollector.snapshot.staleHits).toBe(1)
+    })
+
+    it('stale-if-error with fetcher: fetches new value, returns it on success', async () => {
+      const { reader, options } = createReader()
+      const staleIfError = createStoredValueEnvelope({
+        kind: 'value',
+        value: 'stale-for-error',
+        freshTtlSeconds: 1,
+        staleIfErrorSeconds: 300,
+        now: Date.now() - 2_000
+      })
+      // staleWhileRevalidateSeconds also needed so that staleUntil < now but errorUntil > now
+      options.layers = [createMockLayer('L0', { get: vi.fn(async () => staleIfError) })]
+      const fetcher = vi.fn(async () => 'new-value')
+      options.storeEntry = vi.fn(async () => {})
+
+      const result = await reader.getPrepared('key:1', fetcher)
+      expect(result).toBe('new-value')
+    })
+
+    it('stale-if-error with fetcher error: returns stale value, logs error', async () => {
+      const { reader, options } = createReader()
+      const staleIfError = createStoredValueEnvelope({
+        kind: 'value',
+        value: 'stale-safe',
+        freshTtlSeconds: 1,
+        staleIfErrorSeconds: 300,
+        now: Date.now() - 2_000
+      })
+      options.layers = [createMockLayer('L0', { get: vi.fn(async () => staleIfError) })]
+      const fetcher = vi.fn(async () => {
+        throw new Error('fetch fail')
+      })
+
+      const result = await reader.getPrepared('key:1', fetcher)
+      expect(result).toBe('stale-safe')
+      expect(options.metricsCollector.snapshot.refreshErrors).toBe(1)
+      expect(options.logger.debug).toHaveBeenCalledWith('stale-if-error', expect.objectContaining({ key: 'key:1' }))
+    })
+  })
+
+  // --- getPrepared — miss path ---
+
+  describe('getPrepared — miss path', () => {
+    it('returns null on miss without fetcher', async () => {
+      const { reader, options } = createReader()
+      options.layers = [createMockLayer('L0')]
+
+      const result = await reader.getPrepared('key:1')
+      expect(result).toBeNull()
+      expect(options.metricsCollector.snapshot.misses).toBe(1)
+    })
+
+    it('fetches and stores value on miss with fetcher', async () => {
+      const { reader, options } = createReader()
+      options.layers = [createMockLayer('L0')]
+      const fetcher = vi.fn(async () => 'fetched')
+      options.storeEntry = vi.fn(async () => {})
+
+      const result = await reader.getPrepared('key:1', fetcher)
+      expect(result).toBe('fetched')
+      expect(options.storeEntry).toHaveBeenCalledWith('key:1', 'value', 'fetched', undefined)
+    })
+
+    it('increments misses metric on miss', async () => {
+      const { reader, options } = createReader()
+      options.layers = [createMockLayer('L0')]
+
+      await reader.getPrepared('key:1')
+      expect(options.metricsCollector.snapshot.misses).toBe(1)
+    })
+  })
+
+  // --- fetchAndPopulate (tested via getPrepared miss + fetcher) ---
+
+  describe('fetchAndPopulate', () => {
+    it('successful fetch stores value via storeEntry callback', async () => {
+      const { reader, options } = createReader()
+      options.layers = [createMockLayer('L0')]
+      options.storeEntry = vi.fn(async () => {})
+      const fetcher = vi.fn(async () => ({ name: 'test' }))
+
+      const result = await reader.getPrepared('key:1', fetcher)
+      expect(result).toEqual({ name: 'test' })
+      expect(options.storeEntry).toHaveBeenCalledWith('key:1', 'value', { name: 'test' }, undefined)
+    })
+
+    it('null fetch result returns null without negative caching', async () => {
+      const { reader, options } = createReader()
+      options.layers = [createMockLayer('L0')]
+      options.storeEntry = vi.fn(async () => {})
+      const fetcher = vi.fn(async () => null)
+
+      const result = await reader.getPrepared('key:1', fetcher)
+      expect(result).toBeNull()
+      expect(options.storeEntry).not.toHaveBeenCalled()
+    })
+
+    it('null fetch result stores empty with negative caching enabled', async () => {
+      const { reader, options } = createReader()
+      options.layers = [createMockLayer('L0')]
+      options.negativeCaching = true
+      options.storeEntry = vi.fn(async () => {})
+      const fetcher = vi.fn(async () => null)
+
+      const result = await reader.getPrepared('key:1', fetcher)
+      expect(result).toBeNull()
+      expect(options.storeEntry).toHaveBeenCalledWith('key:1', 'empty', null, undefined)
+    })
+
+    it('shouldCache returning false skips storage but returns value', async () => {
+      const { reader, options } = createReader()
+      options.layers = [createMockLayer('L0')]
+      options.storeEntry = vi.fn(async () => {})
+      const fetcher = vi.fn(async () => 'value')
+
+      const result = await reader.getPrepared('key:1', fetcher, {
+        shouldCache: () => false
+      })
+      expect(result).toBe('value')
+      expect(options.storeEntry).not.toHaveBeenCalled()
+    })
+
+    it('shouldCache error logs warning but continues', async () => {
+      const { reader, options } = createReader()
+      options.layers = [createMockLayer('L0')]
+      options.storeEntry = vi.fn(async () => {})
+      const fetcher = vi.fn(async () => 'value')
+      const shouldCacheError = new Error('predicate fail')
+
+      const result = await reader.getPrepared('key:1', fetcher, {
+        shouldCache: () => {
+          throw shouldCacheError
+        }
+      })
+      expect(result).toBe('value')
+      expect(options.storeEntry).toHaveBeenCalledWith('key:1', 'value', 'value', expect.anything())
+      expect(options.logger.warn).toHaveBeenCalledWith('shouldCache-error', expect.objectContaining({ key: 'key:1' }))
+    })
+  })
+
+  // --- fetchWithGuards ---
+
+  describe('fetchWithGuards', () => {
+    it('rechecks layers for fresh value before fetching', async () => {
+      const { reader, options } = createReader()
+      const freshEnvelope = createStoredValueEnvelope({
+        kind: 'value',
+        value: 'recheck-hit',
+        freshTtlSeconds: 60
+      })
+      const layer = createMockLayer('L0', {
+        get: vi
+          .fn(async () => null)
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce(freshEnvelope)
+      })
+      options.layers = [layer]
+      const fetcher = vi.fn(async () => 'fresh-fetched')
+
+      const result = await reader.getPrepared('key:1', fetcher)
+      // The recheck found a fresh value, so the fetcher doesn't run
+      expect(result).toBe('recheck-hit')
+    })
+
+    it('uses stampedeGuard for deduplication', async () => {
+      const { reader, options } = createReader()
+      options.layers = [createMockLayer('L0')]
+      const spy = vi.spyOn(options.stampedeGuard, 'execute')
+      options.storeEntry = vi.fn(async () => {})
+      const fetcher = vi.fn(async () => 'data')
+
+      await reader.getPrepared('key:1', fetcher)
+      expect(spy).toHaveBeenCalledWith('key:1', expect.any(Function))
+    })
+
+    it('falls back to direct fetch when stampedePrevention is false', async () => {
+      const { reader, options } = createReader()
+      options.layers = [createMockLayer('L0')]
+      options.stampedePrevention = false
+      const spy = vi.spyOn(options.stampedeGuard, 'execute')
+      options.storeEntry = vi.fn(async () => {})
+      const fetcher = vi.fn(async () => 'direct')
+
+      await reader.getPrepared('key:1', fetcher)
+      expect(spy).not.toHaveBeenCalled()
+    })
+
+    it('graceful degradation on single-flight coordinator failure', async () => {
+      const { reader, options } = createReader()
+      options.layers = [createMockLayer('L0')]
+      options.isGracefulDegradationEnabled.mockReturnValue(true)
+      options.singleFlightCoordinator = {
+        execute: vi.fn(async () => {
+          throw new Error('coordinator fail')
+        })
+      }
+      options.storeEntry = vi.fn(async () => {})
+      const fetcher = vi.fn(async () => 'degraded-result')
+
+      const result = await reader.getPrepared('key:1', fetcher)
+      expect(result).toBe('degraded-result')
+      expect(options.metricsCollector.snapshot.degradedOperations).toBe(1)
+      expect(options.emitError).toHaveBeenCalledWith(
+        'single-flight',
+        expect.objectContaining({ key: 'key:1', degraded: true })
+      )
+    })
+  })
+
+  // --- waitForFreshValue ---
+
+  describe('waitForFreshValue', () => {
+    it('polls and returns when fresh value appears', async () => {
+      const { reader, options } = createReader()
+      const freshEnvelope = createStoredValueEnvelope({
+        kind: 'value',
+        value: 'polled-fresh',
+        freshTtlSeconds: 60
+      })
+      const layer = createMockLayer('L0', {
+        get: vi
+          .fn()
+          .mockResolvedValueOnce(null) // initial miss in getPrepared
+          .mockResolvedValueOnce(null) // first readFromLayers (miss) in fetchWithGuards
+          .mockResolvedValueOnce(null) // fresh-only recheck (miss)
+          .mockResolvedValueOnce(null) // waitForFreshValue poll 1
+          .mockResolvedValue(freshEnvelope) // waitForFreshValue poll 2
+      })
+      options.layers = [layer]
+      options.singleFlightCoordinator = {
+        execute: vi.fn(
+          async (
+            _key: string,
+            _opts: unknown,
+            worker: () => Promise<string | null>,
+            waiter: () => Promise<string | null>
+          ) => {
+            return waiter()
+          }
+        )
+      }
+      options.singleFlightTimeoutMs = 5_000
+      options.singleFlightPollMs = 10
+
+      const fetcher = vi.fn(async () => 'fetched')
+      const result = await reader.getPrepared('key:1', fetcher)
+      expect(result).toBe('polled-fresh')
+      expect(options.metricsCollector.snapshot.singleFlightWaits).toBeGreaterThanOrEqual(1)
+    })
+
+    it('falls back to fetchAndPopulate on timeout', async () => {
+      vi.useFakeTimers()
+      const { reader, options } = createReader()
+      const layer = createMockLayer('L0', {
+        get: vi.fn(async () => null)
+      })
+      options.layers = [layer]
+      options.singleFlightCoordinator = {
+        execute: vi.fn(
+          async (
+            _key: string,
+            _opts: unknown,
+            worker: () => Promise<string | null>,
+            waiter: () => Promise<string | null>
+          ) => {
+            return waiter()
+          }
+        )
+      }
+      options.singleFlightTimeoutMs = 100
+      options.singleFlightPollMs = 50
+      options.sleep = vi.fn(async (ms: number) => {
+        vi.advanceTimersByTime(ms)
+      })
+      options.storeEntry = vi.fn(async () => {})
+      const fetcher = vi.fn(async () => 'timeout-fetch')
+
+      const result = await reader.getPrepared('key:1', fetcher)
+      expect(result).toBe('timeout-fetch')
+    })
+  })
+
+  // --- Background refresh management ---
+
+  describe('background refresh management', () => {
+    it('activeRefreshCount tracks in-flight refreshes', () => {
+      const { reader, options } = createReader()
+      expect(reader.activeRefreshCount).toBe(0)
+
+      const stale = createStoredValueEnvelope({
+        kind: 'value',
+        value: 'v',
+        freshTtlSeconds: 1,
+        staleWhileRevalidateSeconds: 60,
+        now: Date.now() - 2_000
+      })
+      options.layers = [createMockLayer('L0', { get: vi.fn(async () => stale) })]
+      const fetcher = vi.fn(async () => {
+        // Keep the refresh in-flight long enough to observe
+        await new Promise((r) => setTimeout(r, 100))
+        return 'refreshed'
+      })
+
+      reader.runScheduleBackgroundRefresh('key:1', fetcher)
+      expect(reader.activeRefreshCount).toBe(1)
+    })
+
+    it('abortAllRefreshes sets abort flags', async () => {
+      const { reader, options } = createReader()
+      const fetcher = vi.fn(async () => {
+        await new Promise((r) => setTimeout(r, 200))
+        return 'data'
+      })
+
+      reader.runScheduleBackgroundRefresh('key:1', fetcher)
+      expect(reader.activeRefreshCount).toBe(1)
+
+      reader.abortAllRefreshes()
+      // Wait for refresh to complete after abort
+      await Promise.all(reader.getAllRefreshPromises())
+      expect(reader.activeRefreshCount).toBe(0)
+    })
+
+    it('getAllRefreshPromises returns all refresh promises', () => {
+      const { reader, options } = createReader()
+      const fetcher = vi.fn(async () => {
+        await new Promise((r) => setTimeout(r, 100))
+        return 'x'
+      })
+
+      reader.runScheduleBackgroundRefresh('key:a', fetcher)
+      reader.runScheduleBackgroundRefresh('key:b', fetcher)
+
+      const promises = reader.getAllRefreshPromises()
+      expect(promises).toHaveLength(2)
+    })
+
+    it('does not schedule refresh when disconnecting', () => {
+      const { reader, options } = createReader()
+      options.isDisconnecting.mockReturnValue(true)
+      const fetcher = vi.fn(async () => 'data')
+
+      reader.runScheduleBackgroundRefresh('key:1', fetcher)
+      expect(reader.activeRefreshCount).toBe(0)
+    })
+  })
+
+  // --- resolveSingleFlightOptions ---
+
+  describe('resolveSingleFlightOptions', () => {
+    it('returns config values with defaults', async () => {
+      const { reader, options } = createReader()
+      options.layers = [createMockLayer('L0')]
+      options.singleFlightLeaseMs = 50_000
+      options.singleFlightTimeoutMs = 10_000
+      options.singleFlightPollMs = 100
+      options.singleFlightRenewIntervalMs = 5_000
+      options.singleFlightCoordinator = {
+        execute: vi.fn(async (_key: string, execOpts: unknown, worker: () => Promise<string | null>) => {
+          // Capture the options passed to execute
+          const opts = execOpts as Record<string, unknown>
+          expect(opts.leaseMs).toBe(50_000)
+          expect(opts.waitTimeoutMs).toBe(10_000)
+          expect(opts.pollIntervalMs).toBe(100)
+          expect(opts.renewIntervalMs).toBe(5_000)
+          return worker()
+        })
+      }
+      options.storeEntry = vi.fn(async () => {})
+      const fetcher = vi.fn(async () => 'result')
+
+      await reader.getPrepared('key:1', fetcher)
+    })
+  })
+
+  // --- applyFreshReadPolicies ---
+
+  describe('applyFreshReadPolicies', () => {
+    it('writes refreshed envelope to layers on sliding TTL', async () => {
+      const { reader, options } = createReader()
+      const envelope = createStoredValueEnvelope({
+        kind: 'value',
+        value: 'slide',
+        freshTtlSeconds: 60
+      })
+      const layer0 = createMockLayer('L0', { get: vi.fn(async () => envelope) })
+      const layer1 = createMockLayer('L1')
+      options.layers = [layer0, layer1]
+
+      await reader.runApplyFreshReadPolicies(
+        'key:1',
+        {
+          found: true,
+          value: 'slide',
+          stored: envelope,
+          state: 'fresh',
+          layerIndex: 1,
+          layerName: 'L1'
+        },
+        { slidingTtl: true },
+        undefined
+      )
+
+      // Both layers up to layerIndex=1 should get set called
+      expect(layer0.set).toHaveBeenCalled()
+      expect(layer1.set).toHaveBeenCalled()
+    })
+
+    it('schedules background refresh when refresh-ahead threshold is met', async () => {
+      const { reader, options } = createReader()
+      const envelope = createStoredValueEnvelope({
+        kind: 'value',
+        value: 'ahead',
+        freshTtlSeconds: 10
+      })
+      const layer = createMockLayer('L0', { get: vi.fn(async () => envelope) })
+      options.layers = [layer]
+      options.refreshAhead = 600
+      options.resolveLayerSeconds.mockReturnValue(600)
+      const fetcher = vi.fn(async () => 'refreshed')
+
+      await reader.runApplyFreshReadPolicies(
+        'key:1',
+        {
+          found: true,
+          value: 'ahead',
+          stored: envelope,
+          state: 'fresh',
+          layerIndex: 0,
+          layerName: 'L0'
+        },
+        undefined,
+        fetcher
+      )
+
+      expect(options.scheduleBackgroundRefreshDispatch).toHaveBeenCalledWith('key:1', fetcher, undefined)
+    })
+  })
+
+  // --- negative cache hits ---
+
+  describe('negative cache hit detection', () => {
+    it('increments negativeCacheHits when serving a negative-cache entry', async () => {
+      const { reader, options } = createReader()
+      const negative = createStoredValueEnvelope({
+        kind: 'empty',
+        freshTtlSeconds: 60
+      })
+      options.layers = [createMockLayer('L0', { get: vi.fn(async () => negative) })]
+
+      const result = await reader.getPrepared('key:1')
+      expect(result).toBeNull()
+      expect(options.metricsCollector.snapshot.negativeCacheHits).toBe(1)
+    })
+  })
+})


### PR DESCRIPTION
Move the entire read pipeline (get, fetch, backfill, background refresh, stale policies, stampede/single-flight) into a dedicated CacheStackReader module under src/internal/.

- CacheStack.ts: 1726 → 1357 lines (-21%)
- CacheStackReader.ts: 552 lines (new)
- 13 methods, 2 fields, 4 constants, 2 types extracted
- 44 new unit tests (98.5% stmt / 97.3% branch coverage)
- All 518 tests pass (474 existing + 44 new), zero behavioral change