### PR TITLE
docs: add BentoCache comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,38 +194,38 @@ const cache = new CacheStack([
 
 ## Comparison
 
-|  | node-cache-manager | keyv | cacheable | BentoCache | **layercache** |
-|---|:---:|:---:|:---:|:---:|:---:|
-| Multi-layer + auto backfill | Partial | Plugin | -- | Partial | **Yes** |
-| Stampede prevention | -- | -- | -- | Partial | **Yes** |
-| Tag invalidation | -- | Yes | Yes | Yes | **Yes** |
-| TypeScript-first | Partial | Yes | Yes | Yes | **Yes** |
-| Event hooks | Yes | Yes | Yes | Yes | **Yes** |
+|  | node-cache-manager | keyv | cacheable | **layercache** |
+|---|:---:|:---:|:---:|:---:|
+| Multi-layer + auto backfill | Partial | Plugin | -- | **Yes** |
+| Stampede prevention | -- | -- | -- | **Yes** |
+| Tag invalidation | -- | Yes | Yes | **Yes** |
+| TypeScript-first | Partial | Yes | Yes | **Yes** |
+| Event hooks | Yes | Yes | Yes | **Yes** |
 
 <details>
 <summary>Full comparison (19 features)</summary>
 
-|  | node-cache-manager | keyv | cacheable | BentoCache | **layercache** |
-|---|:---:|:---:|:---:|:---:|:---:|
-| Multi-layer with auto backfill | Partial | Plugin | -- | Partial | **Yes** |
-| Stampede prevention | -- | -- | -- | Partial | **Yes** |
-| Distributed single-flight | -- | -- | -- | -- | **Yes** |
-| Tag invalidation | -- | Yes | Yes | Yes | **Yes** |
-| Distributed tags | -- | -- | -- | -- | **Yes** |
-| Cross-server L1 flush | -- | -- | -- | Yes | **Yes** |
-| Stale-while-revalidate | -- | -- | -- | Yes | **Yes** |
-| Circuit breaker | -- | -- | -- | Yes | **Yes** |
-| Graceful degradation | -- | -- | -- | Yes | **Yes** |
-| Sliding / adaptive TTL | -- | -- | -- | -- | **Yes** |
-| Cache warming | -- | -- | -- | -- | **Yes** |
-| Persistence / snapshots | -- | -- | -- | -- | **Yes** |
-| Compression | -- | -- | Yes | -- | **Yes** |
-| Admin CLI | -- | -- | -- | -- | **Yes** |
-| TypeScript-first | Partial | Yes | Yes | Yes | **Yes** |
-| Wrap / decorator API | Yes | -- | -- | Partial | **Yes** |
-| Namespaces | -- | Yes | Yes | Yes | **Yes** |
-| Event hooks | Yes | Yes | Yes | Yes | **Yes** |
-| Custom layers | Partial | -- | -- | Yes | **Yes** |
+|  | node-cache-manager | keyv | cacheable | **layercache** |
+|---|:---:|:---:|:---:|:---:|
+| Multi-layer with auto backfill | Partial | Plugin | -- | **Yes** |
+| Stampede prevention | -- | -- | -- | **Yes** |
+| Distributed single-flight | -- | -- | -- | **Yes** |
+| Tag invalidation | -- | Yes | Yes | **Yes** |
+| Distributed tags | -- | -- | -- | **Yes** |
+| Cross-server L1 flush | -- | -- | -- | **Yes** |
+| Stale-while-revalidate | -- | -- | -- | **Yes** |
+| Circuit breaker | -- | -- | -- | **Yes** |
+| Graceful degradation | -- | -- | -- | **Yes** |
+| Sliding / adaptive TTL | -- | -- | -- | **Yes** |
+| Cache warming | -- | -- | -- | **Yes** |
+| Persistence / snapshots | -- | -- | -- | **Yes** |
+| Compression | -- | -- | Yes | **Yes** |
+| Admin CLI | -- | -- | -- | **Yes** |
+| TypeScript-first | Partial | Yes | Yes | **Yes** |
+| Wrap / decorator API | Yes | -- | -- | **Yes** |
+| Namespaces | -- | Yes | Yes | **Yes** |
+| Event hooks | Yes | Yes | Yes | **Yes** |
+| Custom layers | Partial | -- | -- | **Yes** |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -194,38 +194,38 @@ const cache = new CacheStack([
 
 ## Comparison
 
-|  | node-cache-manager | keyv | cacheable | **layercache** |
-|---|:---:|:---:|:---:|:---:|
-| Multi-layer + auto backfill | Partial | Plugin | -- | **Yes** |
-| Stampede prevention | -- | -- | -- | **Yes** |
-| Tag invalidation | -- | Yes | Yes | **Yes** |
-| TypeScript-first | Partial | Yes | Yes | **Yes** |
-| Event hooks | Yes | Yes | Yes | **Yes** |
+|  | node-cache-manager | keyv | cacheable | BentoCache | **layercache** |
+|---|:---:|:---:|:---:|:---:|:---:|
+| Multi-layer + auto backfill | Partial | Plugin | -- | Partial | **Yes** |
+| Stampede prevention | -- | -- | -- | Partial | **Yes** |
+| Tag invalidation | -- | Yes | Yes | Yes | **Yes** |
+| TypeScript-first | Partial | Yes | Yes | Yes | **Yes** |
+| Event hooks | Yes | Yes | Yes | Yes | **Yes** |
 
 <details>
 <summary>Full comparison (19 features)</summary>
 
-|  | node-cache-manager | keyv | cacheable | **layercache** |
-|---|:---:|:---:|:---:|:---:|
-| Multi-layer with auto backfill | Partial | Plugin | -- | **Yes** |
-| Stampede prevention | -- | -- | -- | **Yes** |
-| Distributed single-flight | -- | -- | -- | **Yes** |
-| Tag invalidation | -- | Yes | Yes | **Yes** |
-| Distributed tags | -- | -- | -- | **Yes** |
-| Cross-server L1 flush | -- | -- | -- | **Yes** |
-| Stale-while-revalidate | -- | -- | -- | **Yes** |
-| Circuit breaker | -- | -- | -- | **Yes** |
-| Graceful degradation | -- | -- | -- | **Yes** |
-| Sliding / adaptive TTL | -- | -- | -- | **Yes** |
-| Cache warming | -- | -- | -- | **Yes** |
-| Persistence / snapshots | -- | -- | -- | **Yes** |
-| Compression | -- | -- | Yes | **Yes** |
-| Admin CLI | -- | -- | -- | **Yes** |
-| TypeScript-first | Partial | Yes | Yes | **Yes** |
-| Wrap / decorator API | Yes | -- | -- | **Yes** |
-| Namespaces | -- | Yes | Yes | **Yes** |
-| Event hooks | Yes | Yes | Yes | **Yes** |
-| Custom layers | Partial | -- | -- | **Yes** |
+|  | node-cache-manager | keyv | cacheable | BentoCache | **layercache** |
+|---|:---:|:---:|:---:|:---:|:---:|
+| Multi-layer with auto backfill | Partial | Plugin | -- | Partial | **Yes** |
+| Stampede prevention | -- | -- | -- | Partial | **Yes** |
+| Distributed single-flight | -- | -- | -- | -- | **Yes** |
+| Tag invalidation | -- | Yes | Yes | Yes | **Yes** |
+| Distributed tags | -- | -- | -- | -- | **Yes** |
+| Cross-server L1 flush | -- | -- | -- | Yes | **Yes** |
+| Stale-while-revalidate | -- | -- | -- | Yes | **Yes** |
+| Circuit breaker | -- | -- | -- | Yes | **Yes** |
+| Graceful degradation | -- | -- | -- | Yes | **Yes** |
+| Sliding / adaptive TTL | -- | -- | -- | -- | **Yes** |
+| Cache warming | -- | -- | -- | -- | **Yes** |
+| Persistence / snapshots | -- | -- | -- | -- | **Yes** |
+| Compression | -- | -- | Yes | -- | **Yes** |
+| Admin CLI | -- | -- | -- | -- | **Yes** |
+| TypeScript-first | Partial | Yes | Yes | Yes | **Yes** |
+| Wrap / decorator API | Yes | -- | -- | Partial | **Yes** |
+| Namespaces | -- | Yes | Yes | Yes | **Yes** |
+| Event hooks | Yes | Yes | Yes | Yes | **Yes** |
+| Custom layers | Partial | -- | -- | Yes | **Yes** |
 
 </details>
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -8,27 +8,27 @@ How does layercache compare to other popular Node.js caching libraries?
 
 ## Overview
 
-| Capability | layercache | node-cache-manager | keyv | cacheable |
-|---|:---:|:---:|:---:|:---:|
-| Multi-layer with auto backfill | **Yes** | Partial | Plugin | -- |
-| Stampede prevention | **Yes** | -- | -- | -- |
-| Distributed single-flight | **Yes** | -- | -- | -- |
-| Tag invalidation | **Yes** | -- | -- | Yes |
-| Distributed tags | **Yes** | -- | -- | -- |
-| Cross-server L1 flush | **Yes** | -- | -- | -- |
-| Stale-while-revalidate | **Yes** | -- | -- | -- |
-| Circuit breaker | **Yes** | -- | -- | -- |
-| Graceful degradation | **Yes** | -- | -- | -- |
-| Sliding / adaptive TTL | **Yes** | -- | -- | -- |
-| Cache warming | **Yes** | -- | -- | -- |
-| Persistence / snapshots | **Yes** | -- | -- | -- |
-| Compression | **Yes** | -- | -- | Yes |
-| Admin CLI | **Yes** | -- | -- | -- |
-| TypeScript-first | **Yes** | Partial | Yes | Yes |
-| Wrap / decorator API | **Yes** | Yes | -- | -- |
-| Namespaces | **Yes** | -- | Yes | Yes |
-| Event hooks | **Yes** | Yes | Yes | Yes |
-| Custom layers | **Yes** | Partial | -- | -- |
+| Capability | layercache | BentoCache | node-cache-manager | keyv | cacheable |
+|---|:---:|:---:|:---:|:---:|:---:|
+| Multi-layer with auto backfill | **Yes** | Partial | Partial | Plugin | -- |
+| Stampede prevention | **Yes** | Partial | -- | -- | -- |
+| Distributed single-flight | **Yes** | -- | -- | -- | -- |
+| Tag invalidation | **Yes** | Yes | -- | -- | Yes |
+| Distributed tags | **Yes** | -- | -- | -- | -- |
+| Cross-server L1 flush | **Yes** | Yes | -- | -- | -- |
+| Stale-while-revalidate | **Yes** | Yes | -- | -- | -- |
+| Circuit breaker | **Yes** | Yes | -- | -- | -- |
+| Graceful degradation | **Yes** | Yes | -- | -- | -- |
+| Sliding / adaptive TTL | **Yes** | -- | -- | -- | -- |
+| Cache warming | **Yes** | -- | -- | -- | -- |
+| Persistence / snapshots | **Yes** | -- | -- | -- | -- |
+| Compression | **Yes** | -- | -- | -- | Yes |
+| Admin CLI | **Yes** | -- | -- | -- | -- |
+| TypeScript-first | **Yes** | Yes | Partial | Yes | Yes |
+| Wrap / decorator API | **Yes** | Partial | Yes | -- | -- |
+| Namespaces | **Yes** | Yes | -- | Yes | Yes |
+| Event hooks | **Yes** | Yes | Yes | Yes | Yes |
+| Custom layers | **Yes** | Yes | Partial | -- | -- |
 
 ---
 
@@ -86,6 +86,56 @@ How does layercache compare to other popular Node.js caching libraries?
 **When cacheable might be enough:**
 - Tag-based invalidation with simple caching needs
 - Projects that already use it and don't need distributed features
+
+---
+
+## layercache vs. BentoCache
+
+[BentoCache](https://bentocache.dev) (v1.6.1) is a TypeScript caching library with a two-tier architecture (L1 local + L2 remote), a rich driver ecosystem, and deep AdonisJS integration. It is one of the closest feature comparisons for layercache.
+
+### Where BentoCache shines
+
+- **Driver ecosystem** - Redis, Memory, Filesystem, DynamoDB, and Database drivers (Knex, Kysely, Orchid) for SQLite, MySQL, PostgreSQL, and MSSQL. Broader backend coverage than layercache.
+- **AdonisJS integration** - Official `@adonisjs/cache` package with full framework integration.
+- **Friendly TTLs** - Human-readable strings like `'2.5h'`, `'10m'`, `'30s'` everywhere a TTL is accepted.
+- **Factory Context API** - `ctx.skip()`, `ctx.fail()`, `ctx.gracedEntry`, `ctx.setOptions()` give the factory fine-grained control over caching behavior.
+- **Grace backoff** - When the factory fails during the grace window, TTL is extended by a backoff duration to prevent upstream hammering.
+- **Soft and hard timeouts** - Return stale data after a soft timeout while the factory continues in background; hard timeout throws an explicit error.
+- **Plugin system** - Extensible via a `register(bentocache)` interface. Plugins receive the full instance and can subscribe to events, attach metrics, and more.
+- **Binary bus encoding** - Bus messages use a custom binary format instead of JSON for bandwidth savings.
+- **Grafana dashboard** - Ready-to-use Prometheus metrics with a bundled Grafana dashboard.
+- **Driver compliance test suite** - Ships `bentocache/test_suite` to validate custom driver implementations.
+
+### Where layercache goes further
+
+- **N-layer stacks** - layercache supports any number of layers (Memory + Redis + Disk + …). BentoCache is limited to exactly two tiers (L1 + L2).
+- **Distributed single-flight** - Cross-instance request deduplication via Redis distributed locks. BentoCache's stampede protection is in-memory only — N instances can produce up to N concurrent factory calls for the same key.
+- **Distributed tags** - Shared Redis-backed tag index (`RedisTagIndex`). BentoCache tags are local-only, using client-side invalidation timestamps without a shared index.
+- **Wildcard and pattern invalidation** - Glob-style key pattern matching (`user:*`). Not available in BentoCache.
+- **Generation-based rotation** - Bulk namespace invalidation by bumping a generation number, without scanning keys.
+- **Sliding TTL** - Reset expiry on every read for frequently accessed keys.
+- **Adaptive TTL** - Automatically ramp TTL for hot keys up to a configurable ceiling.
+- **Refresh-ahead** - Proactively refresh values before they expire.
+- **TTL policies** - Calendar-aligned expirations (`until-midnight`, `next-hour`, custom).
+- **Cache warming** - Priority-based pre-population at startup with progress callbacks.
+- **Persistence and snapshots** - Export/import cache state for recovery and migration.
+- **Compression** - Built-in gzip and brotli compression in RedisLayer with configurable thresholds.
+- **MessagePack serializer** - Binary serialization as a built-in alternative to JSON.
+- **Admin CLI** - `npx layercache stats|keys|invalidate|inspect` for operational debugging.
+- **Health checks** - Per-layer async health endpoints with latency measurement.
+- **Per-layer latency tracking** - Average, max, and sample count using Welford's algorithm.
+- **HTTP stats endpoint** - JSON endpoint for dashboards and monitoring.
+- **Framework middleware** - Express, Fastify, Hono, tRPC, GraphQL, and Next.js integrations out of the box.
+- **Write-behind** - Batch writes to non-local layers with configurable flush interval.
+- **Fetcher rate limiting** - Token-bucket rate limiting scoped globally, per-key, or per-fetcher.
+- **Negative caching** - Dedicated support for caching miss results with short TTLs.
+
+### When BentoCache might be enough
+
+- AdonisJS projects that want seamless framework integration
+- Apps that need DynamoDB or SQL database backends
+- Teams that prefer friendly TTL strings and a rich factory context API
+- Simple two-tier caching with Redis and an in-memory layer
 
 ---
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -110,7 +110,7 @@ How does layercache compare to other popular Node.js caching libraries?
 
 - **N-layer stacks** - layercache supports any number of layers (Memory + Redis + Disk + …). BentoCache is limited to exactly two tiers (L1 + L2).
 - **Distributed single-flight** - Cross-instance request deduplication via Redis distributed locks. BentoCache's stampede protection is in-memory only — N instances can produce up to N concurrent factory calls for the same key.
-- **Distributed tags** - Shared Redis-backed tag index (`RedisTagIndex`). BentoCache tags are local-only, using client-side invalidation timestamps without a shared index.
+- **Distributed tags** - Shared Redis-backed tag index (`RedisTagIndex`). BentoCache supports backend-backed tag invalidation, but it does not maintain a shared reverse index for enumerating keys by tag.
 - **Wildcard and pattern invalidation** - Glob-style key pattern matching (`user:*`). Not available in BentoCache.
 - **Generation-based rotation** - Bulk namespace invalidation by bumping a generation number, without scanning keys.
 - **Sliding TTL** - Reset expiry on every read for frequently accessed keys.

--- a/docs/i18n/README.es.md
+++ b/docs/i18n/README.es.md
@@ -194,38 +194,38 @@ const cache = new CacheStack([
 
 ## Comparación
 
-|  | node-cache-manager | keyv | cacheable | **layercache** |
-|---|:---:|:---:|:---:|:---:|
-| Multicapa con autorrelleno | Parcial | Plugin | -- | **Yes** |
-| Prevención de estampidas | -- | -- | -- | **Yes** |
-| Invalidación por tags | -- | Yes | Yes | **Yes** |
-| TypeScript-first | Parcial | Yes | Yes | **Yes** |
-| Hooks de eventos | Yes | Yes | Yes | **Yes** |
+|  | node-cache-manager | keyv | cacheable | BentoCache | **layercache** |
+|---|:---:|:---:|:---:|:---:|:---:|
+| Multicapa con autorrelleno | Parcial | Plugin | -- | Parcial | **Yes** |
+| Prevención de estampidas | -- | -- | -- | Parcial | **Yes** |
+| Invalidación por tags | -- | Yes | Yes | Yes | **Yes** |
+| TypeScript-first | Parcial | Yes | Yes | Yes | **Yes** |
+| Hooks de eventos | Yes | Yes | Yes | Yes | **Yes** |
 
 <details>
 <summary>Comparación completa (19 características, clic para expandir)</summary>
 
-|  | node-cache-manager | keyv | cacheable | **layercache** |
-|---|:---:|:---:|:---:|:---:|
-| Multicapa con autorrelleno | Parcial | Plugin | -- | **Yes** |
-| Prevención de avalanchas | -- | -- | -- | **Yes** |
-| Single-flight distribuido | -- | -- | -- | **Yes** |
-| Invalidación por tags | -- | Yes | Yes | **Yes** |
-| Tags distribuidos | -- | -- | -- | **Yes** |
-| Flush L1 entre servidores | -- | -- | -- | **Yes** |
-| Stale-while-revalidate | -- | -- | -- | **Yes** |
-| Circuit breaker | -- | -- | -- | **Yes** |
-| Degradación elegante | -- | -- | -- | **Yes** |
-| TTL deslizante / adaptativo | -- | -- | -- | **Yes** |
-| Calentamiento de caché | -- | -- | -- | **Yes** |
-| Persistencia / snapshots | -- | -- | -- | **Yes** |
-| Compresión | -- | -- | Yes | **Yes** |
-| CLI de administración | -- | -- | -- | **Yes** |
-| TypeScript-first | Parcial | Yes | Yes | **Yes** |
-| API Wrap / decorador | Yes | -- | -- | **Yes** |
-| Namespaces | -- | Yes | Yes | **Yes** |
-| Hooks de eventos | Yes | Yes | Yes | **Yes** |
-| Capas personalizadas | Parcial | -- | -- | **Yes** |
+|  | node-cache-manager | keyv | cacheable | BentoCache | **layercache** |
+|---|:---:|:---:|:---:|:---:|:---:|
+| Multicapa con autorrelleno | Parcial | Plugin | -- | Parcial | **Yes** |
+| Prevención de avalanchas | -- | -- | -- | Parcial | **Yes** |
+| Single-flight distribuido | -- | -- | -- | -- | **Yes** |
+| Invalidación por tags | -- | Yes | Yes | Yes | **Yes** |
+| Tags distribuidos | -- | -- | -- | -- | **Yes** |
+| Flush L1 entre servidores | -- | -- | -- | Yes | **Yes** |
+| Stale-while-revalidate | -- | -- | -- | Yes | **Yes** |
+| Circuit breaker | -- | -- | -- | Yes | **Yes** |
+| Degradación elegante | -- | -- | -- | Yes | **Yes** |
+| TTL deslizante / adaptativo | -- | -- | -- | -- | **Yes** |
+| Calentamiento de caché | -- | -- | -- | -- | **Yes** |
+| Persistencia / snapshots | -- | -- | -- | -- | **Yes** |
+| Compresión | -- | -- | Yes | -- | **Yes** |
+| CLI de administración | -- | -- | -- | -- | **Yes** |
+| TypeScript-first | Parcial | Yes | Yes | Yes | **Yes** |
+| API Wrap / decorador | Yes | -- | -- | Parcial | **Yes** |
+| Namespaces | -- | Yes | Yes | Yes | **Yes** |
+| Hooks de eventos | Yes | Yes | Yes | Yes | **Yes** |
+| Capas personalizadas | Parcial | -- | -- | Yes | **Yes** |
 
 </details>
 

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -194,38 +194,38 @@ const cache = new CacheStack([
 
 ## 比較
 
-|  | node-cache-manager | keyv | cacheable | **layercache** |
-|---|:---:|:---:|:---:|:---:|
-| 自動バックフィル付きマルチレイヤー | 部分 | プラグイン | -- | **Yes** |
-| スタンピード防止 | -- | -- | -- | **Yes** |
-| タグ無効化 | -- | Yes | Yes | **Yes** |
-| TypeScript ファースト | 部分 | Yes | Yes | **Yes** |
-| イベントフック | Yes | Yes | Yes | **Yes** |
+|  | node-cache-manager | keyv | cacheable | BentoCache | **layercache** |
+|---|:---:|:---:|:---:|:---:|:---:|
+| 自動バックフィル付きマルチレイヤー | 部分 | プラグイン | -- | 部分 | **Yes** |
+| スタンピード防止 | -- | -- | -- | 部分 | **Yes** |
+| タグ無効化 | -- | Yes | Yes | Yes | **Yes** |
+| TypeScript ファースト | 部分 | Yes | Yes | Yes | **Yes** |
+| イベントフック | Yes | Yes | Yes | Yes | **Yes** |
 
 <details>
 <summary>全機能比較（19 項目、クリックで展開）</summary>
 
-|  | node-cache-manager | keyv | cacheable | **layercache** |
-|---|:---:|:---:|:---:|:---:|
-| 自動バックフィル付きマルチレイヤー | 部分 | プラグイン | -- | **Yes** |
-| スタンピード防止 | -- | -- | -- | **Yes** |
-| 分散シングルフライト | -- | -- | -- | **Yes** |
-| タグ無効化 | -- | Yes | Yes | **Yes** |
-| 分散タグ | -- | -- | -- | **Yes** |
-| クロスサーバー L1 フラッシュ | -- | -- | -- | **Yes** |
-| Stale-while-revalidate | -- | -- | -- | **Yes** |
-| サーキットブレーカー | -- | -- | -- | **Yes** |
-| グレースフルデグラデーション | -- | -- | -- | **Yes** |
-| スライディング / アダプティブ TTL | -- | -- | -- | **Yes** |
-| キャッシュウォーミング | -- | -- | -- | **Yes** |
-| スナップショット永続性 | -- | -- | -- | **Yes** |
-| 圧縮 | -- | -- | Yes | **Yes** |
-| 管理 CLI | -- | -- | -- | **Yes** |
-| TypeScript ファースト | 部分 | Yes | Yes | **Yes** |
-| Wrap / デコレーター API | Yes | -- | -- | **Yes** |
-| ネームスペース | -- | Yes | Yes | **Yes** |
-| イベントフック | Yes | Yes | Yes | **Yes** |
-| カスタムレイヤー | 部分 | -- | -- | **Yes** |
+|  | node-cache-manager | keyv | cacheable | BentoCache | **layercache** |
+|---|:---:|:---:|:---:|:---:|:---:|
+| 自動バックフィル付きマルチレイヤー | 部分 | プラグイン | -- | 部分 | **Yes** |
+| スタンピード防止 | -- | -- | -- | 部分 | **Yes** |
+| 分散シングルフライト | -- | -- | -- | -- | **Yes** |
+| タグ無効化 | -- | Yes | Yes | Yes | **Yes** |
+| 分散タグ | -- | -- | -- | -- | **Yes** |
+| クロスサーバー L1 フラッシュ | -- | -- | -- | Yes | **Yes** |
+| Stale-while-revalidate | -- | -- | -- | Yes | **Yes** |
+| サーキットブレーカー | -- | -- | -- | Yes | **Yes** |
+| グレースフルデグラデーション | -- | -- | -- | Yes | **Yes** |
+| スライディング / アダプティブ TTL | -- | -- | -- | -- | **Yes** |
+| キャッシュウォーミング | -- | -- | -- | -- | **Yes** |
+| スナップショット永続性 | -- | -- | -- | -- | **Yes** |
+| 圧縮 | -- | -- | Yes | -- | **Yes** |
+| 管理 CLI | -- | -- | -- | -- | **Yes** |
+| TypeScript ファースト | 部分 | Yes | Yes | Yes | **Yes** |
+| Wrap / デコレーター API | Yes | -- | -- | 部分 | **Yes** |
+| ネームスペース | -- | Yes | Yes | Yes | **Yes** |
+| イベントフック | Yes | Yes | Yes | Yes | **Yes** |
+| カスタムレイヤー | 部分 | -- | -- | Yes | **Yes** |
 
 </details>
 

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -194,38 +194,38 @@ const cache = new CacheStack([
 
 ## 비교
 
-|  | node-cache-manager | keyv | cacheable | **layercache** |
-|---|:---:|:---:|:---:|:---:|
-| 자동 백필 멀티레이어 | 부분 | 플러그인 | -- | **Yes** |
-| 스탬피드 방지 | -- | -- | -- | **Yes** |
-| 태그 무효화 | -- | Yes | Yes | **Yes** |
-| TypeScript 퍼스트 | 부분 | Yes | Yes | **Yes** |
-| 이벤트 훅 | Yes | Yes | Yes | **Yes** |
+|  | node-cache-manager | keyv | cacheable | BentoCache | **layercache** |
+|---|:---:|:---:|:---:|:---:|:---:|
+| 자동 백필 멀티레이어 | 부분 | 플러그인 | -- | 부분 | **Yes** |
+| 스탬피드 방지 | -- | -- | -- | 부분 | **Yes** |
+| 태그 무효화 | -- | Yes | Yes | Yes | **Yes** |
+| TypeScript 퍼스트 | 부분 | Yes | Yes | Yes | **Yes** |
+| 이벤트 훅 | Yes | Yes | Yes | Yes | **Yes** |
 
 <details>
 <summary>전체 비교 (19개 기능, 클릭하여 펼치기)</summary>
 
-|  | node-cache-manager | keyv | cacheable | **layercache** |
-|---|:---:|:---:|:---:|:---:|
-| 자동 백필 멀티레이어 | 부분 | 플러그인 | -- | **Yes** |
-| 스탬피드 방지 | -- | -- | -- | **Yes** |
-| 분산 싱글플라이트 | -- | -- | -- | **Yes** |
-| 태그 무효화 | -- | Yes | Yes | **Yes** |
-| 분산 태그 | -- | -- | -- | **Yes** |
-| 크로스 서버 L1 무효화 | -- | -- | -- | **Yes** |
-| Stale-while-revalidate | -- | -- | -- | **Yes** |
-| 서킷 브레이커 | -- | -- | -- | **Yes** |
-| 장애 복구 | -- | -- | -- | **Yes** |
-| 슬라이딩 / 적응형 TTL | -- | -- | -- | **Yes** |
-| 캐시 워밍 | -- | -- | -- | **Yes** |
-| 스냅샷 영속성 | -- | -- | -- | **Yes** |
-| 압축 | -- | -- | Yes | **Yes** |
-| 관리 CLI | -- | -- | -- | **Yes** |
-| TypeScript 퍼스트 | 부분 | Yes | Yes | **Yes** |
-| Wrap / 데코레이터 API | Yes | -- | -- | **Yes** |
-| 네임스페이스 | -- | Yes | Yes | **Yes** |
-| 이벤트 훅 | Yes | Yes | Yes | **Yes** |
-| 커스텀 레이어 | 부분 | -- | -- | **Yes** |
+|  | node-cache-manager | keyv | cacheable | BentoCache | **layercache** |
+|---|:---:|:---:|:---:|:---:|:---:|
+| 자동 백필 멀티레이어 | 부분 | 플러그인 | -- | 부분 | **Yes** |
+| 스탬피드 방지 | -- | -- | -- | 부분 | **Yes** |
+| 분산 싱글플라이트 | -- | -- | -- | -- | **Yes** |
+| 태그 무효화 | -- | Yes | Yes | Yes | **Yes** |
+| 분산 태그 | -- | -- | -- | -- | **Yes** |
+| 크로스 서버 L1 무효화 | -- | -- | -- | Yes | **Yes** |
+| Stale-while-revalidate | -- | -- | -- | Yes | **Yes** |
+| 서킷 브레이커 | -- | -- | -- | Yes | **Yes** |
+| 장애 복구 | -- | -- | -- | Yes | **Yes** |
+| 슬라이딩 / 적응형 TTL | -- | -- | -- | -- | **Yes** |
+| 캐시 워밍 | -- | -- | -- | -- | **Yes** |
+| 스냅샷 영속성 | -- | -- | -- | -- | **Yes** |
+| 압축 | -- | -- | Yes | -- | **Yes** |
+| 관리 CLI | -- | -- | -- | -- | **Yes** |
+| TypeScript 퍼스트 | 부분 | Yes | Yes | Yes | **Yes** |
+| Wrap / 데코레이터 API | Yes | -- | -- | 부분 | **Yes** |
+| 네임스페이스 | -- | Yes | Yes | Yes | **Yes** |
+| 이벤트 훅 | Yes | Yes | Yes | Yes | **Yes** |
+| 커스텀 레이어 | 부분 | -- | -- | Yes | **Yes** |
 
 </details>
 

--- a/docs/i18n/README.zh-CN.md
+++ b/docs/i18n/README.zh-CN.md
@@ -194,38 +194,38 @@ const cache = new CacheStack([
 
 ## 横向对比
 
-|  | node-cache-manager | keyv | cacheable | **layercache** |
-|---|:---:|:---:|:---:|:---:|
-| 自动回填多层缓存 | 部分 | 插件 | -- | **Yes** |
-| 缓存击穿保护 | -- | -- | -- | **Yes** |
-| 标签失效 | -- | Yes | Yes | **Yes** |
-| TypeScript 优先 | 部分 | Yes | Yes | **Yes** |
-| 事件钩子 | Yes | Yes | Yes | **Yes** |
+|  | node-cache-manager | keyv | cacheable | BentoCache | **layercache** |
+|---|:---:|:---:|:---:|:---:|:---:|
+| 自动回填多层缓存 | 部分 | 插件 | -- | 部分 | **Yes** |
+| 缓存击穿保护 | -- | -- | -- | 部分 | **Yes** |
+| 标签失效 | -- | Yes | Yes | Yes | **Yes** |
+| TypeScript 优先 | 部分 | Yes | Yes | Yes | **Yes** |
+| 事件钩子 | Yes | Yes | Yes | Yes | **Yes** |
 
 <details>
 <summary>完整对比（19 项功能，点击展开）</summary>
 
-|  | node-cache-manager | keyv | cacheable | **layercache** |
-|---|:---:|:---:|:---:|:---:|
-| 自动回填多层缓存 | 部分 | 插件 | -- | **Yes** |
-| 缓存击穿保护 | -- | -- | -- | **Yes** |
-| 分布式单飞 | -- | -- | -- | **Yes** |
-| 标签失效 | -- | Yes | Yes | **Yes** |
-| 分布式标签 | -- | -- | -- | **Yes** |
-| 跨实例 L1 刷新 | -- | -- | -- | **Yes** |
-| Stale-while-revalidate | -- | -- | -- | **Yes** |
-| 熔断器 | -- | -- | -- | **Yes** |
-| 优雅降级 | -- | -- | -- | **Yes** |
-| 滑动 / 自适应 TTL | -- | -- | -- | **Yes** |
-| 缓存预热 | -- | -- | -- | **Yes** |
-| 快照持久化 | -- | -- | -- | **Yes** |
-| 压缩 | -- | -- | Yes | **Yes** |
-| 管理 CLI | -- | -- | -- | **Yes** |
-| TypeScript 优先 | 部分 | Yes | Yes | **Yes** |
-| Wrap / 装饰器 API | Yes | -- | -- | **Yes** |
-| 命名空间 | -- | Yes | Yes | **Yes** |
-| 事件钩子 | Yes | Yes | Yes | **Yes** |
-| 自定义层 | 部分 | -- | -- | **Yes** |
+|  | node-cache-manager | keyv | cacheable | BentoCache | **layercache** |
+|---|:---:|:---:|:---:|:---:|:---:|
+| 自动回填多层缓存 | 部分 | 插件 | -- | 部分 | **Yes** |
+| 缓存击穿保护 | -- | -- | -- | 部分 | **Yes** |
+| 分布式单飞 | -- | -- | -- | -- | **Yes** |
+| 标签失效 | -- | Yes | Yes | Yes | **Yes** |
+| 分布式标签 | -- | -- | -- | -- | **Yes** |
+| 跨实例 L1 刷新 | -- | -- | -- | Yes | **Yes** |
+| Stale-while-revalidate | -- | -- | -- | Yes | **Yes** |
+| 熔断器 | -- | -- | -- | Yes | **Yes** |
+| 优雅降级 | -- | -- | -- | Yes | **Yes** |
+| 滑动 / 自适应 TTL | -- | -- | -- | -- | **Yes** |
+| 缓存预热 | -- | -- | -- | -- | **Yes** |
+| 快照持久化 | -- | -- | -- | -- | **Yes** |
+| 压缩 | -- | -- | Yes | -- | **Yes** |
+| 管理 CLI | -- | -- | -- | -- | **Yes** |
+| TypeScript 优先 | 部分 | Yes | Yes | Yes | **Yes** |
+| Wrap / 装饰器 API | Yes | -- | -- | 部分 | **Yes** |
+| 命名空间 | -- | Yes | Yes | Yes | **Yes** |
+| 事件钩子 | Yes | Yes | Yes | Yes | **Yes** |
+| 自定义层 | 部分 | -- | -- | Yes | **Yes** |
 
 </details>
 


### PR DESCRIPTION
## Summary

- Add a balanced "layercache vs. BentoCache" section to `docs/comparison.md` covering both libraries' strengths
- Add BentoCache column to the overview comparison table in `docs/comparison.md` (19 features)
- Add BentoCache column to both summary and full comparison tables in `README.md`

## Details

The comparison acknowledges BentoCache's genuine strengths (driver ecosystem, AdonisJS integration, friendly TTLs, factory context API, plugin system, Grafana dashboard) while documenting layercache's advantages in distributed coordination, operational tooling, freshness strategies, and multi-layer depth.

Refs #21