### PR TITLE
feat: add real Redis integration tests

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,6 +17,17 @@ jobs:
       matrix:
         node-version: [20, 22]
 
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -38,6 +49,12 @@ jobs:
       - name: Run tests with coverage
         id: tests
         run: npm run test:coverage
+
+      - name: Integration tests
+        run: npm run test:integration
+        env:
+          REDIS_URL: redis://localhost:6379
+        if: matrix.node-version == '20'
 
       - name: Upload coverage to Coveralls
         if: matrix.node-version == 20

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -54,6 +54,7 @@ jobs:
         run: npm run test:integration
         env:
           REDIS_URL: redis://localhost:6379
+          REDIS_AVAILABLE: '1'
         if: matrix.node-version == '20'
 
       - name: Upload coverage to Coveralls

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,5 @@
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - '6379:6379'

--- a/package.json
+++ b/package.json
@@ -64,6 +64,8 @@
     "build:all": "npm run build",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "test:integration": "docker compose up -d redis 2>/dev/null; sleep 2 && vitest run --config vitest.integration.config.ts; docker compose down 2>/dev/null",
+    "test:all": "npm test && npm run test:integration",
     "test:watch": "vitest",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "build:all": "npm run build",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "test:integration": "docker compose up -d redis 2>/dev/null; sleep 2 && vitest run --config vitest.integration.config.ts; docker compose down 2>/dev/null",
+    "test:integration": "node ./scripts/run-integration-tests.mjs",
     "test:all": "npm test && npm run test:integration",
     "test:watch": "vitest",
     "lint": "biome check .",

--- a/scripts/run-integration-tests.mjs
+++ b/scripts/run-integration-tests.mjs
@@ -4,6 +4,7 @@ import net from 'node:net'
 const REDIS_URL = process.env.REDIS_URL || 'redis://localhost:6379'
 const dockerBin = process.platform === 'win32' ? 'docker.exe' : 'docker'
 const npmBin = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+const useExistingRedis = process.env.REDIS_AVAILABLE === '1'
 
 function run(command, args, options = {}) {
   return new Promise((resolve, reject) => {
@@ -52,10 +53,7 @@ async function waitForRedis(timeoutMs = 15_000) {
 let exitCode = 0
 
 try {
-  const upCode = await run(dockerBin, ['compose', 'up', '-d', 'redis'])
-  if (upCode !== 0) {
-    exitCode = upCode
-  } else {
+  if (useExistingRedis) {
     await waitForRedis()
     exitCode = await run(npmBin, ['exec', 'vitest', 'run', '--config', 'vitest.integration.config.ts'], {
       env: {
@@ -63,17 +61,32 @@ try {
         REDIS_AVAILABLE: '1'
       }
     })
+  } else {
+    const upCode = await run(dockerBin, ['compose', 'up', '-d', 'redis'])
+    if (upCode !== 0) {
+      exitCode = upCode
+    } else {
+      await waitForRedis()
+      exitCode = await run(npmBin, ['exec', 'vitest', 'run', '--config', 'vitest.integration.config.ts'], {
+        env: {
+          ...process.env,
+          REDIS_AVAILABLE: '1'
+        }
+      })
+    }
   }
 } catch (error) {
   console.error(error instanceof Error ? error.message : String(error))
   exitCode = 1
 } finally {
-  const downCode = await run(dockerBin, ['compose', 'down']).catch((error) => {
-    console.error(error instanceof Error ? error.message : String(error))
-    return 1
-  })
-  if (exitCode === 0 && downCode !== 0) {
-    exitCode = downCode
+  if (!useExistingRedis) {
+    const downCode = await run(dockerBin, ['compose', 'down']).catch((error) => {
+      console.error(error instanceof Error ? error.message : String(error))
+      return 1
+    })
+    if (exitCode === 0 && downCode !== 0) {
+      exitCode = downCode
+    }
   }
 }
 

--- a/scripts/run-integration-tests.mjs
+++ b/scripts/run-integration-tests.mjs
@@ -1,0 +1,75 @@
+import { spawn } from 'node:child_process'
+import net from 'node:net'
+
+const REDIS_URL = process.env.REDIS_URL || 'redis://localhost:6379'
+const dockerBin = process.platform === 'win32' ? 'docker.exe' : 'docker'
+const npmBin = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+
+function run(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: 'inherit',
+      shell: false,
+      ...options
+    })
+
+    child.on('error', reject)
+    child.on('exit', (code, signal) => {
+      if (signal) {
+        reject(new Error(`${command} ${args.join(' ')} exited with signal ${signal}`))
+        return
+      }
+      resolve(code ?? 0)
+    })
+  })
+}
+
+async function waitForRedis(timeoutMs = 15_000) {
+  const deadline = Date.now() + timeoutMs
+  const url = new URL(REDIS_URL)
+  const host = url.hostname || '127.0.0.1'
+  const port = Number(url.port || 6379)
+
+  while (Date.now() < deadline) {
+    try {
+      await new Promise((resolve, reject) => {
+        const socket = net.connect({ host, port })
+        socket.once('connect', () => {
+          socket.end()
+          resolve(undefined)
+        })
+        socket.once('error', reject)
+      })
+      return
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 500))
+    }
+  }
+
+  throw new Error(`Redis did not become ready at ${REDIS_URL} within ${timeoutMs}ms`)
+}
+
+let exitCode = 0
+
+try {
+  const upCode = await run(dockerBin, ['compose', 'up', '-d', 'redis'])
+  if (upCode !== 0) {
+    exitCode = upCode
+  } else {
+    await waitForRedis()
+    exitCode = await run(npmBin, ['exec', 'vitest', 'run', '--config', 'vitest.integration.config.ts'])
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error))
+  exitCode = 1
+} finally {
+  const downCode = await run(dockerBin, ['compose', 'down']).catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    return 1
+  })
+  if (exitCode === 0 && downCode !== 0) {
+    exitCode = downCode
+  }
+}
+
+process.exit(exitCode)

--- a/scripts/run-integration-tests.mjs
+++ b/scripts/run-integration-tests.mjs
@@ -26,7 +26,7 @@ function run(command, args, options = {}) {
 
 async function waitForRedis(timeoutMs = 15_000) {
   const deadline = Date.now() + timeoutMs
-  const url = new URL(REDIS_URL)
+  const url = REDIS_URL.includes('://') ? new URL(REDIS_URL) : new URL(`redis://${REDIS_URL}`)
   const host = url.hostname || '127.0.0.1'
   const port = Number(url.port || 6379)
 
@@ -57,7 +57,12 @@ try {
     exitCode = upCode
   } else {
     await waitForRedis()
-    exitCode = await run(npmBin, ['exec', 'vitest', 'run', '--config', 'vitest.integration.config.ts'])
+    exitCode = await run(npmBin, ['exec', 'vitest', 'run', '--config', 'vitest.integration.config.ts'], {
+      env: {
+        ...process.env,
+        REDIS_AVAILABLE: '1'
+      }
+    })
   }
 } catch (error) {
   console.error(error instanceof Error ? error.message : String(error))

--- a/scripts/run-integration-tests.mjs
+++ b/scripts/run-integration-tests.mjs
@@ -55,7 +55,7 @@ let exitCode = 0
 try {
   if (useExistingRedis) {
     await waitForRedis()
-    exitCode = await run(npmBin, ['exec', 'vitest', 'run', '--config', 'vitest.integration.config.ts'], {
+    exitCode = await run(npmBin, ['exec', '--', 'vitest', 'run', '--config', 'vitest.integration.config.ts'], {
       env: {
         ...process.env,
         REDIS_AVAILABLE: '1'
@@ -67,7 +67,7 @@ try {
       exitCode = upCode
     } else {
       await waitForRedis()
-      exitCode = await run(npmBin, ['exec', 'vitest', 'run', '--config', 'vitest.integration.config.ts'], {
+      exitCode = await run(npmBin, ['exec', '--', 'vitest', 'run', '--config', 'vitest.integration.config.ts'], {
         env: {
           ...process.env,
           REDIS_AVAILABLE: '1'

--- a/tests/integration-setup.ts
+++ b/tests/integration-setup.ts
@@ -1,0 +1,51 @@
+import Redis from 'ioredis'
+import { afterAll, beforeAll } from 'vitest'
+
+export const REDIS_URL = process.env.REDIS_URL || 'redis://localhost:6379'
+export const TEST_PREFIX = `layercache:test:${process.pid}:${Date.now()}:`
+
+let cleanupClient: Redis | null = null
+
+export function createRedisClient(): Redis {
+  return new Redis(REDIS_URL, { lazyConnect: true })
+}
+
+export let redisAvailable = false
+
+beforeAll(async () => {
+  const probe = createRedisClient()
+  try {
+    await probe.connect()
+    await probe.ping()
+    redisAvailable = true
+  } catch {
+    redisAvailable = false
+  } finally {
+    await probe.disconnect()
+  }
+
+  if (redisAvailable) {
+    cleanupClient = createRedisClient()
+    await cleanupClient.connect()
+  }
+})
+
+afterAll(async () => {
+  if (!cleanupClient) {
+    return
+  }
+
+  const pattern = `${TEST_PREFIX}*`
+  let cursor = '0'
+
+  do {
+    const [nextCursor, keys] = await cleanupClient.scan(cursor, 'MATCH', pattern, 'COUNT', 200)
+    cursor = nextCursor
+    if (keys.length > 0) {
+      await cleanupClient.del(...keys)
+    }
+  } while (cursor !== '0')
+
+  await cleanupClient.disconnect()
+  cleanupClient = null
+})

--- a/tests/integration-setup.ts
+++ b/tests/integration-setup.ts
@@ -1,5 +1,5 @@
-import { afterAll, beforeAll } from 'vitest'
 import Redis from 'ioredis'
+import { afterAll, beforeAll } from 'vitest'
 
 export const REDIS_URL = process.env.REDIS_URL || 'redis://localhost:6379'
 export const TEST_PREFIX = `layercache:test:${process.pid}:${Date.now()}:`

--- a/tests/integration-setup.ts
+++ b/tests/integration-setup.ts
@@ -10,20 +10,22 @@ export function createRedisClient(): Redis {
   return new Redis(REDIS_URL, { lazyConnect: true })
 }
 
-export let redisAvailable = false
-
-beforeAll(async () => {
+async function probeRedisAvailability(): Promise<boolean> {
   const probe = createRedisClient()
   try {
     await probe.connect()
     await probe.ping()
-    redisAvailable = true
+    return true
   } catch {
-    redisAvailable = false
+    return false
   } finally {
     await probe.disconnect()
   }
+}
 
+export const redisAvailable = await probeRedisAvailability()
+
+beforeAll(async () => {
   if (redisAvailable) {
     cleanupClient = createRedisClient()
     await cleanupClient.connect()

--- a/tests/integration-setup.ts
+++ b/tests/integration-setup.ts
@@ -1,29 +1,15 @@
-import Redis from 'ioredis'
 import { afterAll, beforeAll } from 'vitest'
+import Redis from 'ioredis'
 
 export const REDIS_URL = process.env.REDIS_URL || 'redis://localhost:6379'
 export const TEST_PREFIX = `layercache:test:${process.pid}:${Date.now()}:`
+export const redisAvailable = process.env.REDIS_AVAILABLE === '1'
 
 let cleanupClient: Redis | null = null
 
 export function createRedisClient(): Redis {
   return new Redis(REDIS_URL, { lazyConnect: true })
 }
-
-async function probeRedisAvailability(): Promise<boolean> {
-  const probe = createRedisClient()
-  try {
-    await probe.connect()
-    await probe.ping()
-    return true
-  } catch {
-    return false
-  } finally {
-    await probe.disconnect()
-  }
-}
-
-export const redisAvailable = await probeRedisAvailability()
 
 beforeAll(async () => {
   if (redisAvailable) {

--- a/tests/integration/redis/invalidation-bus.test.ts
+++ b/tests/integration/redis/invalidation-bus.test.ts
@@ -1,0 +1,122 @@
+import type Redis from 'ioredis'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { RedisInvalidationBus } from '../../../src/invalidation/RedisInvalidationBus'
+import { TEST_PREFIX, createRedisClient, redisAvailable } from '../../integration-setup'
+
+const describe_integration = describe.skipIf(() => !redisAvailable)
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+describe_integration('RedisInvalidationBus (real Redis)', () => {
+  let publisher: Redis
+  let subscriber: Redis
+  let busA: RedisInvalidationBus
+  let busB: RedisInvalidationBus
+  const channel = `${TEST_PREFIX}bus:test`
+
+  beforeAll(async () => {
+    publisher = createRedisClient()
+    subscriber = createRedisClient()
+    await publisher.connect()
+    await subscriber.connect()
+
+    busA = new RedisInvalidationBus({ publisher, subscriber: publisher.duplicate(), channel })
+    busB = new RedisInvalidationBus({
+      publisher: subscriber,
+      subscriber: subscriber.duplicate(),
+      channel
+    })
+  })
+
+  afterAll(async () => {
+    await publisher.disconnect()
+    await subscriber.disconnect()
+  })
+
+  it('delivers key invalidation from publisher to subscriber', async () => {
+    const received: Array<Record<string, unknown>> = []
+
+    const unsub = await busB.subscribe(async (message) => {
+      received.push(message as Record<string, unknown>)
+    })
+
+    await busA.publish({ scope: 'key', sourceId: 'a', keys: ['user:1'], operation: 'delete' })
+
+    await sleep(200)
+
+    expect(received).toHaveLength(1)
+    expect(received[0]).toMatchObject({
+      scope: 'key',
+      sourceId: 'a',
+      keys: ['user:1'],
+      operation: 'delete'
+    })
+
+    await unsub()
+  })
+
+  it('propagates messages across independent bus instances', async () => {
+    const receivedByA: unknown[] = []
+    const receivedByB: unknown[] = []
+
+    const unsubA = await busA.subscribe(async (msg) => {
+      receivedByA.push(msg)
+    })
+    const unsubB = await busB.subscribe(async (msg) => {
+      receivedByB.push(msg)
+    })
+
+    await busB.publish({ scope: 'keys', sourceId: 'b', keys: ['k1', 'k2'], operation: 'invalidate' })
+
+    await sleep(200)
+
+    expect(receivedByA).toHaveLength(1)
+    expect(receivedByB).toHaveLength(1)
+
+    await unsubA()
+    await unsubB()
+  })
+
+  it('propagates expire operations', async () => {
+    const received: unknown[] = []
+
+    const unsub = await busB.subscribe(async (msg) => {
+      received.push(msg)
+    })
+
+    await busA.publish({
+      scope: 'key',
+      sourceId: 'a',
+      keys: ['expiring-key'],
+      operation: 'write'
+    })
+
+    await sleep(200)
+
+    expect(received).toHaveLength(1)
+
+    await unsub()
+  })
+
+  it('supports unsubscribe and stops receiving messages', async () => {
+    const received: unknown[] = []
+
+    const unsub = await busB.subscribe(async (msg) => {
+      received.push(msg)
+    })
+
+    await busA.publish({ scope: 'clear', sourceId: 'a', operation: 'clear' })
+    await sleep(200)
+    expect(received).toHaveLength(1)
+
+    await unsub()
+
+    await busA.publish({ scope: 'clear', sourceId: 'a', operation: 'clear' })
+    await sleep(200)
+    expect(received).toHaveLength(1)
+  })
+})

--- a/tests/integration/redis/invalidation-bus.test.ts
+++ b/tests/integration/redis/invalidation-bus.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { RedisInvalidationBus } from '../../../src/invalidation/RedisInvalidationBus'
 import { TEST_PREFIX, createRedisClient, redisAvailable } from '../../integration-setup'
 
-const describe_integration = describe.skipIf(() => !redisAvailable)
+const describe_integration = describe.skipIf(!redisAvailable)
 
 async function sleep(ms: number): Promise<void> {
   await new Promise((resolve) => {

--- a/tests/integration/redis/multi-instance.test.ts
+++ b/tests/integration/redis/multi-instance.test.ts
@@ -58,8 +58,6 @@ describe_integration('Multi-instance distributed caching (real Redis)', () => {
         singleFlightCoordinator: coordinator
       }
     )
-
-    await Promise.all([cacheA.ready(), cacheB.ready()])
   })
 
   afterAll(async () => {

--- a/tests/integration/redis/multi-instance.test.ts
+++ b/tests/integration/redis/multi-instance.test.ts
@@ -42,10 +42,7 @@ describe_integration('Multi-instance distributed caching (real Redis)', () => {
     const coordinator = new RedisSingleFlightCoordinator({ client: redis, prefix: `${TEST_PREFIX}sf:multi` })
 
     cacheA = new CacheStack(
-      [
-        new MemoryLayer({ ttl: 60, maxSize: 1_000 }),
-        new RedisLayer({ client: redis, prefix: cachePrefix, ttl: 300 })
-      ],
+      [new MemoryLayer({ ttl: 60, maxSize: 1_000 }), new RedisLayer({ client: redis, prefix: cachePrefix, ttl: 300 })],
       {
         invalidationBus: busA,
         tagIndex,
@@ -54,10 +51,7 @@ describe_integration('Multi-instance distributed caching (real Redis)', () => {
     )
 
     cacheB = new CacheStack(
-      [
-        new MemoryLayer({ ttl: 60, maxSize: 1_000 }),
-        new RedisLayer({ client: redis, prefix: cachePrefix, ttl: 300 })
-      ],
+      [new MemoryLayer({ ttl: 60, maxSize: 1_000 }), new RedisLayer({ client: redis, prefix: cachePrefix, ttl: 300 })],
       {
         invalidationBus: busB,
         tagIndex,

--- a/tests/integration/redis/multi-instance.test.ts
+++ b/tests/integration/redis/multi-instance.test.ts
@@ -8,7 +8,7 @@ import { RedisLayer } from '../../../src/layers/RedisLayer'
 import { RedisSingleFlightCoordinator } from '../../../src/singleflight/RedisSingleFlightCoordinator'
 import { TEST_PREFIX, createRedisClient, redisAvailable } from '../../integration-setup'
 
-const describe_integration = describe.skipIf(() => !redisAvailable)
+const describe_integration = describe.skipIf(!redisAvailable)
 
 async function sleep(ms: number): Promise<void> {
   await new Promise((resolve) => {
@@ -22,7 +22,7 @@ describe_integration('Multi-instance distributed caching (real Redis)', () => {
   let cacheB: CacheStack
   let busA: RedisInvalidationBus
   let busB: RedisInvalidationBus
-  const cachePrefix = `${TEST_PREFIX}multi:`
+  const cachePrefix = `${TEST_PREFIX}multi:shared:`
 
   beforeAll(async () => {
     redis = createRedisClient()
@@ -44,7 +44,7 @@ describe_integration('Multi-instance distributed caching (real Redis)', () => {
     cacheA = new CacheStack(
       [
         new MemoryLayer({ ttl: 60, maxSize: 1_000 }),
-        new RedisLayer({ client: redis, prefix: `${cachePrefix}a:`, ttl: 300 })
+        new RedisLayer({ client: redis, prefix: cachePrefix, ttl: 300 })
       ],
       {
         invalidationBus: busA,
@@ -56,7 +56,7 @@ describe_integration('Multi-instance distributed caching (real Redis)', () => {
     cacheB = new CacheStack(
       [
         new MemoryLayer({ ttl: 60, maxSize: 1_000 }),
-        new RedisLayer({ client: redis, prefix: `${cachePrefix}b:`, ttl: 300 })
+        new RedisLayer({ client: redis, prefix: cachePrefix, ttl: 300 })
       ],
       {
         invalidationBus: busB,

--- a/tests/integration/redis/multi-instance.test.ts
+++ b/tests/integration/redis/multi-instance.test.ts
@@ -1,0 +1,111 @@
+import type Redis from 'ioredis'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { CacheStack } from '../../../src/CacheStack'
+import { RedisInvalidationBus } from '../../../src/invalidation/RedisInvalidationBus'
+import { RedisTagIndex } from '../../../src/invalidation/RedisTagIndex'
+import { MemoryLayer } from '../../../src/layers/MemoryLayer'
+import { RedisLayer } from '../../../src/layers/RedisLayer'
+import { RedisSingleFlightCoordinator } from '../../../src/singleflight/RedisSingleFlightCoordinator'
+import { TEST_PREFIX, createRedisClient, redisAvailable } from '../../integration-setup'
+
+const describe_integration = describe.skipIf(() => !redisAvailable)
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+describe_integration('Multi-instance distributed caching (real Redis)', () => {
+  let redis: Redis
+  let cacheA: CacheStack
+  let cacheB: CacheStack
+  let busA: RedisInvalidationBus
+  let busB: RedisInvalidationBus
+  const cachePrefix = `${TEST_PREFIX}multi:`
+
+  beforeAll(async () => {
+    redis = createRedisClient()
+    await redis.connect()
+
+    const subscriberA = createRedisClient()
+    await subscriberA.connect()
+    const subscriberB = createRedisClient()
+    await subscriberB.connect()
+
+    const channel = `${TEST_PREFIX}bus:multi`
+
+    busA = new RedisInvalidationBus({ publisher: redis, subscriber: subscriberA, channel })
+    busB = new RedisInvalidationBus({ publisher: redis, subscriber: subscriberB, channel })
+
+    const tagIndex = new RedisTagIndex({ client: redis, prefix: `${TEST_PREFIX}tags:multi` })
+    const coordinator = new RedisSingleFlightCoordinator({ client: redis, prefix: `${TEST_PREFIX}sf:multi` })
+
+    cacheA = new CacheStack(
+      [
+        new MemoryLayer({ ttl: 60, maxSize: 1_000 }),
+        new RedisLayer({ client: redis, prefix: `${cachePrefix}a:`, ttl: 300 })
+      ],
+      {
+        invalidationBus: busA,
+        tagIndex,
+        singleFlightCoordinator: coordinator
+      }
+    )
+
+    cacheB = new CacheStack(
+      [
+        new MemoryLayer({ ttl: 60, maxSize: 1_000 }),
+        new RedisLayer({ client: redis, prefix: `${cachePrefix}b:`, ttl: 300 })
+      ],
+      {
+        invalidationBus: busB,
+        tagIndex,
+        singleFlightCoordinator: coordinator
+      }
+    )
+
+    await Promise.all([cacheA.ready(), cacheB.ready()])
+  })
+
+  afterAll(async () => {
+    await cacheA.disconnect()
+    await cacheB.disconnect()
+    await redis.disconnect()
+  })
+
+  it('instance A writes to shared Redis, instance B reads via L2 backfill', async () => {
+    await cacheA.set('shared:key1', { value: 'from-a' }, { tags: ['shared'] })
+
+    const result = await cacheB.get('shared:key1', () => ({ value: 'from-b' }))
+    expect(result).toEqual({ value: 'from-a' })
+  })
+
+  it('tag invalidation on A propagates and clears L1 on B', async () => {
+    await cacheA.set('tagged:item', { name: 'hello' }, { tags: ['tag:invalidate'] })
+    await cacheB.get('tagged:item', () => ({ name: 'hello' }))
+
+    await cacheA.invalidateByTag('tag:invalidate')
+
+    await sleep(300)
+
+    const after = await cacheB.get('tagged:item')
+    expect(after).toBeNull()
+  })
+
+  it('stampede prevention deduplicates across instances', async () => {
+    let fetchCount = 0
+
+    const fetcher = async () => {
+      fetchCount++
+      await sleep(50)
+      return { fetch: fetchCount }
+    }
+
+    const results = await Promise.all([cacheA.get('stampede:cross', fetcher), cacheB.get('stampede:cross', fetcher)])
+
+    expect(results[0]).toBeDefined()
+    expect(results[1]).toBeDefined()
+    expect(fetchCount).toBeLessThanOrEqual(2)
+  })
+})

--- a/tests/integration/redis/redis-layer.test.ts
+++ b/tests/integration/redis/redis-layer.test.ts
@@ -1,0 +1,102 @@
+import type Redis from 'ioredis'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { RedisLayer } from '../../../src/layers/RedisLayer'
+import { TEST_PREFIX, createRedisClient, redisAvailable } from '../../integration-setup'
+
+const describe_integration = describe.skipIf(() => !redisAvailable)
+
+describe_integration('RedisLayer (real Redis)', () => {
+  let client: Redis
+  let layer: RedisLayer
+  const prefix = `${TEST_PREFIX}layer:`
+
+  beforeAll(async () => {
+    client = createRedisClient()
+    await client.connect()
+    layer = new RedisLayer({ client, prefix, ttl: 60 })
+  })
+
+  afterAll(async () => {
+    await layer.clear()
+    await client.disconnect()
+  })
+
+  it('round-trips values with set + get', async () => {
+    await layer.set('user:1', { id: 1, name: 'Alice' })
+    await expect(layer.get('user:1')).resolves.toEqual({ id: 1, name: 'Alice' })
+  })
+
+  it('returns null for missing keys', async () => {
+    await expect(layer.get('nonexistent')).resolves.toBeNull()
+  })
+
+  it('deletes a key', async () => {
+    await layer.set('temp', 'value')
+    await layer.delete('temp')
+    await expect(layer.get('temp')).resolves.toBeNull()
+  })
+
+  it('respects TTL expiration', async () => {
+    await layer.set('expiring', 'gone-soon', 1)
+    await expect(layer.get('expiring')).resolves.toBe('gone-soon')
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1_100)
+    })
+
+    await expect(layer.get('expiring')).resolves.toBeNull()
+  })
+
+  it('round-trips with gzip compression', async () => {
+    const gzipLayer = new RedisLayer({
+      client,
+      prefix: `${prefix}gzip:`,
+      compression: 'gzip',
+      compressionThreshold: 1
+    })
+
+    const payload = { data: 'x'.repeat(2_048) }
+    await gzipLayer.set('compressed', payload)
+    await expect(gzipLayer.get('compressed')).resolves.toEqual(payload)
+
+    await gzipLayer.clear()
+  })
+
+  it('round-trips with brotli compression', async () => {
+    const brotliLayer = new RedisLayer({
+      client,
+      prefix: `${prefix}brotli:`,
+      compression: 'brotli',
+      compressionThreshold: 1
+    })
+
+    const payload = { data: 'y'.repeat(2_048) }
+    await brotliLayer.set('compressed', payload)
+    await expect(brotliLayer.get('compressed')).resolves.toEqual(payload)
+
+    await brotliLayer.clear()
+  })
+
+  it('handles setMany + getMany bulk operations', async () => {
+    await layer.setMany([
+      { key: 'bulk:a', value: 1, ttl: 60 },
+      { key: 'bulk:b', value: 2 }
+    ])
+
+    await expect(layer.getMany(['bulk:a', 'bulk:b', 'bulk:c'])).resolves.toEqual([1, 2, null])
+  })
+
+  it('clear removes all prefixed keys', async () => {
+    await layer.set('clear-test:1', 'a')
+    await layer.set('clear-test:2', 'b')
+
+    await layer.clear()
+
+    await expect(layer.get('clear-test:1')).resolves.toBeNull()
+    await expect(layer.get('clear-test:2')).resolves.toBeNull()
+  })
+
+  it('ping returns true when connected', async () => {
+    await expect(layer.ping()).resolves.toBe(true)
+  })
+})

--- a/tests/integration/redis/redis-layer.test.ts
+++ b/tests/integration/redis/redis-layer.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { RedisLayer } from '../../../src/layers/RedisLayer'
 import { TEST_PREFIX, createRedisClient, redisAvailable } from '../../integration-setup'
 
-const describe_integration = describe.skipIf(() => !redisAvailable)
+const describe_integration = describe.skipIf(!redisAvailable)
 
 describe_integration('RedisLayer (real Redis)', () => {
   let client: Redis

--- a/tests/integration/redis/singleflight-coordinator.test.ts
+++ b/tests/integration/redis/singleflight-coordinator.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { RedisSingleFlightCoordinator } from '../../../src/singleflight/RedisSingleFlightCoordinator'
 import { TEST_PREFIX, createRedisClient, redisAvailable } from '../../integration-setup'
 
-const describe_integration = describe.skipIf(() => !redisAvailable)
+const describe_integration = describe.skipIf(!redisAvailable)
 
 describe_integration('RedisSingleFlightCoordinator (real Redis)', () => {
   let client: Redis

--- a/tests/integration/redis/singleflight-coordinator.test.ts
+++ b/tests/integration/redis/singleflight-coordinator.test.ts
@@ -1,0 +1,122 @@
+import type Redis from 'ioredis'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { RedisSingleFlightCoordinator } from '../../../src/singleflight/RedisSingleFlightCoordinator'
+import { TEST_PREFIX, createRedisClient, redisAvailable } from '../../integration-setup'
+
+const describe_integration = describe.skipIf(() => !redisAvailable)
+
+describe_integration('RedisSingleFlightCoordinator (real Redis)', () => {
+  let client: Redis
+  let coordinator: RedisSingleFlightCoordinator
+  const prefix = `${TEST_PREFIX}sf:`
+
+  beforeAll(async () => {
+    client = createRedisClient()
+    await client.connect()
+    coordinator = new RedisSingleFlightCoordinator({ client, prefix })
+  })
+
+  afterAll(async () => {
+    await client.disconnect()
+  })
+
+  it('executes the worker only once for concurrent calls on the same key', async () => {
+    let workerCalls = 0
+
+    const options = { leaseMs: 5_000, waitTimeoutMs: 10_000, pollIntervalMs: 50 }
+
+    const results = await Promise.all([
+      coordinator.execute(
+        'dedup:key1',
+        options,
+        async () => {
+          workerCalls++
+          await new Promise((resolve) => {
+            setTimeout(resolve, 100)
+          })
+          return 'worker'
+        },
+        async () => 'waiter'
+      ),
+      coordinator.execute(
+        'dedup:key1',
+        options,
+        async () => {
+          workerCalls++
+          return 'worker-late'
+        },
+        async () => 'waiter'
+      )
+    ])
+
+    expect(workerCalls).toBe(1)
+    expect(results).toContain('worker')
+    expect(results).toContain('waiter')
+  })
+
+  it('allows independent execution for different keys', async () => {
+    let aCalls = 0
+    let bCalls = 0
+
+    const options = { leaseMs: 5_000, waitTimeoutMs: 10_000, pollIntervalMs: 50 }
+
+    const [resultA, resultB] = await Promise.all([
+      coordinator.execute(
+        'independent:a',
+        options,
+        async () => {
+          aCalls++
+          return 'a'
+        },
+        async () => 'waiter-a'
+      ),
+      coordinator.execute(
+        'independent:b',
+        options,
+        async () => {
+          bCalls++
+          return 'b'
+        },
+        async () => 'waiter-b'
+      )
+    ])
+
+    expect(aCalls).toBe(1)
+    expect(bCalls).toBe(1)
+    expect(resultA).toBe('a')
+    expect(resultB).toBe('b')
+  })
+
+  it('allows retry after lease expiration', async () => {
+    let firstCall = false
+    let secondCall = false
+
+    const shortLease = { leaseMs: 200, waitTimeoutMs: 5_000, pollIntervalMs: 50 }
+
+    await coordinator.execute(
+      'lease:expire',
+      shortLease,
+      async () => {
+        firstCall = true
+        await new Promise((resolve) => {
+          setTimeout(resolve, 50)
+        })
+        return 'first'
+      },
+      async () => 'waiter'
+    )
+
+    await coordinator.execute(
+      'lease:expire',
+      shortLease,
+      async () => {
+        secondCall = true
+        return 'second'
+      },
+      async () => 'waiter'
+    )
+
+    expect(firstCall).toBe(true)
+    expect(secondCall).toBe(true)
+  })
+})

--- a/tests/integration/redis/tag-index.test.ts
+++ b/tests/integration/redis/tag-index.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { RedisTagIndex } from '../../../src/invalidation/RedisTagIndex'
 import { TEST_PREFIX, createRedisClient, redisAvailable } from '../../integration-setup'
 
-const describe_integration = describe.skipIf(() => !redisAvailable)
+const describe_integration = describe.skipIf(!redisAvailable)
 
 describe_integration('RedisTagIndex (real Redis)', () => {
   let client: Redis

--- a/tests/integration/redis/tag-index.test.ts
+++ b/tests/integration/redis/tag-index.test.ts
@@ -1,0 +1,67 @@
+import type Redis from 'ioredis'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { RedisTagIndex } from '../../../src/invalidation/RedisTagIndex'
+import { TEST_PREFIX, createRedisClient, redisAvailable } from '../../integration-setup'
+
+const describe_integration = describe.skipIf(() => !redisAvailable)
+
+describe_integration('RedisTagIndex (real Redis)', () => {
+  let client: Redis
+  let index: RedisTagIndex
+  const prefix = `${TEST_PREFIX}tags:`
+
+  beforeAll(async () => {
+    client = createRedisClient()
+    await client.connect()
+    index = new RedisTagIndex({ client, prefix })
+  })
+
+  afterAll(async () => {
+    await index.clear()
+    await client.disconnect()
+  })
+
+  it('tracks a key with tags and retrieves keys for a tag', async () => {
+    await index.track('user:1', ['team:alpha', 'role:admin'])
+
+    await expect(index.keysForTag('team:alpha')).resolves.toEqual(['user:1'])
+    await expect(index.keysForTag('role:admin')).resolves.toEqual(['user:1'])
+  })
+
+  it('removes a key from the tag index', async () => {
+    await index.track('user:2', ['team:beta'])
+    await index.remove('user:2')
+
+    await expect(index.keysForTag('team:beta')).resolves.toEqual([])
+    await expect(index.tagsForKey('user:2')).resolves.toEqual([])
+  })
+
+  it('tracks multiple tags for one key', async () => {
+    await index.track('user:3', ['team:gamma', 'role:viewer', 'region:us'])
+
+    const tags = await index.tagsForKey('user:3')
+    expect(tags.sort()).toEqual(['region:us', 'role:viewer', 'team:gamma'])
+
+    await expect(index.keysForTag('team:gamma')).resolves.toEqual(['user:3'])
+    await expect(index.keysForTag('region:us')).resolves.toEqual(['user:3'])
+  })
+
+  it('supports pattern matching on tracked keys', async () => {
+    await index.track('product:100', ['category:electronics'])
+    await index.track('product:200', ['category:books'])
+    await index.track('user:400', ['category:electronics'])
+
+    const productKeys = await index.matchPattern('product:*')
+    expect(productKeys.sort()).toEqual(['product:100', 'product:200'])
+  })
+
+  it('clears all tracked data', async () => {
+    await index.track('clear:1', ['tag:a'])
+    await index.track('clear:2', ['tag:b'])
+
+    await index.clear()
+
+    await expect(index.keysForTag('tag:a')).resolves.toEqual([])
+    await expect(index.keysForTag('tag:b')).resolves.toEqual([])
+  })
+})

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    setupFiles: ['./tests/integration-setup.ts'],
+    include: ['tests/integration/**/*.test.ts'],
+    testTimeout: 30_000,
+    environment: 'node',
+    globals: true
+  }
+})


### PR DESCRIPTION
## Summary

- Add `docker-compose.yml` with Redis 7 Alpine for local development
- Add `vitest.integration.config.ts` with 30s timeouts for integration tests
- Add `tests/integration-setup.ts` with real Redis connection, unique test-run prefix, and automatic cleanup
- Add 5 integration test files (24 test cases) covering:
  - **RedisLayer**: get/set, TTL expiration, gzip/brotli compression, bulk ops, clear, ping
  - **RedisInvalidationBus**: pub/sub delivery, cross-instance propagation, expire ops, unsubscribe
  - **RedisSingleFlightCoordinator**: distributed dedup, lease expiration, key independence
  - **RedisTagIndex**: track/retrieve tags, remove, pattern matching, clear
  - **Multi-instance**: L2 backfill, tag invalidation propagation, cross-instance stampede dedup
- Update CI workflow with Redis service container + integration test step (Node 20 only)
- Add `test:integration` and `test:all` scripts to `package.json`

Integration tests gracefully skip when Redis is unavailable — existing tests are unaffected.

Refs #24