### PR TITLE
feat: add docs website source to monorepo (docs-web/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ coverage/
 .env.*
 *.tgz
 benchmark-results/
+
+# Docs website
+.next/
+docs-web/tsconfig.tsbuildinfo

--- a/biome.json
+++ b/biome.json
@@ -36,6 +36,6 @@
     }
   },
   "files": {
-    "ignore": ["dist", "node_modules", "coverage", "*.json"]
+    "ignore": ["dist", "node_modules", "coverage", "*.json", "docs-web"]
   }
 }

--- a/docs-web/.gitignore
+++ b/docs-web/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.next/
+out/

--- a/docs-web/app/.well-known/agent-card.json/route.ts
+++ b/docs-web/app/.well-known/agent-card.json/route.ts
@@ -1,0 +1,64 @@
+export const dynamic = "force-static";
+
+const BASE = "https://layercache.dev";
+
+const CARD = {
+  name: "Layercache Docs Agent",
+  version: "1.3.2",
+  description:
+    "Documentation agent for Layercache, a production-grade multi-layer caching toolkit for Node.js. Answers questions about the API, layers, invalidation, resilience, and integrations.",
+  url: BASE,
+  provider: {
+    organization: "Layercache",
+    url: "https://github.com/flyingsquirrel0419/layercache",
+  },
+  documentationUrl: `${BASE}/docs`,
+  supportedInterfaces: [
+    {
+      transport: "http+markdown",
+      url: `${BASE}/`,
+      description:
+        "Any page on layercache.dev returns text/markdown when requested with Accept: text/markdown.",
+    },
+  ],
+  capabilities: {
+    streaming: false,
+    pushNotifications: false,
+    stateTransitionHistory: false,
+  },
+  defaultInputModes: ["text/plain", "text/markdown"],
+  defaultOutputModes: ["text/markdown", "text/html"],
+  skills: [
+    {
+      id: "search-docs",
+      name: "Search Docs",
+      description:
+        "Search the Layercache documentation for APIs, options, and usage patterns.",
+      tags: ["docs", "search"],
+    },
+    {
+      id: "get-started",
+      name: "Get Started Guide",
+      description:
+        "Walk a developer through installing Layercache and configuring memory, Redis, and disk layers.",
+      tags: ["tutorial", "install"],
+    },
+    {
+      id: "api-reference",
+      name: "API Reference Lookup",
+      description:
+        "Retrieve reference docs for CacheStack, MemoryLayer, RedisLayer, DiskLayer, invalidation, and resilience APIs.",
+      tags: ["api", "reference"],
+    },
+  ],
+};
+
+export function GET() {
+  return new Response(JSON.stringify(CARD, null, 2), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "public, max-age=3600, s-maxage=86400",
+    },
+  });
+}

--- a/docs-web/app/.well-known/agent-skills/index.json/route.ts
+++ b/docs-web/app/.well-known/agent-skills/index.json/route.ts
@@ -1,0 +1,79 @@
+export const dynamic = "force-static";
+
+const BASE = "https://layercache.dev";
+
+const INDEX = {
+  $schema:
+    "https://raw.githubusercontent.com/cloudflare/agent-skills-discovery-rfc/main/schema/v0.2.0/skills-index.schema.json",
+  version: "0.2.0",
+  publisher: {
+    name: "Layercache",
+    url: BASE,
+  },
+  skills: [
+    {
+      name: "layercache-getting-started",
+      type: "documentation",
+      description:
+        "Install Layercache and configure a multi-layer cache stack (memory + Redis + disk) with stampede prevention.",
+      url: `${BASE}/docs/getting-started`,
+      sha256:
+        "0000000000000000000000000000000000000000000000000000000000000000",
+    },
+    {
+      name: "layercache-api-reference",
+      type: "documentation",
+      description:
+        "Complete API reference for CacheStack, MemoryLayer, RedisLayer, DiskLayer, tags, wrap(), namespace(), and bulk ops.",
+      url: `${BASE}/docs/api`,
+      sha256:
+        "0000000000000000000000000000000000000000000000000000000000000000",
+    },
+    {
+      name: "layercache-invalidation",
+      type: "documentation",
+      description:
+        "Tag-based, prefix, wildcard, and generation-based invalidation across all layers, with Redis pub/sub fan-out.",
+      url: `${BASE}/docs/invalidation`,
+      sha256:
+        "0000000000000000000000000000000000000000000000000000000000000000",
+    },
+    {
+      name: "layercache-resilience",
+      type: "documentation",
+      description:
+        "Circuit breaker, stale-while-revalidate, stale-if-error, per-command timeouts, and graceful degradation.",
+      url: `${BASE}/docs/resilience`,
+      sha256:
+        "0000000000000000000000000000000000000000000000000000000000000000",
+    },
+    {
+      name: "layercache-observability",
+      type: "documentation",
+      description:
+        "OpenTelemetry tracing, Prometheus metrics, event hooks, and HTTP stats endpoints.",
+      url: `${BASE}/docs/observability`,
+      sha256:
+        "0000000000000000000000000000000000000000000000000000000000000000",
+    },
+    {
+      name: "layercache-integrations",
+      type: "documentation",
+      description:
+        "Middleware for Express, Fastify, Hono, tRPC, GraphQL, and Next.js.",
+      url: `${BASE}/docs/integrations`,
+      sha256:
+        "0000000000000000000000000000000000000000000000000000000000000000",
+    },
+  ],
+};
+
+export function GET() {
+  return new Response(JSON.stringify(INDEX, null, 2), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "public, max-age=3600, s-maxage=86400",
+    },
+  });
+}

--- a/docs-web/app/.well-known/api-catalog/route.ts
+++ b/docs-web/app/.well-known/api-catalog/route.ts
@@ -1,0 +1,70 @@
+export const dynamic = "force-static";
+
+const BASE = "https://layercache.dev";
+
+const CATALOG = {
+  linkset: [
+    {
+      anchor: `${BASE}/`,
+      "service-desc": [
+        {
+          href: `${BASE}/.well-known/mcp/server-card.json`,
+          type: "application/json",
+          title: "MCP Server Card",
+        },
+        {
+          href: `${BASE}/.well-known/agent-card.json`,
+          type: "application/json",
+          title: "A2A Agent Card",
+        },
+      ],
+      "service-doc": [
+        {
+          href: `${BASE}/docs`,
+          type: "text/html",
+          title: "Layercache Documentation",
+        },
+        {
+          href: `${BASE}/docs/api`,
+          type: "text/html",
+          title: "Layercache API Reference",
+        },
+      ],
+      "service-meta": [
+        {
+          href: `${BASE}/.well-known/agent-skills/index.json`,
+          type: "application/json",
+          title: "Agent Skills Discovery Index",
+        },
+      ],
+      status: [
+        {
+          href: `${BASE}/docs`,
+          type: "text/html",
+        },
+      ],
+      author: [
+        {
+          href: "https://github.com/flyingsquirrel0419/layercache",
+          title: "Layercache on GitHub",
+        },
+      ],
+      license: [
+        {
+          href: "https://www.apache.org/licenses/LICENSE-2.0",
+          title: "Apache License 2.0",
+        },
+      ],
+    },
+  ],
+};
+
+export function GET() {
+  return new Response(JSON.stringify(CATALOG, null, 2), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/linkset+json",
+      "Cache-Control": "public, max-age=3600, s-maxage=86400",
+    },
+  });
+}

--- a/docs-web/app/.well-known/mcp/server-card.json/route.ts
+++ b/docs-web/app/.well-known/mcp/server-card.json/route.ts
@@ -1,0 +1,79 @@
+export const dynamic = "force-static";
+
+const BASE = "https://layercache.dev";
+
+const CARD = {
+  $schema:
+    "https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/main/schema/server-card.schema.json",
+  serverInfo: {
+    name: "layercache-docs",
+    version: "1.3.2",
+    title: "Layercache Documentation MCP Server",
+    description:
+      "Read-only MCP server exposing Layercache documentation and API reference as tools and resources for AI agents.",
+  },
+  transport: {
+    type: "http",
+    url: `${BASE}/mcp`,
+  },
+  capabilities: {
+    tools: { listChanged: false },
+    resources: { subscribe: false, listChanged: false },
+    prompts: { listChanged: false },
+    logging: {},
+  },
+  tools: [
+    {
+      name: "search_docs",
+      description:
+        "Full-text search across the Layercache documentation. Returns matching pages with titles, URLs, and excerpts.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string", description: "Search query" },
+          limit: { type: "integer", minimum: 1, maximum: 20, default: 5 },
+        },
+        required: ["query"],
+      },
+    },
+    {
+      name: "get_doc",
+      description:
+        "Retrieve a single documentation page as markdown by slug (e.g. 'getting-started', 'api', 'resilience').",
+      inputSchema: {
+        type: "object",
+        properties: {
+          slug: { type: "string" },
+        },
+        required: ["slug"],
+      },
+    },
+  ],
+  resources: [
+    {
+      uri: `${BASE}/docs`,
+      name: "Layercache Docs Index",
+      mimeType: "text/html",
+    },
+    {
+      uri: `${BASE}/.well-known/api-catalog`,
+      name: "API Catalog",
+      mimeType: "application/linkset+json",
+    },
+  ],
+  metadata: {
+    license: "Apache-2.0",
+    homepage: BASE,
+    repository: "https://github.com/flyingsquirrel0419/layercache",
+  },
+};
+
+export function GET() {
+  return new Response(JSON.stringify(CARD, null, 2), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "public, max-age=3600, s-maxage=86400",
+    },
+  });
+}

--- a/docs-web/app/.well-known/oauth-protected-resource/route.ts
+++ b/docs-web/app/.well-known/oauth-protected-resource/route.ts
@@ -1,0 +1,28 @@
+export const dynamic = "force-static";
+
+const BASE = "https://layercache.dev";
+
+// RFC 9728 OAuth 2.0 Protected Resource Metadata.
+// Layercache's public docs and MCP server currently require no bearer
+// authentication; authorization_servers is intentionally empty and
+// bearer_methods_supported is omitted. Agents can still discover that no
+// credentials are needed for read access.
+const METADATA = {
+  resource: BASE,
+  authorization_servers: [] as string[],
+  scopes_supported: [] as string[],
+  bearer_methods_supported: ["header"],
+  resource_documentation: `${BASE}/docs/api`,
+  resource_name: "Layercache Documentation & MCP",
+  resource_policy_uri: `${BASE}/robots.txt`,
+};
+
+export function GET() {
+  return new Response(JSON.stringify(METADATA, null, 2), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "public, max-age=3600, s-maxage=86400",
+    },
+  });
+}

--- a/docs-web/app/actions/search.ts
+++ b/docs-web/app/actions/search.ts
@@ -1,0 +1,6 @@
+"use server";
+import { search } from "@/lib/search-index";
+
+export async function searchDocs(query: string) {
+  return search(query);
+}

--- a/docs-web/app/api/markdown/[[...path]]/route.ts
+++ b/docs-web/app/api/markdown/[[...path]]/route.ts
@@ -1,0 +1,132 @@
+import { NextRequest } from "next/server";
+import fs from "fs";
+import path from "path";
+import { getAllDocs } from "@/lib/mdx";
+
+export const dynamic = "force-static";
+
+const contentDir = path.join(process.cwd(), "content/docs");
+
+const HOME_MARKDOWN = `# Layercache
+
+> Production-ready multi-layer caching for Node.js.
+
+Layercache stacks memory, Redis, and disk behind a single API with single-flight
+stampede prevention, tag invalidation, stale-while-revalidate, circuit breakers,
+and full observability.
+
+## Core Architecture
+
+- **L1 Memory** — per-process, ~0.01 ms
+- **L2 Redis** — shared across instances, ~0.5 ms
+- **L3 Disk** — persistent, ~2 ms
+
+On hit, the fastest available layer serves and backfills slower layers.
+On miss, the fetcher runs exactly once even under 100+ concurrent callers.
+
+## Install
+
+\`\`\`bash
+npm install layercache
+\`\`\`
+
+Requires Node.js >= 20.
+
+## Example
+
+\`\`\`ts
+import { CacheStack, MemoryLayer, RedisLayer } from 'layercache'
+import Redis from 'ioredis'
+
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 60, maxSize: 1_000 }),
+  new RedisLayer({ client: new Redis(), ttl: 3600, commandTimeoutMs: 50 }),
+])
+
+const user = await cache.get('user:123', () => db.findUser(123))
+\`\`\`
+
+## Key Features
+
+- Single-flight deduplication (local + distributed via Redis leases)
+- Tag-based, wildcard, and generation-based invalidation
+- Stale-while-revalidate and stale-if-error
+- Circuit breaker with graceful degradation when a layer fails
+- OpenTelemetry tracing, Prometheus metrics, event hooks
+- Framework middleware: Express, Fastify, Hono, tRPC, GraphQL, Next.js
+
+## Discovery for Agents
+
+- API catalog: \`/.well-known/api-catalog\`
+- A2A Agent Card: \`/.well-known/agent-card.json\`
+- MCP Server Card: \`/.well-known/mcp/server-card.json\`
+- Agent skills index: \`/.well-known/agent-skills/index.json\`
+
+## Links
+
+- Docs: https://layercache.dev/docs
+- API Reference: https://layercache.dev/docs/api
+- Source: https://github.com/flyingsquirrel0419/layercache
+- License: Apache-2.0
+`;
+
+function safeJoin(base: string, target: string): string | null {
+  const resolved = path.resolve(base, target);
+  if (!resolved.startsWith(base)) return null;
+  return resolved;
+}
+
+function readDocMarkdown(slug: string): string | null {
+  const fileName = slug || "index";
+  const filePath = safeJoin(contentDir, `${fileName}.mdx`);
+  if (!filePath) return null;
+  if (!fs.existsSync(filePath)) return null;
+  return fs.readFileSync(filePath, "utf-8");
+}
+
+function markdownResponse(body: string, tokens: number): Response {
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "X-Markdown-Tokens": String(tokens),
+      Vary: "Accept",
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}
+
+function estimateTokens(text: string): number {
+  return Math.max(1, Math.ceil(text.length / 4));
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ path?: string[] }> }
+) {
+  const resolved = await params;
+  const segments = resolved.path ?? [];
+
+  if (segments.length === 0) {
+    return markdownResponse(HOME_MARKDOWN, estimateTokens(HOME_MARKDOWN));
+  }
+
+  if (segments[0] === "docs") {
+    const slug = segments.slice(1).join("/");
+    const md = readDocMarkdown(slug);
+    if (md) return markdownResponse(md, estimateTokens(md));
+
+    if (slug === "") {
+      const list = getAllDocs()
+        .map((d) => `- [${d.title}](/docs/${d.slug}) — ${d.description}`)
+        .join("\n");
+      const body = `# Layercache Documentation\n\n${list}\n`;
+      return markdownResponse(body, estimateTokens(body));
+    }
+  }
+
+  return new Response("Not Found", {
+    status: 404,
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+}

--- a/docs-web/app/docs/[[...slug]]/page.tsx
+++ b/docs-web/app/docs/[[...slug]]/page.tsx
@@ -1,0 +1,89 @@
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
+import { notFound } from "next/navigation";
+import { MDXRemote } from "next-mdx-remote/rsc";
+import { getAllSlugs } from "@/lib/docs-config";
+import { getMDXComponents } from "@/components/docs/MDXComponents";
+import Sidebar from "@/components/docs/Sidebar";
+import TOC from "@/components/docs/TOC";
+import type { Metadata } from "next";
+import rehypeHighlight from "rehype-highlight";
+import rehypeSlug from "rehype-slug";
+import SlugExtractor from "@/components/docs/SlugExtractor";
+
+type Props = {
+  params: Promise<{ slug?: string[] }>;
+};
+
+export async function generateStaticParams() {
+  const slugs = getAllSlugs();
+  return slugs.map((slug) => ({ slug: slug ? [slug] : [] }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const slugStr = slug?.join("/") || "";
+  const contentDir = path.join(process.cwd(), "content/docs");
+  const filePath = path.join(contentDir, `${slugStr || "index"}.mdx`);
+  try {
+    const source = fs.readFileSync(filePath, "utf-8");
+    const { data } = matter(source);
+    return {
+      title: `${data.title || "Docs"} — Layercache`,
+      description: data.description || "",
+    };
+  } catch {
+    return { title: "Layercache Docs" };
+  }
+}
+
+export default async function DocPage({ params }: Props) {
+  const { slug } = await params;
+  const slugStr = slug?.join("/") || "";
+
+  const contentDir = path.join(process.cwd(), "content/docs");
+  const filePath = path.join(contentDir, `${slugStr || "index"}.mdx`);
+
+  try {
+    const source = fs.readFileSync(filePath, "utf-8");
+    const { data, content } = matter(source);
+
+    const components = getMDXComponents();
+
+    return (
+      <>
+        {/* Sidebar: mobile toggle+drawer lives here, outside the lg:hidden aside */}
+        <Sidebar currentSlug={slugStr} />
+
+        <main className="flex-1 min-w-0 px-6 py-8 lg:px-12 max-w-none">
+          <h1 className="text-4xl font-bold mb-2">{data.title}</h1>
+          {data.description && (
+            <p className="text-text-secondary text-lg mb-8">{data.description}</p>
+          )}
+          <div className="prose-custom">
+            <MDXRemote
+              source={content}
+              components={components}
+              options={{
+                mdxOptions: {
+                  rehypePlugins: [rehypeSlug, rehypeHighlight],
+                  format: "mdx",
+                },
+              }}
+            />
+          </div>
+        </main>
+
+        {/* TOC with client-side slug extraction to match rehype-slug */}
+        <SlugExtractor>
+          <aside className="hidden xl:block w-50 flex-shrink-0 border-l border-border h-[calc(100vh-4rem)] sticky top-16 overflow-y-auto p-4">
+            <TOC />
+          </aside>
+        </SlugExtractor>
+      </>
+    );
+  } catch (error) {
+    notFound();
+  }
+}

--- a/docs-web/app/docs/layout.tsx
+++ b/docs-web/app/docs/layout.tsx
@@ -1,0 +1,12 @@
+import { DocsHeader } from "@/components/docs/DocsHeader";
+
+export default function DocsLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen">
+      <DocsHeader />
+      <div className="max-w-screen-xl mx-auto flex">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/docs-web/app/globals.css
+++ b/docs-web/app/globals.css
@@ -1,0 +1,99 @@
+@import "tailwindcss";
+
+:root {
+  --color-background: #fafafa;
+  --color-surface: #ffffff;
+  --color-border: #e5e5e5;
+  --color-text-primary: #1a1a2e;
+  --color-text-secondary: #6b7280;
+  --color-accent: #4f46e5;
+  --color-accent-light: #6366f1;
+}
+
+.dark {
+  --color-background: #0a0a0f;
+  --color-surface: #141420;
+  --color-border: #1e1e35;
+  --color-text-primary: #e4e4ef;
+  --color-text-secondary: #8888a8;
+  --color-accent: #6366f1;
+  --color-accent-light: #818cf8;
+}
+
+@keyframes pulse-slow {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+.animate-pulse-slow {
+  animation: pulse-slow 6s ease-in-out infinite;
+}
+
+.animation-delay-2000 {
+  animation-delay: 2s;
+}
+
+.prose-custom h2 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-top: 2.5rem;
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.prose-custom h3 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+}
+
+.prose-custom p {
+  margin-bottom: 1rem;
+  line-height: 1.75;
+}
+
+.prose-custom ul, .prose-custom ol {
+  margin-bottom: 1rem;
+  padding-left: 1.5rem;
+}
+
+.prose-custom ul {
+  list-style-type: disc;
+}
+
+.prose-custom ol {
+  list-style-type: decimal;
+}
+
+.prose-custom li {
+  margin-bottom: 0.25rem;
+}
+
+.prose-custom a {
+  color: var(--color-accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.prose-custom a:hover {
+  color: var(--color-accent-light);
+}
+
+.prose-custom blockquote {
+  border-left: 4px solid var(--color-accent);
+  padding-left: 1rem;
+  margin: 1.5rem 0;
+  color: var(--color-text-secondary);
+  font-style: italic;
+}
+
+.prose-custom hr {
+  border-color: var(--color-border);
+  margin: 2rem 0;
+}

--- a/docs-web/app/layout.tsx
+++ b/docs-web/app/layout.tsx
@@ -1,0 +1,68 @@
+import type { Metadata } from "next";
+import { Inter, JetBrains_Mono } from "next/font/google";
+import { ThemeProvider } from "next-themes";
+import "./globals.css";
+
+const inter = Inter({
+  subsets: ["latin"],
+  variable: "--font-inter",
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ["latin"],
+  variable: "--font-jetbrains",
+});
+
+export const metadata: Metadata = {
+  title: "Layercache — Production-Ready Multi-Layer Caching for Node.js",
+  description: "Stack memory, Redis, and disk behind one API with stampede prevention, tag invalidation, stale-while-revalidate, and full observability.",
+  openGraph: {
+    title: "Layercache — Multi-Layer Caching for Node.js",
+    description: "Production-ready multi-layer caching with stampede prevention, tag invalidation, and full observability.",
+    url: "https://layercache.dev",
+    siteName: "Layercache",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Layercache — Multi-Layer Caching for Node.js",
+    description: "Production-ready multi-layer caching with stampede prevention, tag invalidation, and full observability.",
+  },
+  metadataBase: new URL("https://layercache.dev"),
+  alternates: {
+    canonical: "/",
+    types: {
+      "text/markdown": "/",
+    },
+  },
+  other: {
+    "ai-content-declaration": "Content-Signal: search=yes, ai-input=yes, ai-train=no",
+  },
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <link rel="api-catalog" href="/.well-known/api-catalog" type="application/linkset+json" />
+        <link rel="service-desc" href="/.well-known/mcp/server-card.json" type="application/json" title="MCP Server Card" />
+        <link rel="service-desc" href="/.well-known/agent-card.json" type="application/json" title="A2A Agent Card" />
+        <link rel="agent-skills" href="/.well-known/agent-skills/index.json" type="application/json" />
+        <link rel="service-doc" href="/docs/api" type="text/html" title="Layercache API Reference" />
+        <link rel="help" href="/docs" type="text/html" title="Layercache Documentation" />
+        <link rel="alternate" href="/" type="text/markdown" title="Markdown version" />
+      </head>
+      <body
+        className={`${inter.variable} ${jetbrainsMono.variable} font-sans antialiased`}
+      >
+        <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
+          {children}
+        </ThemeProvider>
+      </body>
+    </html>
+  );
+}

--- a/docs-web/app/page.tsx
+++ b/docs-web/app/page.tsx
@@ -1,0 +1,21 @@
+import { Navbar } from "@/components/landing/Navbar";
+import { Hero } from "@/components/landing/Hero";
+import { Features } from "@/components/landing/Features";
+import { HowItWorks } from "@/components/landing/HowItWorks";
+import { Comparison } from "@/components/landing/Comparison";
+import { CTA } from "@/components/landing/CTA";
+import { WebMCP } from "@/components/landing/WebMCP";
+
+export default function LandingPage() {
+  return (
+    <main>
+      <WebMCP />
+      <Navbar />
+      <Hero />
+      <Features />
+      <HowItWorks />
+      <Comparison />
+      <CTA />
+    </main>
+  );
+}

--- a/docs-web/app/playground/layout.tsx
+++ b/docs-web/app/playground/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Playground — Layercache",
+  description: "Interactive playground for Layercache caching library",
+};
+
+export default function PlaygroundLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/docs-web/app/playground/page.tsx
+++ b/docs-web/app/playground/page.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Suspense } from "react";
+import dynamic from "next/dynamic";
+
+const PlaygroundClient = dynamic(
+  () => import("@/components/playground/PlaygroundClient").then((m) => m.PlaygroundClient),
+  {
+    ssr: false,
+  }
+);
+
+export default function PlaygroundPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center text-text-secondary">
+          Loading playground...
+        </div>
+      }
+    >
+      <PlaygroundClient />
+    </Suspense>
+  );
+}

--- a/docs-web/app/robots.txt/route.ts
+++ b/docs-web/app/robots.txt/route.ts
@@ -1,0 +1,24 @@
+export const dynamic = "force-static";
+
+const BODY = `# Layercache robots.txt
+# Content Signals (https://contentsignals.org, draft-romm-aipref-contentsignals)
+# Declares preferences for how this site's public content may be used.
+Content-Signal: search=yes, ai-input=yes, ai-train=no
+
+User-agent: *
+Allow: /
+Disallow: /playground
+Disallow: /api/markdown
+
+Sitemap: https://layercache.dev/sitemap.xml
+`;
+
+export function GET() {
+  return new Response(BODY, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, s-maxage=86400",
+    },
+  });
+}

--- a/docs-web/app/search-index.json/route.ts
+++ b/docs-web/app/search-index.json/route.ts
@@ -1,0 +1,19 @@
+import { getAllDocs } from "@/lib/mdx";
+
+export const dynamic = "force-static";
+
+export function GET() {
+  const docs = getAllDocs().map((d) => ({
+    title: d.title,
+    slug: d.slug === "index" ? "" : d.slug,
+    description: d.description,
+  }));
+
+  return new Response(JSON.stringify(docs), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "public, max-age=3600, s-maxage=86400",
+    },
+  });
+}

--- a/docs-web/app/sitemap.ts
+++ b/docs-web/app/sitemap.ts
@@ -1,0 +1,60 @@
+import type { MetadataRoute } from "next";
+import { getAllSlugs } from "@/lib/docs-config";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = "https://layercache.dev";
+
+  const docSlugs = getAllSlugs();
+  const docPages = docSlugs.map((slug) => ({
+    url: `${baseUrl}/docs/${slug}`,
+    lastModified: new Date(),
+    changeFrequency: "weekly" as const,
+    priority: 0.8,
+  }));
+
+  return [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/docs`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.9,
+    },
+    ...docPages,
+    {
+      url: `${baseUrl}/playground`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+    {
+      url: `${baseUrl}/.well-known/api-catalog`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.3,
+    },
+    {
+      url: `${baseUrl}/.well-known/agent-card.json`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.3,
+    },
+    {
+      url: `${baseUrl}/.well-known/mcp/server-card.json`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.3,
+    },
+    {
+      url: `${baseUrl}/.well-known/agent-skills/index.json`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.3,
+    },
+  ];
+}

--- a/docs-web/components/docs/DocsHeader.tsx
+++ b/docs-web/components/docs/DocsHeader.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import ThemeToggle from "@/components/ui/ThemeToggle";
+import { SearchModal } from "./SearchModal";
+
+export function DocsHeader() {
+  const [searchOpen, setSearchOpen] = useState(false);
+
+  // Handle Cmd+K / Ctrl+K
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        setSearchOpen(true);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  return (
+    <>
+      <header className="sticky top-0 z-40 h-16 flex items-center justify-between px-6 border-b border-border bg-background/80 backdrop-blur-lg">
+        <div className="flex items-center gap-2">
+          <Link href="/" className="font-semibold text-text-primary">
+            Layercache
+          </Link>
+          <span className="text-text-secondary">/</span>
+          <span className="text-text-secondary">Docs</span>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setSearchOpen(true)}
+            className="w-9 h-9 rounded-lg flex items-center justify-center text-text-secondary hover:text-text-primary hover:bg-surface transition-colors duration-150 group relative"
+          >
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <circle cx="11" cy="11" r="8" />
+              <line x1="21" y1="21" x2="16.65" y2="16.65" />
+            </svg>
+            <span className="sr-only">Search</span>
+            <span className="absolute top-14 right-6 hidden group-hover:block bg-surface border border-border rounded-md px-2 py-1 text-xs text-text-secondary whitespace-nowrap">
+              Search <kbd className="ml-1 px-1.5 py-0.5 bg-background rounded border border-border">⌘ K</kbd>
+            </span>
+          </button>
+          <ThemeToggle />
+        </div>
+      </header>
+
+      <SearchModal isOpen={searchOpen} onClose={() => setSearchOpen(false)} />
+    </>
+  );
+}

--- a/docs-web/components/docs/MDXComponents.tsx
+++ b/docs-web/components/docs/MDXComponents.tsx
@@ -1,0 +1,64 @@
+import CopyButton from "@/components/ui/CopyButton";
+import Callout from "@/components/ui/Callout";
+import CodeGroup from "@/components/ui/CodeGroup";
+import Stepper from "@/components/ui/Stepper";
+
+export function getMDXComponents() {
+  return {
+    Callout,
+    CodeGroup,
+    Stepper,
+    // Override pre tag for code blocks
+    pre: ({ children }: { children: React.ReactNode }) => {
+      // Extract text from code child for copy button
+      const codeElement = children as React.ReactElement & { props?: { children?: string; className?: string } };
+      const codeText = typeof codeElement?.props?.children === "string"
+        ? codeElement.props.children
+        : "";
+      const filename = codeElement?.props?.className?.replace("language-", "") || "";
+
+      return (
+        <div className="relative group my-6">
+          {filename && (
+            <div className="flex items-center justify-between px-4 py-2 bg-surface border border-border border-b-0 rounded-t-lg">
+              <span className="text-xs text-text-secondary">{filename}</span>
+            </div>
+          )}
+          <pre className={`${filename ? "border-t-0 rounded-t-none" : ""} overflow-x-auto rounded-lg border border-border bg-surface p-4 text-sm`}>
+            {children}
+          </pre>
+          {codeText && <CopyButton text={codeText} />}
+        </div>
+      );
+    },
+    // Style inline code
+    code: ({ children, className }: { children: React.ReactNode; className?: string }) => {
+      // If inside a pre block (code block), just render as-is
+      if (className) {
+        return <code className={className}>{children}</code>;
+      }
+      // Inline code
+      return (
+        <code className="px-1.5 py-0.5 rounded bg-surface border border-border text-sm font-mono">
+          {children}
+        </code>
+      );
+    },
+    // Style tables
+    table: ({ children }: { children: React.ReactNode }) => (
+      <div className="my-6 overflow-x-auto">
+        <table className="w-full border-collapse border border-border">
+          {children}
+        </table>
+      </div>
+    ),
+    th: ({ children }: { children: React.ReactNode }) => (
+      <th className="border border-border px-4 py-2 bg-surface text-left text-sm font-semibold">
+        {children}
+      </th>
+    ),
+    td: ({ children }: { children: React.ReactNode }) => (
+      <td className="border border-border px-4 py-2 text-sm">{children}</td>
+    ),
+  };
+}

--- a/docs-web/components/docs/SearchModal.tsx
+++ b/docs-web/components/docs/SearchModal.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { useRouter } from "next/navigation";
+import { searchDocs } from "@/app/actions/search";
+import {
+  getNextSelectedIndex,
+  shouldApplySearchResponse,
+} from "@/lib/docs/search-modal-state.mjs";
+
+type SearchResult = {
+  title: string;
+  slug: string;
+  snippet: string;
+};
+
+export function SearchModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+  const latestRequestIdRef = useRef(0);
+
+  // Handle keyboard shortcuts
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      } else if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSelectedIndex((i) => getNextSelectedIndex(i, 1, results.length));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSelectedIndex((i) => getNextSelectedIndex(i, -1, results.length));
+      } else if (e.key === "Enter" && results.length > 0) {
+        e.preventDefault();
+        const result = results[selectedIndex];
+        if (result) {
+          router.push(result.slug ? `/docs/${result.slug}` : "/docs");
+          onClose();
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose, results, selectedIndex, router]);
+
+  // Reset state when modal opens/closes
+  useEffect(() => {
+    latestRequestIdRef.current += 1;
+
+    if (isOpen) {
+      setQuery("");
+      setResults([]);
+      setSelectedIndex(0);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(false);
+  }, [isOpen]);
+
+  // Search with debounce
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const timer = setTimeout(async () => {
+      if (!query.trim()) {
+        setResults([]);
+        setIsLoading(false);
+        return;
+      }
+
+      const requestId = latestRequestIdRef.current + 1;
+      latestRequestIdRef.current = requestId;
+      setIsLoading(true);
+      try {
+        const res = await searchDocs(query);
+        if (!shouldApplySearchResponse({
+          isOpen,
+          latestRequestId: latestRequestIdRef.current,
+          requestId,
+        })) {
+          return;
+        }
+
+        setResults(res);
+        setSelectedIndex(0);
+      } catch (error) {
+        if (!shouldApplySearchResponse({
+          isOpen,
+          latestRequestId: latestRequestIdRef.current,
+          requestId,
+        })) {
+          return;
+        }
+
+        console.error("Search error:", error);
+        setResults([]);
+      } finally {
+        if (shouldApplySearchResponse({
+          isOpen,
+          latestRequestId: latestRequestIdRef.current,
+          requestId,
+        })) {
+          setIsLoading(false);
+        }
+      }
+    }, 200); // debounce 200ms
+
+    return () => clearTimeout(timer);
+  }, [isOpen, query]);
+
+  const handleResultClick = (slug: string) => {
+    router.push(slug ? `/docs/${slug}` : "/docs");
+    onClose();
+  };
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <>
+          {/* Backdrop */}
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
+            onClick={onClose}
+          />
+
+          {/* Modal */}
+          <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+            <motion.div
+              initial={{ opacity: 0, scale: 0.95 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.95 }}
+              transition={{ duration: 0.15 }}
+              className="w-full max-w-lg bg-background border border-border rounded-xl shadow-2xl overflow-hidden"
+            >
+              {/* Search Input */}
+              <input
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search docs..."
+                autoFocus
+                className="w-full px-4 py-4 bg-transparent border-b border-border text-lg outline-none placeholder:text-text-secondary"
+              />
+
+              {/* Results */}
+              <div className="max-h-80 overflow-y-auto">
+                {isLoading && query.trim() && (
+                  <div className="p-4 text-center text-text-secondary">Searching...</div>
+                )}
+
+                {!isLoading && query.trim() && results.length === 0 && (
+                  <div className="p-4 text-center text-text-secondary">No results found</div>
+                )}
+
+                {!isLoading && results.length > 0 && (
+                  <div>
+                    {results.map((result, index) => (
+                      <button
+                        key={result.slug}
+                        onClick={() => handleResultClick(result.slug)}
+                        className={`w-full p-3 text-left hover:bg-surface transition-colors ${
+                          index === selectedIndex ? "bg-surface" : ""
+                        }`}
+                      >
+                        <div className="font-medium">{result.title}</div>
+                        <div className="text-sm text-text-secondary truncate">{result.snippet}</div>
+                      </button>
+                    ))}
+                  </div>
+                )}
+
+                {!query.trim() && (
+                  <div className="p-4 text-center text-text-secondary text-sm">
+                    Start typing to search...
+                  </div>
+                )}
+              </div>
+            </motion.div>
+          </div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/docs-web/components/docs/Sidebar.tsx
+++ b/docs-web/components/docs/Sidebar.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { motion, AnimatePresence } from "framer-motion";
+import { docsNav, NavItem } from "@/lib/docs-config";
+import { getOpenGroupsForSlug } from "@/lib/docs/sidebar-state.mjs";
+
+interface SidebarProps {
+  currentSlug: string;
+}
+
+export default function Sidebar({ currentSlug }: SidebarProps) {
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const [openGroups, setOpenGroups] = useState<Set<string>>(
+    () => new Set(getOpenGroupsForSlug(docsNav, currentSlug))
+  );
+
+  useEffect(() => {
+    const activeGroups = getOpenGroupsForSlug(docsNav, currentSlug);
+    if (activeGroups.length === 0) {
+      return;
+    }
+
+    setOpenGroups((prev) => {
+      const next = new Set(prev);
+      activeGroups.forEach((group) => next.add(group));
+      return next;
+    });
+  }, [currentSlug]);
+
+  const toggleGroup = (title: string) => {
+    const newOpenGroups = new Set(openGroups);
+    if (newOpenGroups.has(title)) {
+      newOpenGroups.delete(title);
+    } else {
+      newOpenGroups.add(title);
+    }
+    setOpenGroups(newOpenGroups);
+  };
+
+  const renderNavItem = (item: NavItem, isChild = false) => {
+    const hasChildren = item.children && item.children.length > 0;
+
+    if (hasChildren) {
+      const isOpen = openGroups.has(item.title);
+      return (
+        <div key={item.title} className={isChild ? "ml-0" : ""}>
+          <button
+            onClick={() => toggleGroup(item.title)}
+            className="w-full flex items-center gap-2 py-2 px-3 text-xs font-semibold uppercase tracking-wider text-text-secondary hover:text-text-primary transition-colors"
+          >
+            <motion.svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              animate={{ rotate: isOpen ? 90 : 0 }}
+              transition={{ duration: 0.2 }}
+            >
+              <polyline points="9 18 15 12 9 6" />
+            </motion.svg>
+            {item.title}
+          </button>
+          <AnimatePresence initial={false}>
+            {isOpen && (
+              <motion.div
+                initial={{ height: 0, opacity: 0 }}
+                animate={{ height: "auto", opacity: 1 }}
+                exit={{ height: 0, opacity: 0 }}
+                transition={{ duration: 0.2 }}
+                className="overflow-hidden"
+              >
+                <div className="pl-2">
+                  {item.children!.map((child) => renderNavItem(child, true))}
+                </div>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+      );
+    }
+
+    if (item.slug) {
+      const isActive = currentSlug === item.slug;
+      return (
+        <Link
+          key={item.slug}
+          href={`/docs/${item.slug}`}
+          className={`block py-1.5 px-3 rounded-md text-sm transition-colors ${
+            isActive
+              ? "bg-accent/10 text-accent font-medium"
+              : "text-text-secondary hover:text-text-primary hover:bg-surface"
+          }`}
+          onClick={() => setMobileOpen(false)}
+        >
+          {item.title}
+        </Link>
+      );
+    }
+
+    return null;
+  };
+
+  const navContent = (
+    <nav className="space-y-1">
+      {docsNav.map((item) => renderNavItem(item))}
+    </nav>
+  );
+
+  return (
+    <>
+      {/* Mobile hamburger button */}
+      <button
+        onClick={() => setMobileOpen(true)}
+        className="lg:hidden fixed top-20 left-4 z-30 w-10 h-10 rounded-lg bg-surface border border-border flex items-center justify-center text-text-secondary hover:text-text-primary transition-colors shadow-sm"
+        aria-label="Open sidebar"
+      >
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <line x1="3" y1="12" x2="21" y2="12" />
+          <line x1="3" y1="6" x2="21" y2="6" />
+          <line x1="3" y1="18" x2="21" y2="18" />
+        </svg>
+      </button>
+
+      {/* Mobile drawer */}
+      <AnimatePresence>
+        {mobileOpen && (
+          <>
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              onClick={() => setMobileOpen(false)}
+              className="lg:hidden fixed inset-0 bg-black/50 z-30"
+            />
+            <motion.aside
+              initial={{ x: -300 }}
+              animate={{ x: 0 }}
+              exit={{ x: -300 }}
+              transition={{ type: "spring", damping: 25, stiffness: 200 }}
+              className="lg:hidden fixed left-0 top-16 bottom-0 w-64 bg-background border-r border-border z-40 overflow-y-auto p-4"
+            >
+              {navContent}
+            </motion.aside>
+          </>
+        )}
+      </AnimatePresence>
+
+      {/* Desktop sidebar */}
+      <aside className="hidden lg:flex w-60 flex-shrink-0 border-r border-border h-[calc(100vh-4rem)] sticky top-16 overflow-y-auto p-4">
+        {navContent}
+      </aside>
+    </>
+  );
+}

--- a/docs-web/components/docs/SlugExtractor.tsx
+++ b/docs-web/components/docs/SlugExtractor.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+
+interface HeadingInfo {
+  id: string;
+  text: string;
+  level: number;
+}
+
+const HeadingsContext = createContext<HeadingInfo[]>([]);
+
+export function useHeadings() {
+  return useContext(HeadingsContext);
+}
+
+export default function SlugExtractor({ children }: { children: ReactNode }) {
+  const [headings, setHeadings] = useState<HeadingInfo[]>([]);
+
+  useEffect(() => {
+    // Find all h2 and h3 headings rendered by MDX with rehype-slug
+    const main = document.querySelector("main");
+    if (!main) return;
+
+    const elements = main.querySelectorAll("h2[id], h3[id]");
+    const extracted: HeadingInfo[] = [];
+    elements.forEach((el) => {
+      extracted.push({
+        id: el.id,
+        text: el.textContent || "",
+        level: parseInt(el.tagName[1], 10),
+      });
+    });
+    setHeadings(extracted);
+  }, []);
+
+  return (
+    <HeadingsContext.Provider value={headings}>
+      {children}
+    </HeadingsContext.Provider>
+  );
+}

--- a/docs-web/components/docs/TOC.tsx
+++ b/docs-web/components/docs/TOC.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useHeadings } from "./SlugExtractor";
+
+export default function TOC() {
+  const headings = useHeadings();
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (headings.length === 0) return;
+
+    document.documentElement.style.scrollBehavior = "smooth";
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActiveId(entry.target.id);
+          }
+        });
+      },
+      {
+        rootMargin: "-100px 0px -80% 0px",
+        threshold: 0,
+      }
+    );
+
+    headings.forEach((heading) => {
+      const element = document.getElementById(heading.id);
+      if (element) {
+        observer.observe(element);
+      }
+    });
+
+    return () => {
+      document.documentElement.style.scrollBehavior = "";
+      headings.forEach((heading) => {
+        const element = document.getElementById(heading.id);
+        if (element) {
+          observer.unobserve(element);
+        }
+      });
+    };
+  }, [headings]);
+
+  if (headings.length === 0) {
+    return null;
+  }
+
+  return (
+    <nav className="space-y-1">
+      {headings.map((heading) => (
+        <a
+          key={heading.id}
+          href={`#${heading.id}`}
+          className={`block text-sm transition-colors ${
+            activeId === heading.id
+              ? "text-accent font-medium"
+              : "text-text-secondary hover:text-text-primary"
+          } ${heading.level >= 3 ? "pl-4" : ""}`}
+        >
+          {heading.text}
+        </a>
+      ))}
+    </nav>
+  );
+}

--- a/docs-web/components/landing/AnimatedSection.tsx
+++ b/docs-web/components/landing/AnimatedSection.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { motion, useReducedMotion } from "framer-motion";
+
+interface AnimatedSectionProps {
+  children: React.ReactNode;
+  className?: string;
+  delay?: number;
+}
+
+export function AnimatedSection({
+  children,
+  className = "",
+  delay = 0,
+}: AnimatedSectionProps) {
+  const reducedMotion = useReducedMotion();
+
+  if (reducedMotion) {
+    return <section className={className}>{children}</section>;
+  }
+
+  return (
+    <motion.section
+      className={className}
+      initial={{ opacity: 0, y: 30 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, margin: "-100px" }}
+      transition={{ duration: 0.5, delay, ease: "easeOut" }}
+    >
+      {children}
+    </motion.section>
+  );
+}

--- a/docs-web/components/landing/CTA.tsx
+++ b/docs-web/components/landing/CTA.tsx
@@ -1,0 +1,30 @@
+import { AnimatedSection } from "./AnimatedSection";
+import Button from "@/components/ui/Button";
+
+export function CTA() {
+  return (
+    <AnimatedSection className="py-24 px-6 relative overflow-hidden">
+      <div className="absolute inset-0 -z-10 bg-gradient-to-b from-accent/5 to-transparent" />
+      <div className="max-w-3xl mx-auto text-center">
+        <h2 className="text-3xl md:text-4xl font-bold mb-4">
+          Ready to Cache Smarter?
+        </h2>
+        <p className="text-text-secondary mb-8">
+          Get started with Layercache in minutes. Production-ready caching with
+          zero configuration headaches.
+        </p>
+        <div className="flex items-center justify-center gap-4">
+          <Button variant="primary" href="/docs/getting-started">
+            Get Started
+          </Button>
+          <Button
+            variant="secondary"
+            href="https://github.com/flyingsquirrel0419/layercache"
+          >
+            View on GitHub
+          </Button>
+        </div>
+      </div>
+    </AnimatedSection>
+  );
+}

--- a/docs-web/components/landing/Comparison.tsx
+++ b/docs-web/components/landing/Comparison.tsx
@@ -1,0 +1,95 @@
+import { AnimatedSection } from "./AnimatedSection";
+
+const features = [
+  { name: "Multi-layer stacking", layercache: true, cacheManager: false, keyv: false, cacheable: false },
+  { name: "Stampede prevention", layercache: true, cacheManager: false, keyv: false, cacheable: true },
+  { name: "Tag invalidation", layercache: true, cacheManager: false, keyv: false, cacheable: true },
+  { name: "Pattern invalidation", layercache: true, cacheManager: false, keyv: false, cacheable: false },
+  { name: "Stale-while-revalidate", layercache: true, cacheManager: true, keyv: false, cacheable: true },
+  { name: "Circuit breaker", layercache: true, cacheManager: false, keyv: false, cacheable: false },
+  { name: "Write-behind", layercache: true, cacheManager: false, keyv: false, cacheable: false },
+  { name: "Adaptive TTL", layercache: true, cacheManager: false, keyv: false, cacheable: false },
+  { name: "Generation versioning", layercache: true, cacheManager: false, keyv: false, cacheable: false },
+  { name: "Negative caching", layercache: true, cacheManager: false, keyv: false, cacheable: false },
+  { name: "Per-layer TTL", layercache: true, cacheManager: false, keyv: false, cacheable: false },
+  { name: "Distributed single-flight", layercache: true, cacheManager: false, keyv: false, cacheable: false },
+  { name: "Cross-server invalidation", layercache: true, cacheManager: false, keyv: false, cacheable: false },
+  { name: "Snapshot persistence", layercache: true, cacheManager: false, keyv: false, cacheable: false },
+  { name: "Memcached support", layercache: true, cacheManager: true, keyv: true, cacheable: false },
+  { name: "Disk layer", layercache: true, cacheManager: false, keyv: false, cacheable: false },
+  { name: "Prometheus metrics", layercache: true, cacheManager: false, keyv: false, cacheable: false },
+  { name: "OpenTelemetry", layercache: true, cacheManager: false, keyv: false, cacheable: false },
+  { name: "Admin CLI", layercache: true, cacheManager: false, keyv: false, cacheable: false },
+];
+
+function Cell({ supported }: { supported: boolean }) {
+  if (supported) {
+    return (
+      <td className="py-3 px-4 text-center">
+        <svg
+          className="inline-block w-5 h-5 text-green-500"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+      </td>
+    );
+  }
+  return (
+    <td className="py-3 px-4 text-center text-text-secondary/30">&mdash;</td>
+  );
+}
+
+export function Comparison() {
+  return (
+    <AnimatedSection className="py-24 px-6">
+      <div className="max-w-5xl mx-auto">
+        <h2 className="text-3xl md:text-4xl font-bold text-center mb-12">
+          How Layercache Compares
+        </h2>
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse">
+            <thead>
+              <tr className="sticky top-0 bg-surface">
+                <th className="py-3 px-4 text-left text-sm font-semibold w-40">
+                  Feature
+                </th>
+                <th className="py-3 px-4 text-left text-sm font-semibold w-28 text-accent font-bold">
+                  Layercache
+                </th>
+                <th className="py-3 px-4 text-left text-sm font-semibold">
+                  node-cache-manager
+                </th>
+                <th className="py-3 px-4 text-left text-sm font-semibold">
+                  keyv
+                </th>
+                <th className="py-3 px-4 text-left text-sm font-semibold">
+                  cacheable
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {features.map((feature) => (
+                <tr
+                  key={feature.name}
+                  className="border-b border-border hover:bg-surface/50"
+                >
+                  <td className="py-3 px-4 text-sm">{feature.name}</td>
+                  <Cell supported={feature.layercache} />
+                  <Cell supported={feature.cacheManager} />
+                  <Cell supported={feature.keyv} />
+                  <Cell supported={feature.cacheable} />
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </AnimatedSection>
+  );
+}

--- a/docs-web/components/landing/Features.tsx
+++ b/docs-web/components/landing/Features.tsx
@@ -1,0 +1,167 @@
+import { AnimatedSection } from "./AnimatedSection";
+
+export function Features() {
+  return (
+    <section className="py-24 px-6">
+      <div className="max-w-6xl mx-auto">
+        <h2 className="text-3xl md:text-4xl font-bold text-center mb-16">
+          Everything You Need for Production Caching
+        </h2>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <AnimatedSection delay={0}>
+            <div className="p-6 rounded-xl border border-border bg-surface hover:border-accent/50 transition-colors duration-300 h-full flex flex-col">
+              <div className="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center mb-4">
+                <svg
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  className="text-accent"
+                >
+                  <rect x="4" y="14" width="16" height="6" rx="1" />
+                  <rect x="6" y="8" width="12" height="6" rx="1" />
+                  <rect x="8" y="2" width="8" height="6" rx="1" />
+                </svg>
+              </div>
+              <h3 className="text-lg font-semibold mb-2">Multi-Layer Stacking</h3>
+              <p className="text-text-secondary text-sm leading-relaxed">
+                Stack memory, Redis, disk, and Memcached behind a single API.
+                Automatic backfill across layers.
+              </p>
+            </div>
+          </AnimatedSection>
+
+          <AnimatedSection delay={0.1}>
+            <div className="p-6 rounded-xl border border-border bg-surface hover:border-accent/50 transition-colors duration-300 h-full flex flex-col">
+              <div className="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center mb-4">
+                <svg
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  className="text-accent"
+                >
+                  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+                </svg>
+              </div>
+              <h3 className="text-lg font-semibold mb-2">Stampede Prevention</h3>
+              <p className="text-text-secondary text-sm leading-relaxed">
+                Shared in-flight promises collapse concurrent callers on the
+                same key. Distributed single-flight via Redis leases with
+                automatic renewal.
+              </p>
+            </div>
+          </AnimatedSection>
+
+          <AnimatedSection delay={0.2}>
+            <div className="p-6 rounded-xl border border-border bg-surface hover:border-accent/50 transition-colors duration-300 h-full flex flex-col">
+              <div className="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center mb-4">
+                <svg
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  className="text-accent"
+                >
+                  <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z" />
+                  <line x1="7" y1="7" x2="7.01" y2="7" />
+                </svg>
+              </div>
+              <h3 className="text-lg font-semibold mb-2">Tag Invalidation</h3>
+              <p className="text-text-secondary text-sm leading-relaxed">
+                Invalidate by tag, pattern, or prefix. Trie-backed index for
+                efficient lookups. Distributed invalidation via Redis pub/sub.
+              </p>
+            </div>
+          </AnimatedSection>
+
+          <AnimatedSection delay={0.3}>
+            <div className="p-6 rounded-xl border border-border bg-surface hover:border-accent/50 transition-colors duration-300 h-full flex flex-col">
+              <div className="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center mb-4">
+                <svg
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  className="text-accent"
+                >
+                  <path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+                  <path d="M3 3v5h5" />
+                  <path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16" />
+                  <path d="M16 21h5v-5" />
+                </svg>
+              </div>
+              <h3 className="text-lg font-semibold mb-2">
+                Stale-While-Revalidate
+              </h3>
+              <p className="text-text-secondary text-sm leading-relaxed">
+                Serve stale data while refreshing in the background.
+                Configurable freshness windows per layer.
+              </p>
+            </div>
+          </AnimatedSection>
+
+          <AnimatedSection delay={0.4}>
+            <div className="p-6 rounded-xl border border-border bg-surface hover:border-accent/50 transition-colors duration-300 h-full flex flex-col">
+              <div className="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center mb-4">
+                <svg
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  className="text-accent"
+                >
+                  <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+                </svg>
+              </div>
+              <h3 className="text-lg font-semibold mb-2">Circuit Breaker</h3>
+              <p className="text-text-secondary text-sm leading-relaxed">
+                Auto-open after consecutive failures. Graceful degradation
+                preserves local single-flight when distributed coordinators
+                falter.
+              </p>
+            </div>
+          </AnimatedSection>
+
+          <AnimatedSection delay={0.5}>
+            <div className="p-6 rounded-xl border border-border bg-surface hover:border-accent/50 transition-colors duration-300 h-full flex flex-col">
+              <div className="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center mb-4">
+                <svg
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  className="text-accent"
+                >
+                  <circle cx="6" cy="6" r="3" />
+                  <circle cx="18" cy="18" r="3" />
+                  <line x1="8.5" y1="8.5" x2="15.5" y2="15.5" />
+                </svg>
+              </div>
+              <h3 className="text-lg font-semibold mb-2">
+                Distributed Single-Flight
+              </h3>
+              <p className="text-text-secondary text-sm leading-relaxed">
+                Cross-process request deduplication via Redis. Lease-based
+                locking with automatic renewal.
+              </p>
+            </div>
+          </AnimatedSection>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/docs-web/components/landing/Hero.tsx
+++ b/docs-web/components/landing/Hero.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { motion, useReducedMotion } from "framer-motion";
+import { useEffect, useState } from "react";
+import Button from "@/components/ui/Button";
+
+const CODE_SNIPPET = `import { CacheStack, MemoryLayer, RedisLayer } from 'layercache';
+import Redis from 'ioredis';
+
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 30, maxSize: 5_000 }),
+  new RedisLayer({
+    client: new Redis(),
+    ttl: 300,
+    commandTimeoutMs: 50, // v1.3+ per-command Redis timeouts
+  }),
+]);
+
+const user = await cache.get('user:123', () => db.findUser(123));`;
+
+export function Hero() {
+  const reducedMotion = useReducedMotion();
+  const [displayedCode, setDisplayedCode] = useState("");
+  const [showCursor, setShowCursor] = useState(true);
+
+  // Typing animation
+  useEffect(() => {
+    if (reducedMotion) {
+      setDisplayedCode(CODE_SNIPPET);
+      return;
+    }
+
+    let index = 0;
+    const interval = setInterval(() => {
+      if (index <= CODE_SNIPPET.length) {
+        setDisplayedCode(CODE_SNIPPET.slice(0, index));
+        index++;
+      } else {
+        clearInterval(interval);
+      }
+    }, 40);
+
+    return () => clearInterval(interval);
+  }, [reducedMotion]);
+
+  // Blinking cursor
+  useEffect(() => {
+    if (reducedMotion) {
+      setShowCursor(false);
+      return;
+    }
+
+    const interval = setInterval(() => {
+      setShowCursor((prev) => !prev);
+    }, 530);
+
+    return () => clearInterval(interval);
+  }, [reducedMotion]);
+
+  return (
+    <section className="min-h-screen flex flex-col items-center justify-center px-6 overflow-hidden relative">
+      {/* Background gradient effects */}
+      <div className="absolute inset-0 -z-10">
+        <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-accent/20 rounded-full blur-3xl animate-pulse-slow"></div>
+        <div className="absolute bottom-1/4 right-1/4 w-96 h-96 bg-accent-light/10 rounded-full blur-3xl animate-pulse-slow animation-delay-2000"></div>
+      </div>
+
+      {/* Hero content */}
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.8, ease: "easeOut" }}
+        className="text-center"
+      >
+        <h1 className="text-5xl md:text-7xl font-bold tracking-tight mb-6">
+          Production-Ready
+          <br />
+          <span className="text-accent">Multi-Layer Caching</span>
+          <br />
+          for Node.js
+        </h1>
+
+        <p className="text-lg md:text-xl text-text-secondary mb-6 max-w-2xl mx-auto">
+          Stack memory, Redis, and disk behind one API — with single-flight
+          stampede prevention, tag invalidation, and graceful degradation when
+          layers fail.
+        </p>
+
+        <div className="flex items-center justify-center gap-2 mb-8 flex-wrap">
+          <span className="text-xs font-medium px-2.5 py-1 rounded-full bg-accent/10 text-accent border border-accent/20">
+            v1.3.4
+          </span>
+          <span className="text-xs font-medium px-2.5 py-1 rounded-full bg-surface text-text-secondary border border-border">
+            Node.js ≥ 20
+          </span>
+          <span className="text-xs font-medium px-2.5 py-1 rounded-full bg-surface text-text-secondary border border-border">
+            Apache-2.0
+          </span>
+          <span className="text-xs font-medium px-2.5 py-1 rounded-full bg-surface text-text-secondary border border-border">
+            529 tests
+          </span>
+        </div>
+
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-3 sm:gap-4 mb-12 sm:mb-16">
+          <Button variant="primary" href="/docs/getting-started" className="w-full sm:w-auto">
+            Get Started
+          </Button>
+          <Button
+            variant="secondary"
+            href="https://github.com/flyingsquirrel0419/layercache"
+            className="w-full sm:w-auto"
+          >
+            View on GitHub
+          </Button>
+        </div>
+      </motion.div>
+
+      {/* Code window */}
+      <motion.div
+        initial={{ opacity: 0, y: 30 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.8, delay: 0.8, ease: "easeOut" }}
+        className="max-w-2xl w-full px-4 sm:px-0"
+      >
+        <div className="rounded-xl border border-border bg-surface overflow-hidden">
+          {/* Window chrome */}
+          <div className="flex items-center gap-2 px-3 sm:px-4 py-2 sm:py-3 border-b border-border">
+            <div className="w-3 h-3 rounded-full bg-red-500/60"></div>
+            <div className="w-3 h-3 rounded-full bg-yellow-500/60"></div>
+            <div className="w-3 h-3 rounded-full bg-green-500/60"></div>
+            <span className="ml-2 text-xs sm:text-sm text-text-secondary">example.ts</span>
+          </div>
+
+          {/* Code block */}
+          <pre className="p-3 sm:p-4 text-xs sm:text-sm font-mono overflow-x-auto">
+            <code>
+              {displayedCode}
+              {showCursor && (
+                <span className="inline-block w-2 h-4 bg-accent ml-1 align-middle"></span>
+              )}
+            </code>
+          </pre>
+        </div>
+      </motion.div>
+    </section>
+  );
+}

--- a/docs-web/components/landing/HowItWorks.tsx
+++ b/docs-web/components/landing/HowItWorks.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { motion, AnimatePresence } from "framer-motion";
+import { useState, useEffect } from "react";
+import { AnimatedSection } from "./AnimatedSection";
+
+interface LayerBarProps {
+  label: string;
+  speed: string;
+  colorClass: string;
+  active: boolean;
+  badge?: string;
+  icon: React.ReactNode;
+  ringColor?: string;
+}
+
+function LayerBar({ label, speed, colorClass, active, badge, icon, ringColor }: LayerBarProps) {
+  const getBadgeColor = () => {
+    if (badge === "MISS") return "bg-red-500/20 text-red-400";
+    if (badge === "FETCH") return "bg-green-500/20 text-green-400";
+    if (badge === "SET") return "bg-green-500/20 text-green-400";
+    return "";
+  };
+
+  return (
+    <motion.div
+      animate={active ? { scale: 1.02 } : { scale: 1 }}
+      transition={{ duration: 0.2 }}
+      className={`rounded-lg border p-4 flex items-center justify-between ${colorClass} ${
+        active && ringColor ? `${ringColor}` : ""
+      }`}
+    >
+      <div className="flex items-center gap-3">
+        <span className="text-xl">{icon}</span>
+        <span className="font-medium">{label}</span>
+      </div>
+      <div className="flex items-center gap-2">
+        <span className="text-sm text-text-secondary">{speed}</span>
+        {badge && (
+          <AnimatePresence>
+            <motion.span
+              initial={{ scale: 0, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              exit={{ scale: 0, opacity: 0 }}
+              className={`text-xs px-2 py-0.5 rounded-full font-medium ${getBadgeColor()}`}
+            >
+              {badge}
+            </motion.span>
+          </AnimatePresence>
+        )}
+      </div>
+    </motion.div>
+  );
+}
+
+export function HowItWorks() {
+  const [simulating, setSimulating] = useState(false);
+  const [activeStep, setActiveStep] = useState<number | null>(null);
+  const [badges, setBadges] = useState<(string | null)[]>([null, null, null, null]);
+  const [ringColor, setRingColor] = useState<string | null>(null);
+
+  const layers = [
+    {
+      label: "Memory (L1)",
+      speed: "~ 0.01 ms",
+      colorClass: "bg-accent/10 border-accent/30",
+      icon: "🔲",
+    },
+    {
+      label: "Redis (L2)",
+      speed: "~ 0.5 ms",
+      colorClass: "bg-purple-500/10 border-purple-500/30",
+      icon: "🗄️",
+    },
+    {
+      label: "Disk (L3)",
+      speed: "~ 2 ms",
+      colorClass: "bg-blue-500/10 border-blue-500/30",
+      icon: "💾",
+    },
+    {
+      label: "Data Source",
+      speed: "varies",
+      colorClass: "bg-amber-500/10 border-amber-500/30",
+      icon: "🌐",
+    },
+  ];
+
+  const simulateRequest = () => {
+    if (simulating) return;
+    setSimulating(true);
+    setActiveStep(0);
+
+    // Step 1: Memory MISS
+    setBadges(["MISS", null, null, null]);
+    setRingColor("ring-2 ring-offset-2 ring-offset-background ring-red-400");
+
+    setTimeout(() => {
+      // Step 2: Redis MISS
+      setActiveStep(1);
+      setBadges([null, "MISS", null, null]);
+    }, 800);
+
+    setTimeout(() => {
+      // Step 3: Disk MISS
+      setActiveStep(2);
+      setBadges([null, null, "MISS", null]);
+    }, 1600);
+
+    setTimeout(() => {
+      // Step 4: Fetch from source
+      setActiveStep(3);
+      setBadges([null, null, null, "FETCH"]);
+      setRingColor("ring-2 ring-offset-2 ring-offset-background ring-green-400");
+    }, 2400);
+
+    setTimeout(() => {
+      // Step 5: Backfill all layers
+      setActiveStep(null);
+      setBadges(["SET", "SET", "SET", null]);
+    }, 3400);
+
+    setTimeout(() => {
+      // Reset
+      setBadges([null, null, null, null]);
+      setRingColor(null);
+      setSimulating(false);
+    }, 4200);
+  };
+
+  return (
+    <AnimatedSection className="py-24 px-6">
+      <div className="max-w-5xl mx-auto">
+        <h2 className="text-3xl md:text-4xl font-bold text-center mb-4">How It Works</h2>
+        <p className="text-text-secondary text-center mb-12">
+          Data flows through layers from fastest to slowest, with automatic backfill
+        </p>
+
+        <div className="max-w-lg mx-auto mb-8">
+          <div className="flex flex-col gap-3">
+            {layers.map((layer, index) => (
+              <div key={index} className="relative">
+                <LayerBar
+                  label={layer.label}
+                  speed={layer.speed}
+                  colorClass={layer.colorClass}
+                  active={activeStep === index}
+                  badge={badges[index] || undefined}
+                  icon={layer.icon}
+                  ringColor={ringColor && (activeStep === index || badges[index] === "SET") ? ringColor : ""}
+                />
+                {index < layers.length - 1 && (
+                  <div className="flex justify-center -my-1 relative z-10">
+                    <motion.svg
+                      width="24"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      className="text-accent"
+                      animate={
+                        activeStep === index || (activeStep === null && badges.some(b => b === "SET"))
+                          ? { y: [0, 4, 0] }
+                          : {}
+                      }
+                      transition={{ duration: 0.5, repeat: Infinity }}
+                    >
+                      <path
+                        d="M12 4L12 20M12 20L8 16M12 20L16 16"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </motion.svg>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex justify-center">
+          <button
+            onClick={simulateRequest}
+            disabled={simulating}
+            className={`px-6 py-3 rounded-lg font-medium transition-colors ${
+              simulating
+                ? "bg-gray-700 text-gray-400 cursor-not-allowed"
+                : "bg-accent text-white hover:bg-accent-light"
+            }`}
+          >
+            {simulating ? "Simulating..." : "Simulate Request"}
+          </button>
+        </div>
+      </div>
+    </AnimatedSection>
+  );
+}

--- a/docs-web/components/landing/Navbar.tsx
+++ b/docs-web/components/landing/Navbar.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { motion } from "framer-motion";
+import ThemeToggle from "@/components/ui/ThemeToggle";
+import Link from "next/link";
+
+export function Navbar() {
+  const [scrolled, setScrolled] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  useEffect(() => {
+    const handler = () => setScrolled(window.scrollY > 20);
+    window.addEventListener("scroll", handler, { passive: true });
+    return () => window.removeEventListener("scroll", handler);
+  }, []);
+
+  return (
+    <nav
+      className={`sticky top-0 z-50 transition-all duration-300 ${
+        scrolled
+          ? "bg-background/80 backdrop-blur-lg border-b border-border"
+          : ""
+      }`}
+    >
+      <div className="max-w-6xl mx-auto flex items-center justify-between h-16 px-6">
+        {/* Logo + Name */}
+        <Link href="/" className="flex items-center gap-2">
+          <svg width="28" height="28" viewBox="0 0 28 28" fill="none">
+            <rect
+              x="2"
+              y="16"
+              width="24"
+              height="6"
+              rx="2"
+              fill="#6366f1"
+              opacity="0.9"
+            />
+            <rect
+              x="4"
+              y="9"
+              width="20"
+              height="6"
+              rx="2"
+              fill="#6366f1"
+              opacity="0.7"
+            />
+            <rect
+              x="6"
+              y="2"
+              width="16"
+              height="6"
+              rx="2"
+              fill="#6366f1"
+              opacity="0.5"
+            />
+          </svg>
+          <span className="font-bold text-lg">Layercache</span>
+        </Link>
+
+        {/* Desktop nav links */}
+        <div className="hidden md:flex items-center gap-6">
+          <Link
+            href="/docs"
+            className="text-text-secondary hover:text-text-primary transition-colors text-sm"
+          >
+            Docs
+          </Link>
+          <Link
+            href="/playground"
+            className="text-text-secondary hover:text-text-primary transition-colors text-sm"
+          >
+            Playground
+          </Link>
+          <a
+            href="https://github.com/flyingsquirrel0419/layercache"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-text-secondary hover:text-text-primary transition-colors text-sm"
+          >
+            GitHub
+          </a>
+          <ThemeToggle />
+        </div>
+
+        {/* Mobile menu */}
+        <div className="flex md:hidden items-center gap-3">
+          <ThemeToggle />
+          <button
+            onClick={() => setMobileOpen(!mobileOpen)}
+            className="p-2 text-text-secondary hover:text-text-primary"
+            aria-label="Toggle menu"
+          >
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            >
+              <line x1="3" y1="6" x2="21" y2="6" />
+              <line x1="3" y1="12" x2="21" y2="12" />
+              <line x1="3" y1="18" x2="21" y2="18" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {/* Mobile dropdown */}
+      {mobileOpen && (
+        <motion.div
+          initial={{ opacity: 0, y: -10 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="md:hidden border-b border-border bg-background/95 backdrop-blur-lg px-6 py-4 space-y-3"
+        >
+          <Link
+            href="/docs"
+            className="block text-text-secondary hover:text-text-primary"
+          >
+            Docs
+          </Link>
+          <Link
+            href="/playground"
+            className="block text-text-secondary hover:text-text-primary"
+          >
+            Playground
+          </Link>
+          <a
+            href="https://github.com/flyingsquirrel0419/layercache"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block text-text-secondary hover:text-text-primary"
+          >
+            GitHub
+          </a>
+        </motion.div>
+      )}
+    </nav>
+  );
+}

--- a/docs-web/components/landing/WebMCP.tsx
+++ b/docs-web/components/landing/WebMCP.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useEffect } from "react";
+
+type WebMCPTool = {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  execute: (input: Record<string, unknown>) => Promise<unknown> | unknown;
+};
+
+type ModelContext = {
+  provideContext: (ctx: { tools: WebMCPTool[] }) => void | Promise<void>;
+};
+
+declare global {
+  interface Navigator {
+    modelContext?: ModelContext;
+  }
+}
+
+const DOC_LINKS: Record<string, string> = {
+  overview: "/docs",
+  "getting-started": "/docs/getting-started",
+  tutorial: "/docs/tutorial",
+  api: "/docs/api",
+  layers: "/docs/layers",
+  invalidation: "/docs/invalidation",
+  resilience: "/docs/resilience",
+  serialization: "/docs/serialization",
+  observability: "/docs/observability",
+  distributed: "/docs/distributed",
+  integrations: "/docs/integrations",
+  migration: "/docs/migration",
+  cli: "/docs/cli",
+};
+
+export function WebMCP() {
+  useEffect(() => {
+    if (typeof navigator === "undefined" || !navigator.modelContext) return;
+
+    const tools: WebMCPTool[] = [
+      {
+        name: "open_layercache_docs",
+        description:
+          "Open a Layercache documentation page in the current tab. Accepts a known slug (e.g. 'getting-started', 'api', 'resilience').",
+        inputSchema: {
+          type: "object",
+          properties: {
+            slug: {
+              type: "string",
+              description:
+                "Documentation slug. One of: overview, getting-started, tutorial, api, layers, invalidation, resilience, serialization, observability, distributed, integrations, migration, cli.",
+            },
+          },
+          required: ["slug"],
+        },
+        execute: async ({ slug }) => {
+          const target =
+            DOC_LINKS[(slug as string) ?? ""] ?? "/docs";
+          window.location.assign(target);
+          return { navigated: true, url: target };
+        },
+      },
+      {
+        name: "search_layercache_docs",
+        description:
+          "Search the Layercache documentation. Returns matching pages with title, URL, and an excerpt.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            query: { type: "string", description: "Search query" },
+            limit: {
+              type: "integer",
+              minimum: 1,
+              maximum: 20,
+              default: 5,
+            },
+          },
+          required: ["query"],
+        },
+        execute: async ({ query, limit }) => {
+          const q = (query as string) ?? "";
+          const n = Math.max(1, Math.min(20, (limit as number) ?? 5));
+          try {
+            const res = await fetch("/search-index.json", {
+              headers: { Accept: "application/json" },
+            });
+            if (!res.ok) throw new Error("search index unavailable");
+            const index: Array<{
+              title: string;
+              slug: string;
+              description: string;
+            }> = await res.json();
+            const needle = q.toLowerCase();
+            return index
+              .filter(
+                (d) =>
+                  d.title.toLowerCase().includes(needle) ||
+                  d.description.toLowerCase().includes(needle)
+              )
+              .slice(0, n)
+              .map((d) => ({
+                title: d.title,
+                url: `/docs/${d.slug}`,
+                excerpt: d.description,
+              }));
+          } catch {
+            return Object.entries(DOC_LINKS)
+              .filter(([slug]) => slug.includes(q.toLowerCase()))
+              .slice(0, n)
+              .map(([slug, url]) => ({
+                title: slug,
+                url,
+                excerpt: "",
+              }));
+          }
+        },
+      },
+      {
+        name: "get_install_command",
+        description:
+          "Return the install command for Layercache for a chosen package manager.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            packageManager: {
+              type: "string",
+              enum: ["npm", "pnpm", "yarn", "bun"],
+              default: "npm",
+            },
+          },
+        },
+        execute: async ({ packageManager }) => {
+          const pm = (packageManager as string) ?? "npm";
+          const cmd =
+            pm === "pnpm"
+              ? "pnpm add layercache"
+              : pm === "yarn"
+              ? "yarn add layercache"
+              : pm === "bun"
+              ? "bun add layercache"
+              : "npm install layercache";
+          return { command: cmd, requires: "Node.js >= 20" };
+        },
+      },
+    ];
+
+    Promise.resolve(navigator.modelContext.provideContext({ tools })).catch(
+      () => {
+        /* WebMCP not supported; fail silently */
+      }
+    );
+  }, []);
+
+  return null;
+}

--- a/docs-web/components/playground/CodeEditor.tsx
+++ b/docs-web/components/playground/CodeEditor.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { ComponentProps, forwardRef } from "react";
+
+interface CodeEditorProps extends Omit<ComponentProps<"textarea">, "onChange"> {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export const CodeEditor = forwardRef<HTMLTextAreaElement, CodeEditorProps>(
+  ({ value, onChange, className = "", ...props }, ref) => {
+    return (
+      <textarea
+        ref={ref}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className={`w-full h-full min-h-[400px] p-4 bg-background border border-border rounded-lg font-mono text-sm resize-none outline-none focus:border-accent/50 ${className}`}
+        spellCheck={false}
+        {...props}
+      />
+    );
+  }
+);
+
+CodeEditor.displayName = "CodeEditor";

--- a/docs-web/components/playground/PlaygroundClient.tsx
+++ b/docs-web/components/playground/PlaygroundClient.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { motion } from "framer-motion";
+import { CodeEditor } from "./CodeEditor";
+import { ResultPanel } from "./ResultPanel";
+import { PresetSelector } from "./PresetSelector";
+import { presets } from "@/lib/playground/presets";
+import {
+  RUN_TIMEOUT_MS,
+  armRunTimeout,
+  clearRunTimeout,
+} from "@/lib/playground/run-timeout-controller.mjs";
+
+interface LogEntry {
+  type: "log" | "error" | "cache";
+  message: string;
+  timestamp: number;
+}
+
+interface LayerInfo {
+  name: string;
+  latencyMs: number;
+  size: number;
+  keys: string[];
+}
+
+export function PlaygroundClient() {
+  const [code, setCode] = useState(presets[0].code);
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [layerInfo, setLayerInfo] = useState<LayerInfo[] | undefined>();
+  const [activePreset, setActivePreset] = useState<string | null>(presets[0].id);
+  const [isRunning, setIsRunning] = useState(false);
+
+  const workerRef = useRef<Worker | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const stopWorker = useCallback((worker: Worker | null = workerRef.current) => {
+    clearRunTimeout(timeoutRef);
+
+    if (!worker) {
+      return;
+    }
+
+    worker.terminate();
+    if (workerRef.current === worker) {
+      workerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => stopWorker();
+  }, [stopWorker]);
+
+  const handleRun = useCallback(() => {
+    if (isRunning) return;
+
+    // Clean up any previous worker
+    stopWorker();
+
+    // Create fresh worker
+    const worker = new Worker(
+      new URL("../../lib/playground/worker.ts", import.meta.url)
+    );
+
+    worker.onmessage = (event) => {
+      const { type, message, timestamp, layerInfo } = event.data;
+      if (type === "log" || type === "error" || type === "cache") {
+        setLogs((prev) => [...prev, { type, message, timestamp }]);
+      } else if (type === "done") {
+        stopWorker(worker);
+        setLayerInfo(layerInfo);
+        setIsRunning(false);
+      }
+    };
+
+    worker.onerror = (error) => {
+      setLogs((prev) => [
+        ...prev,
+        { type: "error" as const, message: `Error: ${error.message || "Worker failed"}`, timestamp: Date.now() },
+      ]);
+      stopWorker(worker);
+      setIsRunning(false);
+    };
+
+    workerRef.current = worker;
+
+    // Main-thread kill timer — still fires when the worker thread is stuck in a sync loop.
+    armRunTimeout({
+      timeoutRef,
+      ms: RUN_TIMEOUT_MS,
+      onTimeout: () => {
+        if (workerRef.current !== worker) {
+          return;
+        }
+
+        setLogs((prev) => [
+          ...prev,
+          { type: "error" as const, message: "Execution timed out (30s limit) — worker terminated", timestamp: Date.now() },
+        ]);
+        stopWorker(worker);
+        setIsRunning(false);
+      },
+    });
+
+    setLogs([]);
+    setLayerInfo(undefined);
+    setIsRunning(true);
+    worker.postMessage({ type: "run", code });
+  }, [code, isRunning, stopWorker]);
+
+  const handlePresetSelect = useCallback((id: string) => {
+    const preset = presets.find((p) => p.id === id);
+    if (preset) {
+      setCode(preset.code);
+      setActivePreset(id);
+      setLogs([]);
+      setLayerInfo(undefined);
+    }
+  }, []);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3 }}
+      className="min-h-screen bg-background"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+        <h1 className="text-lg font-bold text-text-primary">Playground</h1>
+        <button
+          onClick={handleRun}
+          disabled={isRunning}
+          className={`px-4 py-2 rounded-lg font-medium transition-colors ${
+            isRunning
+              ? "bg-surface text-text-secondary cursor-not-allowed"
+              : "bg-accent text-white hover:opacity-90"
+          }`}
+        >
+          {isRunning ? "Running..." : "Run"}
+        </button>
+      </div>
+
+      {/* Preset Selector */}
+      <PresetSelector activeId={activePreset} onSelect={handlePresetSelect} />
+
+      {/* Main Content */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-0 h-[calc(100vh-8rem)]">
+        {/* Code Editor */}
+        <div className="border-r border-border p-0">
+          <CodeEditor value={code} onChange={setCode} />
+        </div>
+
+        {/* Result Panel */}
+        <div className="p-0">
+          <ResultPanel logs={logs} layerInfo={layerInfo} />
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/docs-web/components/playground/PresetSelector.tsx
+++ b/docs-web/components/playground/PresetSelector.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { presets } from "@/lib/playground/presets";
+
+interface PresetSelectorProps {
+  activeId: string | null;
+  onSelect: (id: string) => void;
+}
+
+export function PresetSelector({ activeId, onSelect }: PresetSelectorProps) {
+  return (
+    <div className="flex gap-2 overflow-x-auto pb-2 px-4">
+      {presets.map((preset) => (
+        <button
+          key={preset.id}
+          onClick={() => onSelect(preset.id)}
+          title={preset.description}
+          className={`px-3 py-1.5 rounded-md text-sm whitespace-nowrap transition-colors ${
+            activeId === preset.id
+              ? "bg-accent text-white"
+              : "bg-surface border border-border text-text-secondary hover:text-text-primary"
+          }`}
+        >
+          {preset.title}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/docs-web/components/playground/ResultPanel.tsx
+++ b/docs-web/components/playground/ResultPanel.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+interface LogEntry {
+  type: "log" | "error" | "cache";
+  message: string;
+  timestamp: number;
+}
+
+interface LayerInfo {
+  name: string;
+  latencyMs: number;
+  size: number;
+  keys: string[];
+}
+
+interface ResultPanelProps {
+  logs: LogEntry[];
+  layerInfo?: LayerInfo[];
+}
+
+export function ResultPanel({ logs, layerInfo }: ResultPanelProps) {
+  const startTime = logs.length > 0 ? logs[0].timestamp : Date.now();
+
+  const getLogColor = (type: LogEntry["type"]): string => {
+    switch (type) {
+      case "log":
+        return "text-text-primary";
+      case "error":
+        return "text-red-400";
+      case "cache":
+        return "text-accent";
+      default:
+        return "text-text-primary";
+    }
+  };
+
+  const formatTimestamp = (timestamp: number): string => {
+    const elapsed = timestamp - startTime;
+    return `[${elapsed}ms]`;
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Console output */}
+      <div className="flex-1 overflow-y-auto max-h-[350px] p-4 bg-background border-b border-border">
+        {logs.length === 0 ? (
+          <div className="text-text-secondary text-sm">Run code to see output here</div>
+        ) : (
+          <div className="space-y-1">
+            {logs.map((log, index) => (
+              <div key={index} className={`font-mono text-sm py-0.5 ${getLogColor(log.type)}`}>
+                <span className="opacity-50">{formatTimestamp(log.timestamp)}</span> {log.message}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Layer status */}
+      {layerInfo && (
+        <div className="p-4 bg-surface">
+          <div className="flex flex-wrap gap-2">
+            {layerInfo.map((layer) => (
+              <div
+                key={layer.name}
+                className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-background border border-border"
+              >
+                <div
+                  className={`w-2 h-2 rounded-full ${
+                    layer.size > 0 ? "bg-green-500" : "bg-gray-400"
+                  }`}
+                />
+                <span className="text-sm font-medium text-text-primary">{layer.name}</span>
+                <span className="text-xs text-text-secondary">
+                  {layer.size} {layer.size === 1 ? "item" : "items"}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/docs-web/components/ui/Button.tsx
+++ b/docs-web/components/ui/Button.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+
+type ButtonProps = {
+  variant?: "primary" | "secondary" | "ghost";
+  href?: string;
+  className?: string;
+  children: React.ReactNode;
+} & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "className">;
+
+const variantClasses = {
+  primary:
+    "bg-accent text-white hover:bg-accent-light shadow-sm",
+  secondary:
+    "border border-border text-text-primary hover:bg-surface",
+  ghost:
+    "text-text-secondary hover:text-text-primary",
+};
+
+export default function Button({
+  variant = "primary",
+  href,
+  className = "",
+  children,
+  ...props
+}: ButtonProps) {
+  const baseClasses =
+    "inline-flex items-center justify-center px-5 py-2.5 rounded-lg text-sm font-medium transition-colors duration-150";
+  const classes = `${baseClasses} ${variantClasses[variant]} ${className}`.trim();
+
+  if (href) {
+    return (
+      <Link href={href} className={classes}>
+        {children}
+      </Link>
+    );
+  }
+
+  return (
+    <button className={classes} {...props}>
+      {children}
+    </button>
+  );
+}

--- a/docs-web/components/ui/Callout.tsx
+++ b/docs-web/components/ui/Callout.tsx
@@ -1,0 +1,54 @@
+type CalloutType = "info" | "warning" | "tip";
+
+type CalloutProps = {
+  type?: CalloutType;
+  title?: string;
+  children: React.ReactNode;
+};
+
+const calloutConfig: Record<
+  CalloutType,
+  { border: string; bg: string; icon: string }
+> = {
+  info: {
+    border: "border-blue-500",
+    bg: "bg-blue-50 dark:bg-blue-500/10",
+    icon: "\u2139\uFE0F",
+  },
+  warning: {
+    border: "border-amber-500",
+    bg: "bg-amber-50 dark:bg-amber-500/10",
+    icon: "\u26A0\uFE0F",
+  },
+  tip: {
+    border: "border-green-500",
+    bg: "bg-green-50 dark:bg-green-500/10",
+    icon: "\uD83D\uDCA1",
+  },
+};
+
+export default function Callout({
+  type = "info",
+  title,
+  children,
+}: CalloutProps) {
+  const config = calloutConfig[type];
+
+  return (
+    <div
+      className={`my-6 rounded-lg border-l-4 ${config.border} ${config.bg} p-4`}
+    >
+      <div className="flex items-start gap-2">
+        <span className="text-base leading-6 shrink-0">{config.icon}</span>
+        <div>
+          {title && (
+            <p className="font-semibold text-text-primary mb-1">{title}</p>
+          )}
+          <div className="text-text-secondary text-sm [&>p]:m-0">
+            {children}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs-web/components/ui/CodeGroup.tsx
+++ b/docs-web/components/ui/CodeGroup.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useState } from "react";
+
+type CodeGroupProps = {
+  labels: string[];
+  children: React.ReactNode[];
+};
+
+export default function CodeGroup({ labels, children }: CodeGroupProps) {
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  return (
+    <div className="my-6 rounded-lg overflow-hidden border border-border">
+      <div className="flex border-b border-border bg-surface">
+        {labels.map((label, index) => (
+          <button
+            key={index}
+            onClick={() => setActiveIndex(index)}
+            className={`px-4 py-2 text-sm font-medium transition-colors duration-150 ${
+              index === activeIndex
+                ? "text-accent border-b-2 border-accent"
+                : "text-text-secondary hover:text-text-primary"
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+      <div>{children[activeIndex]}</div>
+    </div>
+  );
+}

--- a/docs-web/components/ui/CopyButton.tsx
+++ b/docs-web/components/ui/CopyButton.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+
+type CopyButtonProps = {
+  text: string;
+};
+
+export default function CopyButton({ text }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="absolute top-2 right-2 p-1.5 rounded-md text-text-secondary hover:text-text-primary hover:bg-surface transition-colors duration-150"
+      aria-label={copied ? "Copied" : "Copy to clipboard"}
+    >
+      {copied ? (
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+      ) : (
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/docs-web/components/ui/Stepper.tsx
+++ b/docs-web/components/ui/Stepper.tsx
@@ -1,0 +1,30 @@
+type Step = {
+  title: string;
+  content: React.ReactNode;
+};
+
+type StepperProps = {
+  steps: Step[];
+};
+
+export default function Stepper({ steps }: StepperProps) {
+  return (
+    <div className="my-8 space-y-6">
+      {steps.map((step, index) => (
+        <div key={index} className="flex gap-4">
+          <div className="shrink-0">
+            <div className="w-8 h-8 rounded-full bg-accent text-white flex items-center justify-center text-sm font-bold">
+              {index + 1}
+            </div>
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold text-text-primary">
+              {step.title}
+            </h3>
+            <div className="mt-1 text-text-secondary">{step.content}</div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/docs-web/components/ui/ThemeToggle.tsx
+++ b/docs-web/components/ui/ThemeToggle.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { useState, useEffect } from "react";
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return <div className="w-9 h-9" />;
+  }
+
+  return (
+    <button
+      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+      className="w-9 h-9 rounded-lg flex items-center justify-center text-text-secondary hover:text-text-primary hover:bg-surface transition-colors duration-150"
+      aria-label="Toggle theme"
+    >
+      {theme === "dark" ? (
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <circle cx="12" cy="12" r="5" />
+          <line x1="12" y1="1" x2="12" y2="3" />
+          <line x1="12" y1="21" x2="12" y2="23" />
+          <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+          <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+          <line x1="1" y1="12" x2="3" y2="12" />
+          <line x1="21" y1="12" x2="23" y2="12" />
+          <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+          <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+        </svg>
+      ) : (
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/docs-web/content/docs/api.mdx
+++ b/docs-web/content/docs/api.mdx
@@ -1,0 +1,907 @@
+---
+title: "API Reference"
+description: "Complete API documentation for layercache"
+---
+
+# API Reference
+
+Complete API documentation for layercache.
+
+## Table of Contents
+
+- [CacheStack](#cachestack)
+  - [Constructor](#constructor)
+  - [Read Operations](#read-operations)
+  - [Write Operations](#write-operations)
+  - [Invalidation](#invalidation)
+  - [Wrapping & Namespaces](#wrapping--namespaces)
+  - [Warming & Persistence](#warming--persistence)
+  - [Observability](#observability)
+  - [Generation Management](#generation-management)
+  - [Lifecycle](#lifecycle)
+- [Cache Layers](#cache-layers)
+  - [MemoryLayer](#memorylayer)
+  - [RedisLayer](#redislayer)
+  - [DiskLayer](#disklayer)
+  - [MemcachedLayer](#memcachedlayer)
+  - [Custom Layers](#custom-layers)
+- [Options Reference](#options-reference)
+  - [CacheStackOptions](#cachestackoptions)
+  - [Per-Operation Options](#per-operation-options)
+- [Invalidation Strategies](#invalidation-strategies)
+- [Freshness Strategies](#freshness-strategies)
+- [Resilience](#resilience)
+- [Compression & Serialization](#compression--serialization)
+- [Distributed Features](#distributed-features)
+- [Event Hooks](#event-hooks)
+- [Framework Integrations](#framework-integrations)
+- [Admin CLI](#admin-cli)
+
+---
+
+## CacheStack
+
+The main class that orchestrates reads, writes, and invalidation across multiple cache layers.
+
+### Constructor
+
+```ts
+import { CacheStack, MemoryLayer, RedisLayer } from 'layercache'
+
+const cache = new CacheStack(layers, options?)
+```
+
+**Parameters:**
+- `layers` - `CacheLayer[]` - Array of cache layers, ordered from fastest (L1) to slowest (Ln)
+- `options` - `CacheStackOptions` - Optional configuration (see [CacheStackOptions](#cachestackoptions))
+
+---
+
+### Read Operations
+
+#### `cache.get<T>(key, fetcher?, options?): Promise<T | null>`
+
+Reads through all layers in order. On a partial hit (found in L2 but not L1), backfills the upper layers automatically. On a full miss, runs the fetcher if provided.
+
+```ts
+// Without fetcher - returns null on miss
+const user = await cache.get<User>('user:123')
+
+// With fetcher - runs once on miss, fills all layers
+const user = await cache.get<User>('user:123', () => db.findUser(123))
+
+// With full options
+const user = await cache.get<User>('user:123', () => db.findUser(123), {
+  ttl: { memory: 30, redis: 600 },
+  tags: ['user', 'user:123'],
+  negativeCache: true,
+  negativeTtl: 15,
+  staleWhileRevalidate: 30,
+  staleIfError: 300,
+  ttlJitter: 5
+})
+```
+
+#### `cache.getOrThrow<T>(key, fetcher?, options?): Promise<T>`
+
+Like `get()`, but throws `CacheMissError` instead of returning `null`.
+
+```ts
+import { CacheMissError } from 'layercache'
+
+try {
+  const config = await cache.getOrThrow<Config>('app:config')
+} catch (err) {
+  if (err instanceof CacheMissError) {
+    console.error(`Missing key: ${err.key}`)
+  }
+}
+```
+
+#### `cache.mget<T>(entries): Promise<Array<T | null>>`
+
+Concurrent multi-key fetch. Uses layer-level `getMany()` fast paths when all entries are simple reads.
+
+```ts
+const [user1, user2] = await cache.mget([
+  { key: 'user:1', fetch: () => db.findUser(1) },
+  { key: 'user:2', fetch: () => db.findUser(2) },
+])
+```
+
+#### `cache.has(key): Promise<boolean>`
+
+Check if a key exists in any layer.
+
+#### `cache.ttl(key): Promise<number | null>`
+
+Get the remaining TTL in seconds for a key in the first layer that has it. Returns `null` if the key doesn't exist.
+
+#### `cache.inspect(key): Promise<CacheInspectResult | null>`
+
+Returns detailed metadata about a cache key for debugging.
+
+```ts
+const info = await cache.inspect('user:123')
+// {
+//   key: 'user:123',
+//   foundInLayers: ['memory', 'redis'],
+//   freshTtlSeconds: 45,
+//   staleTtlSeconds: 75,
+//   errorTtlSeconds: 345,
+//   isStale: false,
+//   tags: ['user', 'user:123']
+// }
+```
+
+---
+
+### Write Operations
+
+#### `cache.set<T>(key, value, options?): Promise<void>`
+
+Writes to all layers simultaneously.
+
+```ts
+await cache.set('user:123', user, {
+  ttl: { memory: 60, redis: 600 },
+  tags: ['user', 'user:123'],
+  staleWhileRevalidate: { redis: 30 },
+  staleIfError: { redis: 120 },
+  ttlJitter: { redis: 5 }
+})
+
+// Uniform TTL across all layers
+await cache.set('user:123', user, { ttl: 120, tags: ['user'] })
+```
+
+#### `cache.mset<T>(entries): Promise<void>`
+
+Concurrent multi-key write.
+
+#### `cache.delete(key): Promise<void>`
+
+Delete from all layers.
+
+#### `cache.mdelete(keys): Promise<void>`
+
+Bulk delete.
+
+#### `cache.clear(): Promise<void>`
+
+Delete all keys from all layers.
+
+---
+
+### Invalidation
+
+#### `cache.invalidateByTag(tag): Promise<void>`
+
+Deletes every key stored with this tag across all layers.
+
+```ts
+await cache.set('user:123',       user,  { tags: ['user:123'] })
+await cache.set('user:123:posts', posts, { tags: ['user:123'] })
+
+await cache.invalidateByTag('user:123') // both keys gone
+```
+
+#### `cache.invalidateByTags(tags, mode?): Promise<void>`
+
+Delete keys matching any or all of a set of tags.
+
+```ts
+await cache.invalidateByTags(['tenant:a', 'users'], 'all') // keys tagged with both
+await cache.invalidateByTags(['users', 'posts'], 'any')    // keys tagged with either
+```
+
+#### `cache.invalidateByPattern(pattern): Promise<void>`
+
+Glob-style deletion. Patterns must be non-empty, at most 1024 characters, and free of control characters.
+
+```ts
+await cache.invalidateByPattern('user:*')
+```
+
+#### `cache.invalidateByPrefix(prefix): Promise<void>`
+
+Hierarchical prefix-based invalidation. Prefer this over glob when keys are hierarchical.
+
+```ts
+await cache.invalidateByPrefix('user:123:') // deletes user:123:profile, user:123:posts, ...
+```
+
+---
+
+### Wrapping & Namespaces
+
+#### `cache.wrap(prefix, fetcher, options?)`
+
+Wraps an async function so every call is transparently cached. The key is derived from function arguments unless you supply a `keyResolver`.
+
+```ts
+const getUser = cache.wrap('user', (id: number) => db.findUser(id))
+const user = await getUser(123) // key -> "user:123"
+
+// Custom key resolver
+const getUser = cache.wrap(
+  'user',
+  (id: number) => db.findUser(id),
+  { keyResolver: (id) => String(id), ttl: 300 }
+)
+```
+
+#### `cache.namespace(prefix): CacheNamespace`
+
+Returns a scoped view with the same full API. `clear()` only touches `prefix:*` keys.
+
+```ts
+const users = cache.namespace('users')
+const posts = cache.namespace('posts')
+
+await users.set('123', userData)    // stored as "users:123"
+await users.clear()                 // only deletes "users:*"
+
+// Nested namespaces
+const tenant = cache.namespace('tenant:abc')
+const tenantPosts = tenant.namespace('posts')
+await tenantPosts.set('1', data)   // stored as "tenant:abc:posts:1"
+```
+
+Namespace prefixes must be non-empty, at most 256 characters, and free of control characters.
+
+---
+
+### Warming & Persistence
+
+#### `cache.warm(entries, options?)`
+
+Pre-populate layers at startup. Higher `priority` values run first.
+
+```ts
+await cache.warm(
+  [
+    { key: 'config',  fetcher: () => db.getConfig(),  priority: 10 },
+    { key: 'user:1',  fetcher: () => db.findUser(1),  priority: 5 },
+    { key: 'user:2',  fetcher: () => db.findUser(2),  priority: 5 },
+  ],
+  { concurrency: 4, continueOnError: true }
+)
+```
+
+#### `cache.exportState() / cache.importState(snapshot)`
+
+In-memory snapshot transfer.
+
+```ts
+const snapshot = await cache.exportState()
+await anotherCache.importState(snapshot)
+```
+
+#### `cache.persistToFile(path) / cache.restoreFromFile(path)`
+
+Disk-based snapshot persistence. Restricted to `process.cwd()` by default (configurable via `snapshotBaseDir`).
+
+```ts
+await cache.persistToFile('./cache-snapshot.json')
+await cache.restoreFromFile('./cache-snapshot.json')
+```
+
+---
+
+### Observability
+
+#### `cache.getMetrics(): CacheMetricsSnapshot`
+
+```ts
+const { hits, misses, fetches, staleHits, refreshes, writeFailures } = cache.getMetrics()
+```
+
+#### `cache.getStats(): CacheStatsSnapshot`
+
+Returns metrics, per-layer degradation state, and background refresh count.
+
+```ts
+const { metrics, layers, backgroundRefreshes } = cache.getStats()
+// layers: [{ name, isLocal, degradedUntil }]
+```
+
+#### `cache.getHitRate()`
+
+Computed hit rate overall and per-layer.
+
+#### `cache.healthCheck(): Promise<CacheHealthCheckResult[]>`
+
+```ts
+const health = await cache.healthCheck()
+// [{ layer: 'memory', healthy: true, latencyMs: 0.03 }, ...]
+```
+
+#### `cache.resetMetrics(): void`
+
+Resets all counters to zero.
+
+---
+
+### Generation Management
+
+Add a generation prefix to every key and rotate it for bulk invalidation without scanning.
+
+```ts
+const cache = new CacheStack([...], { generation: 1 })
+
+await cache.set('user:123', user)
+cache.bumpGeneration() // now reads use v2:user:123
+
+// Optional: auto-cleanup old generation keys
+const cache = new CacheStack([...], {
+  generation: 1,
+  generationCleanup: { batchSize: 500 }
+})
+```
+
+#### `cache.bumpGeneration()`
+
+Rotate cache namespace by incrementing generation.
+
+#### `cache.getGeneration()`
+
+Get current generation number.
+
+---
+
+### Lifecycle
+
+#### `cache.disconnect(): Promise<void>`
+
+Graceful shutdown (unsubscribes from invalidation bus, etc.).
+
+---
+
+## Cache Layers
+
+All layers implement the `CacheLayer` interface:
+
+```ts
+interface CacheLayer {
+  readonly name: string
+  readonly defaultTtl?: number
+  readonly isLocal?: boolean
+
+  get<T>(key: string): Promise<T | null>
+  getEntry?<T>(key: string): Promise<unknown | null>
+  getMany?<T>(keys: string[]): Promise<Array<unknown | null>>
+  set(key: string, value: unknown, ttl?: number): Promise<void>
+  setMany?(entries: Array<{ key: string; value: unknown; ttl?: number }>): Promise<void>
+  delete(key: string): Promise<void>
+  deleteMany?(keys: string[]): Promise<void>
+  clear(): Promise<void>
+  keys?(): Promise<string[]>
+  forEachKey?(visitor: (key: string) => void | Promise<void>): Promise<void>
+  has?(key: string): Promise<boolean>
+  ttl?(key: string): Promise<number | null>
+  size?(): Promise<number>
+  ping?(): Promise<boolean>
+  dispose?(): Promise<void>
+}
+```
+
+### MemoryLayer
+
+In-process LRU/LFU/FIFO eviction with configurable max size.
+
+```ts
+new MemoryLayer({
+  ttl: 60,
+  maxSize: 5_000,
+  name: 'memory'    // default
+})
+```
+
+### RedisLayer
+
+Distributed caching via ioredis with compression, serializers, and optional prefix.
+
+```ts
+new RedisLayer({
+  client: redis,
+  ttl: 300,
+  prefix: 'myapp:cache:',
+  compression: 'gzip',
+  compressionThreshold: 1_024,
+  serializer: new MsgpackSerializer(),
+  name: 'redis',
+  allowUnprefixedClear: false
+})
+```
+
+### DiskLayer
+
+Persistent file-based caching with atomic writes and optional at-rest protection.
+
+```ts
+import { resolve } from 'node:path'
+
+new DiskLayer({
+  directory: resolve('./var/cache/layercache'),
+  maxFiles: 50_000,
+  name: 'disk'
+})
+```
+
+#### At-Rest Protection
+
+DiskLayer supports AES-256-GCM encryption or HMAC-SHA256 signing to protect cached data on disk:
+
+```ts
+new DiskLayer({
+  directory: resolve('./var/cache/layercache'),
+  encryptionKey: process.env.CACHE_ENCRYPTION_KEY,  // AES-256-GCM encryption
+  signingKey: process.env.CACHE_SIGNING_KEY,         // HMAC-SHA256 signing (ignored if encryptionKey is set)
+  name: 'disk'
+})
+```
+
+Encryption also provides authenticated integrity — a separate `signingKey` is unnecessary when `encryptionKey` is provided.
+
+### MemcachedLayer
+
+Memcached support with pluggable serializers and bulk operations.
+
+```ts
+new MemcachedLayer({
+  client: memcachedClient,
+  ttl: 300,
+  name: 'memcached'
+})
+```
+
+### Custom Layers
+
+Implement `CacheLayer` to plug in any backend:
+
+```ts
+class MyCustomLayer implements CacheLayer {
+  readonly name = 'custom'
+  readonly defaultTtl = 300
+  readonly isLocal = false
+
+  async get<T>(key: string): Promise<T | null> { /* ... */ }
+  async set(key: string, value: unknown, ttl?: number): Promise<void> { /* ... */ }
+  async delete(key: string): Promise<void> { /* ... */ }
+  async clear(): Promise<void> { /* ... */ }
+}
+```
+
+---
+
+## Options Reference
+
+### CacheStackOptions
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `logger` | `Logger \| boolean` | `false` | Pluggable logger interface or boolean |
+| `metrics` | `boolean` | `true` | Enable/disable metrics collection |
+| `stampedePrevention` | `boolean` | `true` | In-process request deduplication |
+| `stampedeMaxInFlight` | `number` | - | Max concurrent in-flight deduplicated requests |
+| `stampedeEntryTimeoutMs` | `number` | - | Per-entry timeout for stampede guard |
+| `invalidationBus` | `RedisInvalidationBus` | - | Distributed L1 invalidation |
+| `tagIndex` | `TagIndex \| RedisTagIndex` | in-memory | Custom tag tracking |
+| `generation` | `number` | - | Generation prefix for bulk invalidation |
+| `generationCleanup` | `boolean \| { batchSize: number }` | - | Auto-prune stale generation keys |
+| `broadcastL1Invalidation` | `boolean` | `false` | Publish writes to peer memory layers |
+| `negativeCaching` | `boolean` | `false` | Cache nulls globally |
+| `negativeTtl` | `number \| LayerTtlMap` | - | Global TTL for negative cache entries |
+| `staleWhileRevalidate` | `number \| LayerTtlMap` | - | Global stale-while-revalidate window (seconds) |
+| `staleIfError` | `number \| LayerTtlMap` | - | Global stale-if-error window (seconds) |
+| `ttlJitter` | `number \| LayerTtlMap` | - | Global TTL jitter (seconds) |
+| `refreshAhead` | `number \| LayerTtlMap` | - | Global refresh-ahead threshold (seconds) |
+| `adaptiveTtl` | `boolean \| AdaptiveTtlOptions` | - | Auto-ramp TTLs for hot keys |
+| `circuitBreaker` | `CircuitBreakerOptions` | - | Per-fetcher failure tracking |
+| `gracefulDegradation` | `boolean \| { retryAfterMs: number }` | - | Skip failed layers temporarily |
+| `writePolicy` | `'strict' \| 'best-effort'` | `'strict'` | Write failure behavior |
+| `writeStrategy` | `'write-through' \| 'write-behind'` | `'write-through'` | Write batching strategy |
+| `writeBehind` | `WriteBehindOptions` | - | Batch size, flush interval, max queue |
+| `fetcherRateLimit` | `RateLimitOptions` | - | Global rate limiting |
+| `backgroundRefreshTimeoutMs` | `number` | `30000` | Max time for stale refresh attempts |
+| `singleFlightCoordinator` | `RedisSingleFlightCoordinator` | - | Distributed deduplication |
+| `singleFlightLeaseMs` | `number` | `30000` | Distributed lock duration |
+| `singleFlightTimeoutMs` | `number` | `5000` | Wait timeout for distributed lock |
+| `singleFlightPollMs` | `number` | `50` | Polling interval |
+| `singleFlightRenewIntervalMs` | `number` | - | Lease renewal cadence |
+| `snapshotBaseDir` | `string \| false` | `process.cwd()` | Base directory for file snapshots |
+| `snapshotMaxBytes` | `number \| false` | - | Max snapshot file size |
+| `snapshotMaxEntries` | `number \| false` | - | Max entries in a snapshot |
+| `invalidationMaxKeys` | `number \| false` | - | Safety limit for invalidation scans |
+| `maxProfileEntries` | `number` | `100000` | Max size before pruning internal maps |
+
+### Per-Operation Options
+
+| Option | Type | Description |
+|---|---|---|
+| `tags` | `string[]` | Tags for tag-based invalidation |
+| `ttl` | `number \| LayerTtlMap` | TTL in seconds, or per-layer overrides |
+| `ttlPolicy` | `string \| object \| function` | `'until-midnight'`, `'next-hour'`, `{ alignTo }`, or custom |
+| `negativeCache` | `boolean` | Cache null results |
+| `negativeTtl` | `number` | Short TTL for misses |
+| `staleWhileRevalidate` | `number \| LayerTtlMap` | Return stale and refresh in background |
+| `staleIfError` | `number \| LayerTtlMap` | Keep serving stale if refresh fails |
+| `ttlJitter` | `number \| LayerTtlMap` | +/- random jitter on expiry |
+| `slidingTtl` | `boolean` | Reset TTL on every read |
+| `refreshAhead` | `number` | Trigger background refresh when TTL drops below threshold |
+| `adaptiveTtl` | `AdaptiveTtlOptions` | Auto-ramp TTL for hot keys |
+| `circuitBreaker` | `CircuitBreakerOptions` | Per-operation circuit breaker |
+| `fetcherRateLimit` | `RateLimitOptions` | Per-operation rate limiting |
+| `shouldCache` | `(value: T) => boolean` | Predicate to skip caching specific results |
+
+---
+
+## Invalidation Strategies
+
+### Tag Invalidation
+
+```ts
+await cache.set('user:123', user, { tags: ['user', 'user:123'] })
+await cache.invalidateByTag('user:123')
+```
+
+### Batch Tag Invalidation
+
+```ts
+await cache.invalidateByTags(['tenant:a', 'users'], 'all')
+await cache.invalidateByTags(['users', 'posts'], 'any')
+```
+
+### Wildcard Invalidation
+
+```ts
+await cache.invalidateByPattern('user:*')
+```
+
+### Prefix Invalidation
+
+```ts
+await cache.invalidateByPrefix('user:123:')
+```
+
+### Generation-Based Invalidation
+
+```ts
+cache.bumpGeneration() // instant bulk invalidation without scanning
+```
+
+---
+
+## Freshness Strategies
+
+### Stale-While-Revalidate
+
+```ts
+await cache.set('config', config, {
+  ttl: 60,
+  staleWhileRevalidate: 30,  // serve stale for 30s while refreshing
+  staleIfError: 300           // serve stale for 5min if refresh fails
+})
+```
+
+### Sliding TTL
+
+```ts
+await cache.get('session:abc', fetchSession, { slidingTtl: true })
+```
+
+### Adaptive TTL
+
+```ts
+await cache.get('popular-post', fetchPost, {
+  adaptiveTtl: { hotAfter: 5, step: 60, maxTtl: 3600 }
+})
+```
+
+### Refresh-Ahead
+
+```ts
+await cache.get('leaderboard', fetchLeaderboard, {
+  ttl: 120,
+  refreshAhead: 30 // refresh when <= 30s remain
+})
+```
+
+### TTL Policies
+
+```ts
+await cache.set('daily-report', report, { ttlPolicy: 'until-midnight' })
+await cache.set('hourly-rollup', rollup, { ttlPolicy: 'next-hour' })
+await cache.set('aligned', value, { ttlPolicy: { alignTo: 300 } })
+await cache.set('custom', value, {
+  ttlPolicy: ({ key }) => key.startsWith('hot:') ? 30 : 300
+})
+```
+
+### Per-Layer TTL Overrides
+
+```ts
+await cache.set('session:abc', data, {
+  ttl: { memory: 30, redis: 3600 }
+})
+```
+
+### Conditional Caching
+
+```ts
+const data = await cache.get('api:response', fetchFromApi, {
+  shouldCache: (value) => (value as any).status === 200
+})
+```
+
+---
+
+## Resilience
+
+### Graceful Degradation
+
+```ts
+new CacheStack([...], {
+  gracefulDegradation: { retryAfterMs: 10_000 }
+})
+```
+
+### Circuit Breaker
+
+```ts
+new CacheStack([...], {
+  circuitBreaker: { failureThreshold: 5, cooldownMs: 30_000 }
+})
+
+// Per-operation
+await cache.get('fragile-key', fetch, {
+  circuitBreaker: { failureThreshold: 3, cooldownMs: 10_000 }
+})
+```
+
+### Write Policies
+
+```ts
+// Strict (default): fail if any layer fails
+new CacheStack([...], { writePolicy: 'strict' })
+
+// Best-effort: only fail if every layer fails
+new CacheStack([...], { writePolicy: 'best-effort' })
+```
+
+### Scoped Fetcher Rate Limiting
+
+```ts
+await cache.get('user:123', fetchUser, {
+  fetcherRateLimit: { maxConcurrent: 1, scope: 'key' }
+})
+```
+
+---
+
+## Compression & Serialization
+
+### Compression
+
+```ts
+new RedisLayer({
+  client: redis,
+  ttl: 300,
+  compression: 'gzip',         // or 'brotli'
+  compressionThreshold: 1_024  // skip compression for small values
+})
+```
+
+### MessagePack Serializer
+
+```ts
+import { MsgpackSerializer } from 'layercache'
+
+new RedisLayer({
+  client: redis,
+  ttl: 300,
+  serializer: new MsgpackSerializer()
+})
+```
+
+---
+
+## Distributed Features
+
+### Distributed Single-Flight
+
+```ts
+import { RedisSingleFlightCoordinator } from 'layercache'
+
+const coordinator = new RedisSingleFlightCoordinator({ client: redis })
+
+new CacheStack([...], {
+  singleFlightCoordinator: coordinator,
+  singleFlightLeaseMs: 30_000,
+  singleFlightRenewIntervalMs: 10_000,
+})
+```
+
+### Cross-Server L1 Invalidation
+
+```ts
+import { RedisInvalidationBus } from 'layercache'
+
+const bus = new RedisInvalidationBus({ publisher: redis, subscriber: new Redis() })
+
+new CacheStack([...], {
+  invalidationBus: bus,
+  broadcastL1Invalidation: true
+})
+```
+
+### Distributed Tag Index
+
+```ts
+import { RedisTagIndex } from 'layercache'
+
+const tagIndex = new RedisTagIndex({
+  client: redis,
+  prefix: 'myapp:tag-index',
+  knownKeysShards: 8
+})
+
+new CacheStack([...], { tagIndex })
+```
+
+---
+
+## Event Hooks
+
+`CacheStack` extends `EventEmitter`:
+
+| Event | Payload |
+|---|---|
+| `hit` | `{ key, layer }` |
+| `miss` | `{ key }` |
+| `set` | `{ key }` |
+| `delete` | `{ key }` |
+| `stale-serve` | `{ key, state, layer }` |
+| `stampede-dedupe` | `{ key }` |
+| `backfill` | `{ key, fromLayer, toLayer }` |
+| `warm` | `{ key }` |
+| `error` | `{ event, context }` |
+
+```ts
+cache.on('hit',   ({ key, layer }) => metrics.inc('cache.hit', { layer }))
+cache.on('miss',  ({ key })        => metrics.inc('cache.miss'))
+cache.on('error', ({ event, context }) => logger.error(event, context))
+```
+
+---
+
+## Framework Integrations
+
+### Express
+
+```ts
+import { createExpressCacheMiddleware } from 'layercache'
+
+app.get('/api/users', createExpressCacheMiddleware(cache, {
+  ttl: 30,
+  tags: ['users'],
+  keyResolver: (req) => `user:${req.url}`
+}), handler)
+```
+
+### Fastify
+
+```ts
+import { createFastifyLayercachePlugin } from 'layercache/integrations/fastify'
+
+await fastify.register(createFastifyLayercachePlugin(cache, {
+  statsPath: '/cache/stats'
+}))
+```
+
+### Hono
+
+```ts
+import { createHonoCacheMiddleware } from 'layercache/integrations/hono'
+
+app.use('/api/*', createHonoCacheMiddleware(cache, { ttl: 60 }))
+```
+
+### tRPC
+
+```ts
+import { createTrpcCacheMiddleware } from 'layercache/integrations/trpc'
+
+const cacheMiddleware = createTrpcCacheMiddleware(cache, 'trpc', { ttl: 60 })
+export const cachedProcedure = t.procedure.use(cacheMiddleware)
+```
+
+### GraphQL
+
+```ts
+import { cacheGraphqlResolver } from 'layercache/integrations/graphql'
+
+const resolvers = {
+  Query: {
+    user: cacheGraphqlResolver(cache, 'user', (_root, { id }) => db.findUser(id), {
+      keyResolver: (_root, { id }) => id,
+      ttl: 300
+    })
+  }
+}
+```
+
+### NestJS
+
+Use `CacheStack` directly in your NestJS modules:
+
+```ts
+import { CacheStack, MemoryLayer, RedisLayer } from 'layercache'
+import Redis from 'ioredis'
+
+@Module({
+  providers: [
+    {
+      provide: 'CACHE',
+      useFactory: () => new CacheStack([
+        new MemoryLayer({ ttl: 20 }),
+        new RedisLayer({ client: new Redis(), ttl: 300 })
+      ])
+    }
+  ],
+  exports: ['CACHE']
+})
+export class CacheModule {}
+```
+
+> **Note:** The separate `@cachestack/nestjs` package was removed in v1.3.2. Import directly from `layercache` instead.
+
+### OpenTelemetry
+
+```ts
+import { createOpenTelemetryPlugin } from 'layercache/integrations/opentelemetry'
+
+createOpenTelemetryPlugin(cache, tracer)
+```
+
+### Stats HTTP Handler
+
+```ts
+import { createCacheStatsHandler } from 'layercache'
+import http from 'node:http'
+
+const statsHandler = createCacheStatsHandler(cache)
+http.createServer(statsHandler).listen(9090)
+```
+
+---
+
+## Admin CLI
+
+Inspect and manage Redis-backed caches from the terminal.
+
+```bash
+npx layercache stats      --redis redis://localhost:6379
+npx layercache keys       --redis redis://localhost:6379 --pattern "user:*"
+npx layercache invalidate --redis redis://localhost:6379 --tag user:123
+npx layercache invalidate --redis redis://localhost:6379 --pattern "session:*"
+```
+
+---
+
+## Debug Logging
+
+```bash
+DEBUG=layercache:debug node server.js
+```
+
+Or pass a logger instance:
+
+```ts
+new CacheStack([...], {
+  logger: {
+    debug(message, context) { myLogger.debug(message, context) }
+  }
+})
+```

--- a/docs-web/content/docs/cli.mdx
+++ b/docs-web/content/docs/cli.mdx
@@ -1,0 +1,591 @@
+---
+title: "CLI Tool"
+description: "Inspect and manage Redis-backed caches from the command line"
+---
+
+Layercache provides a command-line interface for inspecting and managing Redis-backed caches. Use it to check statistics, list keys, inspect values, and invalidate data without writing code.
+
+## Installation
+
+### Global Install
+
+```bash
+npm install -g layercache
+```
+
+### Using npx
+
+No installation required:
+
+```bash
+npx layercache stats --redis redis://localhost:6379
+```
+
+## Commands
+
+### stats
+
+Display cache statistics with optional pattern filtering.
+
+#### Basic Usage
+
+```bash
+layercache stats --redis redis://localhost:6379
+```
+
+#### Response
+
+```json
+{
+  "totalKeys": 1234,
+  "pattern": "*"
+}
+```
+
+#### With Pattern Filter
+
+```bash
+layercache stats --redis redis://localhost:6379 --pattern "user:*"
+```
+
+#### Use Cases
+
+- Check cache size before deployment
+- Monitor key growth over time
+- Verify pattern-based key distribution
+
+### keys
+
+List all cached keys matching a pattern.
+
+#### Basic Usage
+
+```bash
+layercache keys --redis redis://localhost:6379
+```
+
+#### Output
+
+```
+user:1
+user:2
+user:3
+session:abc123
+config:app
+...
+```
+
+#### With Pattern Filter
+
+```bash
+layercache keys --redis redis://localhost:6379 --pattern "user:*"
+```
+
+#### Output
+
+```
+user:1
+user:2
+user:3
+...
+```
+
+#### Use Cases
+
+- Find all keys for a specific entity
+- Debug cache key patterns
+- Export key lists for analysis
+- Verify tag index contents
+
+### inspect
+
+Inspect a specific cache key to view metadata and value.
+
+#### Basic Usage
+
+```bash
+layercache inspect --redis redis://localhost:6379 --key "user:123"
+```
+
+#### Response
+
+```json
+{
+  "key": "user:123",
+  "exists": true,
+  "ttlSeconds": 245,
+  "sizeBytes": 1024,
+  "isEnvelope": true,
+  "state": "fresh",
+  "preview": {
+    "kind": "fresh",
+    "value": {
+      "id": 123,
+      "name": "John Doe",
+      "email": "john@example.com"
+    },
+    "freshUntil": 1712848000000,
+    "staleUntil": 1712848300000,
+    "errorUntil": 1712848900000
+  }
+}
+```
+
+#### Non-Existent Key
+
+```json
+{
+  "key": "user:999",
+  "exists": false,
+  "ttlSeconds": null,
+  "sizeBytes": 0,
+  "isEnvelope": false,
+  "state": null,
+  "preview": null
+}
+```
+
+#### Field Descriptions
+
+- **exists** - Whether the key exists in Redis
+- **ttlSeconds** - Remaining TTL (-1 if no expiry, -2 if key doesn't exist)
+- **sizeBytes** - Size of the stored value in bytes
+- **isEnvelope** - Whether the value is a Layercache envelope (vs raw)
+- **state** - Cache state: `fresh`, `stale`, or `error`
+- **preview** - Value preview with metadata
+
+#### Use Cases
+
+- Debug cache contents
+- Verify TTL configuration
+- Check value state (fresh/stale/error)
+- Inspect envelope metadata
+
+### invalidate
+
+Invalidate cached data by pattern or tag.
+
+#### By Pattern
+
+```bash
+layercache invalidate --redis redis://localhost:6379 --pattern "user:*"
+```
+
+#### Response
+
+```json
+{
+  "deletedKeys": 123,
+  "pattern": "user:*"
+}
+```
+
+#### By Tag
+
+```bash
+layercache invalidate --redis redis://localhost:6379 --tag "user:123"
+```
+
+#### Response
+
+```json
+{
+  "deletedKeys": 5,
+  "tag": "user:123"
+}
+```
+
+#### Safety Guard for Untargeted Invalidation
+
+Running `invalidate` without `--pattern` or `--tag` defaults to matching all keys (`*`). This now requires an explicit `--force` flag to prevent accidental cache wipes:
+
+```bash
+# This shows a warning and aborts
+layercache invalidate --redis redis://localhost:6379
+
+# Explicitly confirm full invalidation
+layercache invalidate --redis redis://localhost:6379 --force
+```
+
+#### Custom Tag Index Prefix
+
+```bash
+layercache invalidate \
+  --redis redis://localhost:6379 \
+  --tag "tenant:abc" \
+  --tag-index-prefix "myapp:tag-index"
+```
+
+#### Use Cases
+
+- Bulk invalidation after data updates
+- Clear user-specific caches on logout
+- Invalidate by entity type (e.g., all products)
+- Clear tenant-specific data
+
+## Options
+
+### Global Options
+
+#### `--redis &lt;url&gt;`
+
+Redis connection URL (required).
+
+```bash
+--redis redis://localhost:6379
+--redis redis://user:pass@localhost:6379/2
+--redis rediss://prod-redis.example.com:6380  # TLS
+```
+
+Supported formats:
+- `redis://[user:pass@]host[:port][/db]`
+- `rediss://[user:pass@]host[:port][/db]` (TLS)
+- `host:port` (simplified)
+- `host` (defaults to port 6379)
+
+### Command-Specific Options
+
+#### `--pattern &lt;glob&gt;`
+
+Glob pattern for filtering keys (used with `stats`, `keys`, `invalidate`).
+
+```bash
+# All user keys
+--pattern "user:*"
+
+# Specific user
+--pattern "user:123:*"
+
+# Multiple patterns
+--pattern "user:*"
+--pattern "session:*"
+```
+
+#### `--key &lt;key&gt;`
+
+Exact cache key to inspect (used with `inspect`).
+
+```bash
+--key "user:123"
+--key "config:app"
+```
+
+#### `--tag &lt;tag&gt;`
+
+Tag for invalidation (used with `invalidate`).
+
+```bash
+--tag "user:123"
+--tag "tenant:abc"
+```
+
+#### `--tag-index-prefix &lt;prefix&gt;`
+
+Redis key prefix for tag index (used with `invalidate`).
+
+```bash
+--tag-index-prefix "layercache:tag-index"
+--tag-index-prefix "myapp:cache:tags"
+```
+
+#### `--require-tls`
+
+Require TLS connection. Fails if the Redis URL uses `redis://` (plaintext) instead of `rediss://`.
+
+```bash
+layercache stats --redis redis://localhost:6379 --require-tls
+# Error: --require-tls is set but the URL uses redis:// (plaintext).
+```
+
+#### `--force`
+
+Bypass the safety guard for untargeted `invalidate` operations. Required when running `invalidate` without `--pattern` or `--tag`.
+
+```bash
+# Without --force: warns and aborts
+layercache invalidate --redis redis://localhost:6379
+
+# With --force: proceeds with full invalidation
+layercache invalidate --redis redis://localhost:6379 --force
+```
+
+## Usage Examples
+
+### Check Cache Health
+
+```bash
+# Total keys in cache
+layercache stats --redis redis://localhost:6379
+
+# Keys by pattern
+layercache stats --redis redis://localhost:6379 --pattern "user:*"
+layercache stats --redis redis://localhost:6379 --pattern "session:*"
+layercache stats --redis redis://localhost:6379 --pattern "config:*"
+```
+
+### Debug Cache Issues
+
+```bash
+# Inspect a specific key
+layercache inspect --redis redis://localhost:6379 --key "user:123"
+
+# Check if key exists and its TTL
+layercache inspect --redis redis://localhost:6379 --key "config:app"
+
+# View all keys for a user
+layercache keys --redis redis://localhost:6379 --pattern "user:123:*"
+```
+
+### Invalidate Data
+
+```bash
+# Invalidate all user caches
+layercache invalidate --redis redis://localhost:6379 --pattern "user:*"
+
+# Invalidate specific user
+layercache invalidate --redis redis://localhost:6379 --tag "user:123"
+
+# Invalidate all sessions
+layercache invalidate --redis redis://localhost:6379 --pattern "session:*"
+
+# Invalidate tenant data
+layercache invalidate --redis redis://localhost:6379 --tag "tenant:abc"
+```
+
+### Deployment Scripts
+
+```bash
+#!/bin/bash
+# deploy.sh - Clear caches before deployment
+
+REDIS_URL="redis://prod-redis.example.com:6379"
+
+# Check current state
+echo "Current cache size:"
+layercache stats --redis "$REDIS_URL"
+
+# Clear all application caches
+echo "Clearing application caches..."
+layercache invalidate --redis "$REDIS_URL" --pattern "app:*"
+
+# Verify cleared
+echo "After invalidation:"
+layercache stats --redis "$REDIS_URL" --pattern "app:*"
+```
+
+### Monitoring Scripts
+
+```bash
+#!/bin/bash
+# monitor-cache.sh - Monitor cache growth
+
+REDIS_URL="redis://localhost:6379"
+
+while true; do
+  echo "$(date): Total keys"
+  layercache stats --redis "$REDIS_URL"
+  echo "$(date): User keys"
+  layercache stats --redis "$REDIS_URL" --pattern "user:*"
+  echo "---"
+  sleep 300  # Every 5 minutes
+done
+```
+
+### Cron Jobs
+
+```bash
+# Clear expired sessions hourly
+0 * * * * layercache invalidate --redis redis://localhost:6379 --pattern "session:expired:*"
+
+# Invalidate stale configs daily
+0 3 * * * layercache invalidate --redis redis://localhost:6379 --pattern "config:daily:*"
+
+# Report cache size weekly
+0 9 * * 1 layercache stats --redis redis://localhost:6379 > /var/log/cache-size.log
+```
+
+## Error Handling
+
+### Connection Errors
+
+```bash
+# Invalid URL
+$ layercache stats --redis "invalid-url"
+Error: Failed to connect to Redis at invalid-url: connect ECONNREFUSED
+
+# Missing --redis flag
+$ layercache stats
+Error: --redis requires a value (e.g. redis://localhost:6379)
+```
+
+### Scan Limits
+
+The CLI stops scanning after 1,000,000 keys to prevent runaway scans:
+
+```bash
+$ layercache keys --redis redis://localhost:6379 --pattern "*"
+Warning: stopped scanning after 1000000 keys. Use a more specific --pattern to narrow results.
+```
+
+### Missing Keys
+
+```bash
+# Inspect non-existent key
+$ layercache inspect --redis redis://localhost:6379 --key "missing"
+{
+  "key": "missing",
+  "exists": false,
+  "ttlSeconds": null,
+  "sizeBytes": 0,
+  "isEnvelope": false,
+  "state": null,
+  "preview": null
+}
+```
+
+## Best Practices
+
+### 1. Use Specific Patterns
+
+Avoid scanning all keys:
+
+```bash
+# Bad - scans entire database
+layercache keys --redis redis://localhost:6379 --pattern "*"
+
+# Good - specific pattern
+layercache keys --redis redis://localhost:6379 --pattern "user:*"
+```
+
+### 2. Use Tag Invalidation
+
+Prefer tags over pattern matching:
+
+```bash
+# Slower - scans and deletes each key
+layercache invalidate --redis redis://localhost:6379 --pattern "user:123:*"
+
+# Faster - uses tag index
+layercache invalidate --redis redis://localhost:6379 --tag "user:123"
+```
+
+### 3. Verify Before Invalidating
+
+Check what will be invalidated:
+
+```bash
+# First, check what matches
+layercache stats --redis redis://localhost:6379 --pattern "user:*"
+
+# Then invalidate
+layercache invalidate --redis redis://localhost:6379 --pattern "user:*"
+```
+
+### 4. Use Connection Pooling
+
+For frequent CLI operations, use a connection pool or reuse connections in scripts.
+
+### 5. Set Timeouts
+
+For slow Redis instances, set connection timeouts:
+
+```bash
+# The CLI uses 5-second connect timeout
+# Adjust by modifying Redis client options in your scripts
+```
+
+## Integration with CI/CD
+
+### GitHub Actions
+
+```yaml
+name: Deploy
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Clear caches
+        run: |
+          npx layercache invalidate \
+            --redis ${{ secrets.REDIS_URL }} \
+            --pattern "app:*"
+```
+
+### Docker
+
+```dockerfile
+FROM node:20-alpine
+
+RUN npm install -g layercache
+
+# Use in entrypoint script
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+```
+
+```bash
+#!/bin/bash
+# entrypoint.sh
+
+# Clear caches on startup
+layercache invalidate --redis "$REDIS_URL" --pattern "temp:*"
+
+# Start application
+exec node server.js
+```
+
+## Advanced Usage
+
+### Piping to Other Tools
+
+```bash
+# Count keys
+layercache keys --redis redis://localhost:6379 --pattern "user:*" | wc -l
+
+# Search for specific user
+layercache keys --redis redis://localhost:6379 | grep "user:123"
+
+# Export to file
+layercache keys --redis redis://localhost:6379 --pattern "user:*" > user-keys.txt
+
+# Analyze with jq
+layercache inspect --redis redis://localhost:6379 --key "user:123" | jq '.preview.value'
+```
+
+### Batch Operations
+
+```bash
+# Invalidate multiple tags
+for tag in user:123 user:456 user:789; do
+  layercache invalidate --redis redis://localhost:6379 --tag "$tag"
+done
+
+# Check multiple patterns
+for pattern in user:* session:* config:*; do
+  echo "Pattern: $pattern"
+  layercache stats --redis redis://localhost:6379 --pattern "$pattern"
+done
+```
+
+### Monitoring with Grafana
+
+Export stats to Prometheus via a cron job:
+
+```bash
+#!/bin/bash
+# Export to Prometheus pushgateway
+
+STATS=$(layercache stats --redis redis://localhost:6379 --pattern "user:*")
+cat <<EOF | curl --data-binary @- http://pushgateway:9091/metrics/job/layercache
+# HELP layercache_keys_total Total number of cache keys
+# TYPE layercache_keys_total gauge
+layercache_keys_total{pattern="user:*"} $(echo "$STATS" | jq -r '.totalKeys')
+EOF
+```

--- a/docs-web/content/docs/distributed.mdx
+++ b/docs-web/content/docs/distributed.mdx
@@ -1,0 +1,482 @@
+---
+title: "Distributed Deployment"
+description: "Coordinate cache operations across multiple servers with Redis-based coordination"
+---
+
+Layercache provides distributed coordination features for multi-server deployments. Prevent stampedes, coordinate invalidations, and maintain consistent tag indexes across your infrastructure.
+
+## Overview
+
+When running multiple instances of your application, you need to coordinate cache operations to avoid:
+
+1. **Stampedes** - Multiple servers fetching the same uncached key simultaneously
+2. **Stale L1 caches** - Memory layers holding outdated data after writes
+3. **Inconsistent tags** - Different servers with different tag-to-key mappings
+
+Layercache solves these with three Redis-based components:
+
+- **RedisSingleFlightCoordinator** - Distributed request deduplication
+- **RedisInvalidationBus** - Cross-server L1 invalidation via pub/sub
+- **RedisTagIndex** - Shared tag index for consistent invalidations
+
+## RedisSingleFlightCoordinator
+
+Prevent multiple servers from fetching the same key simultaneously using distributed locking.
+
+### How It Works
+
+1. First server to request a key acquires a Redis lock (SET NX PX)
+2. Lock holder runs the fetcher and writes the value
+3. Other servers wait and poll for the value
+4. Lock is released automatically via Lua script
+5. Waiters read the cached value and return
+
+### Installation
+
+```tsx
+import { CacheStack, MemoryLayer, RedisLayer, RedisSingleFlightCoordinator } from 'layercache'
+import Redis from 'ioredis'
+
+const redis = new Redis()
+const coordinator = new RedisSingleFlightCoordinator({ client: redis })
+```
+
+### Basic Setup
+
+```tsx
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 20 }),
+  new RedisLayer({ client: redis, ttl: 300 })
+], {
+  singleFlightCoordinator: coordinator,
+  singleFlightLeaseMs: 30000,        // Lock duration
+  singleFlightTimeoutMs: 5000,       // Max wait time
+  singleFlightPollMs: 50             // Polling interval
+})
+```
+
+### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `singleFlightCoordinator` | `RedisSingleFlightCoordinator` | - | Coordinator instance |
+| `singleFlightLeaseMs` | `number` | `30000` | Lock duration in milliseconds |
+| `singleFlightTimeoutMs` | `number` | `5000` | Max wait time for lock |
+| `singleFlightPollMs` | `number` | `50` | Polling interval in milliseconds |
+| `singleFlightRenewIntervalMs` | `number` | `leaseMs / 2` | Lease renewal interval |
+
+### Lease Renewal
+
+The lock holder automatically renews the lease to prevent expiration during long fetches:
+
+```tsx
+const cache = new CacheStack([/* ... */], {
+  singleFlightCoordinator: coordinator,
+  singleFlightLeaseMs: 60000,
+  singleFlightRenewIntervalMs: 10000  // Renew every 10 seconds
+})
+```
+
+### Custom Prefix
+
+```tsx
+const coordinator = new RedisSingleFlightCoordinator({
+  client: redis,
+  prefix: 'myapp:singleflight'
+})
+```
+
+## RedisInvalidationBus
+
+Broadcast invalidations to all servers via Redis pub/sub.
+
+### How It Works
+
+1. Server A writes a key
+2. Invalidation message is published to Redis channel
+3. All servers receive the message
+4. Each server invalidates its local memory layer
+5. Tag index is updated (if using RedisTagIndex)
+
+### Installation
+
+```tsx
+import { CacheStack, MemoryLayer, RedisLayer, RedisInvalidationBus } from 'layercache'
+import Redis from 'ioredis'
+
+const publisher = new Redis()
+const subscriber = new Redis()
+
+const bus = new RedisInvalidationBus({
+  publisher,
+  subscriber,
+  channel: 'myapp:invalidation'
+})
+```
+
+### Basic Setup
+
+```tsx
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 20 }),
+  new RedisLayer({ client: publisher, ttl: 300 })
+], {
+  invalidationBus: bus,
+  broadcastL1Invalidation: true
+})
+```
+
+### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `invalidationBus` | `RedisInvalidationBus` | - | Bus instance |
+| `broadcastL1Invalidation` | `boolean` | `false` | Enable L1 invalidation broadcasts |
+| `channel` | `string` | `'layercache:invalidation'` | Pub/sub channel name |
+| `logger` | `Logger` | - | Optional logger for errors |
+
+### Invalidation Message Format
+
+```tsx
+{
+  sourceId: string,      // Unique server ID
+  scope: 'key' | 'keys' | 'clear',
+  operation: 'write' | 'delete' | 'invalidate' | 'clear',
+  keys: string[],        // Affected keys
+  timestamp: number
+}
+```
+
+### Example Flow
+
+```tsx
+// Server A
+await cache.set('user:123', user)
+// → Publishes { keys: ['user:123'], operation: 'write' }
+
+// Server B (memory layer)
+// → Receives message, deletes 'user:123' from memory
+
+// Server B (next read)
+await cache.get('user:123', fetchUser)
+// → Miss in memory, hits in Redis, backfills memory
+```
+
+### Custom Channel
+
+```tsx
+const bus = new RedisInvalidationBus({
+  publisher: redis,
+  subscriber: new Redis(),
+  channel: 'myapp:cache:invalidation',
+  logger: console
+})
+```
+
+### Cleanup
+
+```tsx
+// When shutting down, unsubscribe from Redis
+await cache.disconnect()
+```
+
+## RedisTagIndex
+
+Maintain a consistent tag index across all servers using Redis sets.
+
+### How It Works
+
+1. When setting a key with tags, add key-to-tags mapping to Redis
+2. Add key to tag-indexed sets for efficient lookups
+3. When invalidating by tag, fetch all keys for that tag
+4. Delete keys and publish invalidations
+
+### Sharding for Scale
+
+The tag index shards known-keys sets across multiple Redis keys for horizontal scaling:
+
+- Default: 1 shard (single set)
+- Recommended: 8-16 shards for high cardinality
+- Sharding reduces single-key contention
+
+### Installation
+
+```tsx
+import { CacheStack, MemoryLayer, RedisLayer, RedisTagIndex } from 'layercache'
+import Redis from 'ioredis'
+
+const redis = new Redis()
+
+const tagIndex = new RedisTagIndex({
+  client: redis,
+  prefix: 'myapp:tag-index',
+  knownKeysShards: 8  // Distribute across 8 sets
+})
+```
+
+### Basic Setup
+
+```tsx
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 20 }),
+  new RedisLayer({ client: redis, ttl: 300 })
+], {
+  tagIndex
+})
+
+// Use tags as usual
+await cache.set('user:123', user, { tags: ['user', 'user:123'] })
+await cache.invalidateByTag('user:123')
+```
+
+### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `client` | `Redis` | - | Redis client |
+| `prefix` | `string` | `'layercache:tag-index'` | Key prefix for index |
+| `scanCount` | `number` | `100` | SSCAN batch size |
+| `knownKeysShards` | `number` | `1` | Number of shards for known keys |
+
+### Redis Key Structure
+
+```
+myapp:tag-index:tag:&lt;tag&gt;           → SET of keys with this tag
+myapp:tag-index:key:&lt;key&gt;           → SET of tags for this key
+myapp:tag-index:keys:&lt;shard&gt;        → SET of all known keys (sharded)
+```
+
+### Tag Invalidation Flow
+
+```tsx
+// 1. Set key with tags
+await cache.set('user:123:posts', posts, {
+  tags: ['user:123', 'posts']
+})
+
+// 2. Invalidate by tag
+await cache.invalidateByTag('user:123')
+
+// Behind the scenes:
+// - Fetches all keys from 'myapp:tag-index:tag:user:123'
+// - Deletes keys from Redis
+// - Publishes invalidation to RedisInvalidationBus
+// - Cleans up tag index entries
+```
+
+### Sharding Example
+
+```tsx
+// For high-volume deployments, use more shards
+const tagIndex = new RedisTagIndex({
+  client: redis,
+  knownKeysShards: 16  // Distribute across 16 sets
+})
+
+// Each shard handles ~1/16 of known keys
+// Reduces contention on SSCAN/SADD operations
+```
+
+## Complete Distributed Setup
+
+Combine all three components for a production-ready distributed cache:
+
+```tsx
+import { CacheStack, MemoryLayer, RedisLayer } from 'layercache'
+import {
+  RedisSingleFlightCoordinator,
+  RedisInvalidationBus,
+  RedisTagIndex
+} from 'layercache'
+import Redis from 'ioredis'
+
+const redis = new Redis({
+  host: process.env.REDIS_HOST,
+  port: 6379,
+  retryStrategy: (times) => Math.min(times * 50, 2000)
+})
+
+// 1. Distributed single-flight
+const coordinator = new RedisSingleFlightCoordinator({
+  client: redis,
+  prefix: 'myapp:singleflight'
+})
+
+// 2. Cross-server invalidation
+const bus = new RedisInvalidationBus({
+  publisher: redis,
+  subscriber: new Redis(),
+  channel: 'myapp:invalidation',
+  logger: console
+})
+
+// 3. Shared tag index
+const tagIndex = new RedisTagIndex({
+  client: redis,
+  prefix: 'myapp:tag-index',
+  knownKeysShards: 8
+})
+
+// 4. Create cache stack
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 20 }),
+  new RedisLayer({ client: redis, ttl: 300 })
+], {
+  // Distributed single-flight
+  singleFlightCoordinator: coordinator,
+  singleFlightLeaseMs: 30000,
+  singleFlightTimeoutMs: 5000,
+  singleFlightPollMs: 50,
+
+  // L1 invalidation
+  invalidationBus: bus,
+  broadcastL1Invalidation: true,
+
+  // Tag index
+  tagIndex
+})
+
+// 5. Use the cache
+await cache.set('user:123', user, { tags: ['user:123'] })
+const user = await cache.get('user:123', fetchUser)
+await cache.invalidateByTag('user:123')
+
+// 6. Graceful shutdown
+process.on('SIGTERM', async () => {
+  await cache.disconnect()
+  await redis.quit()
+  process.exit(0)
+})
+```
+
+## Architecture Diagram
+
+```
+┌─────────────┐     ┌─────────────┐     ┌─────────────┐
+│  Server A   │     │  Server B   │     │   Redis     │
+├─────────────┤     ├─────────────┤     ├─────────────┤
+│ Memory L1   │     │ Memory L1   │     │             │
+│ Redis L2    │     │ Redis L2    │     │ Data Store  │
+│             │     │             │     │             │
+│ Coordinator │◄────┤ Coordinator │◄────│ Locks       │
+│ Bus Pub     │     │ Bus Sub     │◄────│ Pub/Sub     │
+│ Tag Index   │◄────┤ Tag Index   │◄────│ Tag Sets    │
+└─────────────┘     └─────────────┘     └─────────────┘
+```
+
+## Performance Considerations
+
+### Single Flight
+
+- **Lock acquisition**: ~1-2ms (SET NX)
+- **Polling overhead**: ~50ms intervals
+- **Lease renewal**: Background, non-blocking
+
+### Invalidation Bus
+
+- **Publish latency**: &lt;1ms
+- **Message size**: ~1KB per invalidation
+- **Subscriber lag**: Network-dependent
+
+### Tag Index
+
+- **Set operations**: O(1) per key
+- **Tag invalidation**: O(n) where n = keys with tag
+- **Sharding**: Reduces contention by factor of shards
+
+### Recommended Settings
+
+For high-traffic deployments:
+
+```tsx
+const cache = new CacheStack([/* ... */], {
+  // Single-flight: longer leases for slow fetchers
+  singleFlightLeaseMs: 60000,
+  singleFlightRenewIntervalMs: 10000,
+  singleFlightPollMs: 100,
+
+  // Tag index: more shards for scale
+  tagIndex: new RedisTagIndex({
+    client: redis,
+    knownKeysShards: 16
+  })
+})
+```
+
+## Monitoring
+
+### Track Coordinator Operations
+
+```tsx
+cache.on('error', ({ event, context }) => {
+  if (context.operation === 'singleFlight') {
+    console.error('Single-flight error:', context.error)
+  }
+})
+```
+
+### Monitor Bus Messages
+
+```tsx
+cache.on('invalidation', ({ keys, sourceId }) => {
+  console.log(`Invalidated ${keys.length} keys from ${sourceId}`)
+})
+```
+
+### Check Tag Index Size
+
+```tsx
+const redis = new Redis()
+const keys = await redis.keys('layercache:tag-index:tag:*')
+console.log(`Tracking ${keys.length} tags`)
+```
+
+## Troubleshooting
+
+### Lock Timeouts
+
+If servers timeout waiting for locks:
+
+```tsx
+// Increase lease duration
+singleFlightLeaseMs: 60000
+
+// Increase wait timeout
+singleFlightTimeoutMs: 10000
+```
+
+### Stale L1 Data
+
+If memory layers aren't invalidating:
+
+```tsx
+// Ensure broadcast is enabled
+broadcastL1Invalidation: true
+
+// Check bus connection
+bus.on('error', (err) => console.error('Bus error:', err))
+```
+
+### Slow Tag Invalidations
+
+If tag invalidations are slow:
+
+```tsx
+// Increase shards for parallelization
+tagIndex: new RedisTagIndex({
+  client: redis,
+  knownKeysShards: 16  // More shards
+})
+```
+
+### High Redis Memory
+
+If tag index uses too much memory:
+
+```tsx
+// Reduce scan batch size
+tagIndex: new RedisTagIndex({
+  client: redis,
+  scanCount: 50  // Fewer keys per SSCAN
+})
+```

--- a/docs-web/content/docs/getting-started.mdx
+++ b/docs-web/content/docs/getting-started.mdx
@@ -1,0 +1,159 @@
+---
+title: "Getting Started"
+description: "Install and configure your first multi-layer cache stack"
+---
+
+## Installation
+
+```bash
+npm install layercache
+```
+
+## Basic Setup
+
+The simplest cache stack uses a single memory layer:
+
+```ts
+import { CacheStack, MemoryLayer } from 'layercache'
+
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 60 })
+])
+```
+
+### Reading Through the Cache
+
+Use the read-through pattern to fetch data with automatic caching:
+
+```ts
+const user = await cache.get('user:123', () =>
+  db.findUser(123)
+)
+
+// On first call: fetcher runs, result is cached
+// On subsequent calls: serves from memory, no fetcher execution
+```
+
+## Multi-Layer Setup
+
+For production, add Redis for cross-process sharing:
+
+```ts
+import { CacheStack, MemoryLayer, RedisLayer } from 'layercache'
+import Redis from 'ioredis'
+
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 60, maxSize: 1_000 }),       // L1: in-process
+  new RedisLayer({ client: new Redis(), ttl: 3600 }),  // L2: shared
+])
+```
+
+### How Layered Reads Work
+
+When you call `cache.get()`:
+
+1. **L1 Memory** is checked first (~0.01ms)
+2. If missing, **L2 Redis** is checked (~0.5ms)
+3. If also missing, your **fetcher** runs (~20ms+)
+4. On any partial hit, upper layers are **backfilled** automatically
+
+## Three-Layer Setup with Disk Persistence
+
+Add disk persistence for fault tolerance:
+
+```ts
+import { CacheStack, MemoryLayer, RedisLayer, DiskLayer } from 'layercache'
+
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 60, maxSize: 5_000 }),
+  new RedisLayer({
+    client: new Redis(),
+    ttl: 3600,
+    compression: 'gzip'
+  }),
+  new DiskLayer({
+    directory: './var/cache',
+    maxFiles: 10_000
+  }),
+])
+```
+
+## Key Configuration Options
+
+### MemoryLayer
+
+```ts
+new MemoryLayer({
+  ttl: 60,           // Time-to-live in seconds
+  maxSize: 1000,     // Max number of entries (LRU eviction)
+})
+```
+
+### RedisLayer
+
+```ts
+new RedisLayer({
+  client: new Redis(),           // ioredis client
+  ttl: 3600,                     // Time-to-live in seconds
+  compression: 'gzip',           // 'gzip' | 'brotli' | false
+  compressionThreshold: 1024,    // Min bytes to compress
+})
+```
+
+### DiskLayer
+
+```ts
+new DiskLayer({
+  directory: './var/cache',      // Storage directory
+  maxFiles: 10_000,              // Max files (LRU eviction)
+})
+```
+
+## Common Patterns
+
+### Function Wrapping
+
+Transparently cache any function with `wrap()`:
+
+```ts
+const cachedFetch = cache.wrap('users', async (id: string) => {
+  return db.findUser(id)
+})
+
+const user = await cachedFetch('123')
+// Uses key "users:123" automatically
+```
+
+### Namespacing
+
+Create scoped cache views with prefixes:
+
+```ts
+const userCache = cache.namespace('user')
+const productCache = cache.namespace('product')
+
+await userCache.set('123', data)
+await productCache.set('456', data)
+// Stored as "user:123" and "product:456"
+```
+
+### Bulk Operations
+
+Set and get multiple keys efficiently:
+
+```ts
+await cache.setMany([
+  { key: 'user:1', value: { name: 'Alice' } },
+  { key: 'user:2', value: { name: 'Bob' } },
+])
+
+const users = await cache.getMany(['user:1', 'user:2'], (keys) =>
+  db.findUsers(keys)
+)
+```
+
+## Next Steps
+
+- **[Tutorial](/docs/tutorial)** — Learn stampede prevention, tag invalidation, and more
+- **[API Reference](/docs/api)** — Complete method documentation
+- **[Integrations](/docs/integrations)** — Use with Express, Fastify, NestJS, and more

--- a/docs-web/content/docs/index.mdx
+++ b/docs-web/content/docs/index.mdx
@@ -1,0 +1,15 @@
+---
+title: "Documentation"
+description: "Production-ready multi-layer caching for Node.js"
+---
+
+Welcome to the Layercache documentation.
+
+Layercache stacks memory, Redis, and disk behind a single API with stampede prevention, tag invalidation, stale-while-revalidate, and full observability.
+
+## Quick Links
+
+- **[Getting Started](/docs/getting-started)** — Install and configure your first cache stack
+- **[Tutorial](/docs/tutorial)** — 10-step walkthrough of production features
+- **[API Reference](/docs/api)** — Complete method and option documentation
+- **[Integrations](/docs/integrations)** — Express, Fastify, NestJS, Hono, tRPC, GraphQL

--- a/docs-web/content/docs/integrations.mdx
+++ b/docs-web/content/docs/integrations.mdx
@@ -1,0 +1,478 @@
+---
+title: "Framework Integrations"
+description: "Integrate Layercache with Express, Fastify, Hono, NestJS, tRPC, GraphQL, and OpenTelemetry"
+---
+
+Layercache provides first-class integrations with popular Node.js frameworks and observability tools. Each integration is designed to be lightweight, type-safe, and minimal in configuration.
+
+## Express
+
+The Express middleware caches JSON responses from your route handlers.
+
+### Installation
+
+```bash
+npm install layercache
+```
+
+### Basic Usage
+
+```tsx
+import express from 'express'
+import { CacheStack, MemoryLayer, RedisLayer, createExpressCacheMiddleware } from 'layercache'
+import Redis from 'ioredis'
+
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 20 }),
+  new RedisLayer({ client: new Redis(), ttl: 300 })
+])
+
+const app = express()
+
+// Cache all GET requests to /api/users
+app.get('/api/users',
+  createExpressCacheMiddleware(cache, {
+    ttl: 30,
+    tags: ['users']
+  }),
+  async (req, res) => {
+    const users = await fetchUsersFromDB()
+    res.json(users)
+  }
+)
+
+app.listen(3000)
+```
+
+### Custom Cache Keys
+
+```tsx
+app.get('/api/users/:id',
+  createExpressCacheMiddleware(cache, {
+    keyResolver: (req) => `user:${req.params.id}`,
+    ttl: 300
+  }),
+  async (req, res) => {
+    const user = await fetchUser(req.params.id)
+    res.json(user)
+  }
+)
+```
+
+### Options
+
+- `keyResolver` - Function to generate cache keys from requests
+- `methods` - HTTP methods to cache (default: `['GET']`)
+- `ttl` - Time-to-live in seconds
+- `tags` - Tags for invalidation
+- `allowPrivateCaching` - Allow implicit URL-based keys (default: false)
+
+### Response Headers
+
+The middleware adds `x-cache: HIT` or `x-cache: MISS` headers to responses.
+
+## Fastify
+
+The Fastify plugin decorates your app with a cache instance and provides an optional stats endpoint.
+
+### Installation
+
+```bash
+npm install layercache
+```
+
+### Basic Usage
+
+```tsx
+import Fastify from 'fastify'
+import { CacheStack, MemoryLayer, RedisLayer, createFastifyLayercachePlugin } from 'layercache'
+import Redis from 'ioredis'
+
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 20 }),
+  new RedisLayer({ client: new Redis(), ttl: 300 })
+])
+
+const fastify = Fastify()
+
+await fastify.register(createFastifyLayercachePlugin(cache, {
+  exposeStatsRoute: true,
+  statsPath: '/cache/stats',
+  allowPublicStatsRoute: false
+}))
+
+// Use the cache directly in routes
+fastify.get('/api/users', async (request, reply) => {
+  const users = await cache.get('users', () => fetchUsersFromDB())
+  return users
+})
+```
+
+### Options
+
+- `exposeStatsRoute` - Enable stats endpoint (default: false)
+- `statsPath` - Path for stats endpoint (default: '/cache/stats')
+- `allowPublicStatsRoute` - Allow public access (default: false)
+- `authorizeStatsRoute` - Async authorization function
+- `unauthorizedStatusCode` - Status code for unauthorized (default: 403)
+
+## Hono
+
+The Hono middleware caches JSON responses with minimal overhead.
+
+### Installation
+
+```bash
+npm install layercache
+```
+
+### Basic Usage
+
+```tsx
+import { Hono } from 'hono'
+import { CacheStack, MemoryLayer, createHonoCacheMiddleware } from 'layercache'
+
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 20 })
+])
+
+const app = new Hono()
+
+app.use('/api/*', createHonoCacheMiddleware(cache, {
+  ttl: 60,
+  tags: ['api']
+}))
+
+app.get('/api/users', async (c) => {
+  const users = await fetchUsersFromDB()
+  return c.json(users)
+})
+```
+
+### Custom Cache Keys
+
+```tsx
+app.get('/api/users/:id',
+  createHonoCacheMiddleware(cache, {
+    keyResolver: (req) => `user:${req.path.split('/').pop()}`,
+    ttl: 300
+  }),
+  async (c) => {
+    const id = c.req.param('id')
+    const user = await fetchUser(id)
+    return c.json(user)
+  }
+)
+```
+
+## NestJS
+
+Use `CacheStack` directly in your NestJS providers. Import from `layercache` — no separate package needed.
+
+### Module Setup
+
+```tsx
+import { Module } from '@nestjs/common'
+import { CacheStack, MemoryLayer, RedisLayer } from 'layercache'
+import Redis from 'ioredis'
+
+@Module({
+  providers: [
+    {
+      provide: 'CACHE_STACK',
+      useFactory: () => new CacheStack([
+        new MemoryLayer({ ttl: 20 }),
+        new RedisLayer({ client: new Redis(), ttl: 300 })
+      ])
+    }
+  ],
+  exports: ['CACHE_STACK']
+})
+export class CacheModule {}
+```
+
+### Async Configuration
+
+```tsx
+import { Module } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { CacheStack, MemoryLayer, RedisLayer } from 'layercache'
+import Redis from 'ioredis'
+
+@Module({
+  providers: [
+    {
+      provide: 'CACHE_STACK',
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => new CacheStack([
+        new MemoryLayer({ ttl: 20 }),
+        new RedisLayer({
+          client: new Redis(config.get('REDIS_URL')),
+          ttl: 300
+        })
+      ])
+    }
+  ],
+  exports: ['CACHE_STACK']
+})
+export class CacheModule {}
+```
+
+### Using in Services
+
+```tsx
+import { Injectable, Inject } from '@nestjs/common'
+import { CacheStack } from 'layercache'
+
+@Injectable()
+export class UsersService {
+  constructor(
+    @Inject('CACHE_STACK') private readonly cache: CacheStack
+  ) {}
+
+  async getUser(id: string): Promise<User> {
+    return this.cache.get(`user:${id}`, () =>
+      this.usersRepository.findOne(id)
+    )
+  }
+}
+```
+
+> **Note:** The separate `@cachestack/nestjs` package was removed in v1.3.2. Use `CacheStack` directly from `layercache`.
+
+## tRPC
+
+The tRPC middleware caches procedure results based on input arguments.
+
+### Installation
+
+```bash
+npm install layercache
+```
+
+### Basic Usage
+
+```tsx
+import { initTRPC } from '@trpc/server'
+import { CacheStack, MemoryLayer, createTrpcCacheMiddleware } from 'layercache'
+
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 60 })
+])
+
+const t = initTRPC.create()
+
+const cacheMiddleware = createTrpcCacheMiddleware(cache, 'trpc', {
+  keyResolver: (input) => JSON.stringify(input),
+  ttl: 300
+})
+
+export const cachedProcedure = t.procedure.use(cacheMiddleware)
+
+export const appRouter = t.router({
+  user: cachedProcedure
+    .input((val: unknown) => val as { id: string })
+    .query(async ({ input }) => {
+      return fetchUser(input.id)
+    })
+})
+```
+
+### Context-Aware Caching
+
+```tsx
+const cacheMiddleware = createTrpcCacheMiddleware(cache, 'user', {
+  keyResolver: (input, path, type) => {
+    return `${type}:${path}:${JSON.stringify(input)}`
+  },
+  ttl: 300
+})
+```
+
+## GraphQL
+
+Cache resolver results with the GraphQL wrapper.
+
+### Installation
+
+```bash
+npm install layercache
+```
+
+### Basic Usage
+
+```tsx
+import { CacheStack, MemoryLayer, cacheGraphqlResolver } from 'layercache'
+
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 60 })
+])
+
+const resolvers = {
+  Query: {
+    user: cacheGraphqlResolver(
+      cache,
+      'user',
+      async (_root, { id }) => {
+        return fetchUser(id)
+      },
+      {
+        keyResolver: (_root, { id }) => id,
+        ttl: 300
+      }
+    )
+  }
+}
+```
+
+### With Tags
+
+```tsx
+const resolvers = {
+  Query: {
+    user: cacheGraphqlResolver(
+      cache,
+      'user',
+      async (_root, { id }) => {
+        return fetchUser(id)
+      },
+      {
+        keyResolver: (_root, { id }) => id,
+        ttl: 300,
+        tags: ({ id }) => ['user', `user:${id}`]
+      }
+    )
+  }
+}
+```
+
+## OpenTelemetry
+
+Add distributed tracing to cache operations with OpenTelemetry integration.
+
+### Installation
+
+```bash
+npm install layercache @opentelemetry/api
+```
+
+### Basic Setup
+
+```tsx
+import { trace } from '@opentelemetry/api'
+import { CacheStack, MemoryLayer, createOpenTelemetryPlugin } from 'layercache'
+
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 60 })
+])
+
+const tracer = trace.getTracer('layercache')
+
+const plugin = createOpenTelemetryPlugin(cache, tracer)
+
+// Cache operations are now traced
+await cache.get('user:123', fetchUser)
+
+// Clean up on shutdown
+plugin.uninstall()
+```
+
+### Span Attributes
+
+Each cache operation creates a span with the following attributes:
+
+- `layercache.success` - Whether the operation succeeded
+- `layercache.result` - The result type (hit, miss, etc.)
+- Error details if the operation failed
+
+### Custom Tracer
+
+```tsx
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
+import { Resource } from '@opentelemetry/resources'
+
+const provider = new NodeTracerProvider({
+  resource: new Resource({ service: 'my-app' })
+})
+provider.register()
+
+const tracer = trace.getTracer('my-app', '1.0.0')
+const plugin = createOpenTelemetryPlugin(cache, tracer)
+```
+
+## Stats HTTP Handler
+
+Expose cache statistics via HTTP for monitoring dashboards.
+
+### Basic Usage
+
+```tsx
+import { createCacheStatsHandler } from 'layercache'
+import http from 'node:http'
+
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 60 })
+])
+
+const handler = createCacheStatsHandler(cache)
+
+const server = http.createServer(handler)
+server.listen(9090)
+```
+
+### With Authorization
+
+```tsx
+const handler = createCacheStatsHandler(cache, {
+  authorize: async (req) => {
+    const authHeader = req.headers['authorization']
+    return authHeader === `Bearer ${process.env.API_KEY}`
+  },
+  unauthorizedStatusCode: 401
+})
+```
+
+### Public Access
+
+```tsx
+const handler = createCacheStatsHandler(cache, {
+  allowPublicAccess: true
+})
+```
+
+### Response Format
+
+```json
+{
+  "metrics": {
+    "hits": 1234,
+    "misses": 56,
+    "fetches": 56,
+    "sets": 890,
+    "deletes": 12,
+    "backfills": 234,
+    "invalidations": 45,
+    "staleHits": 5,
+    "refreshes": 3,
+    "refreshErrors": 0,
+    "writeFailures": 0,
+    "singleFlightWaits": 7,
+    "negativeCacheHits": 12,
+    "circuitBreakerTrips": 0,
+    "degradedOperations": 0
+  },
+  "layers": [
+    {
+      "name": "memory",
+      "isLocal": true,
+      "degradedUntil": null
+    },
+    {
+      "name": "redis",
+      "isLocal": false,
+      "degradedUntil": null
+    }
+  ],
+  "backgroundRefreshes": 3
+}
+```

--- a/docs-web/content/docs/invalidation.mdx
+++ b/docs-web/content/docs/invalidation.mdx
@@ -1,0 +1,482 @@
+---
+title: "Cache Invalidation"
+description: "Strategies for invalidating cached data"
+---
+
+# Cache Invalidation
+
+Cache invalidation is one of the hardest problems in distributed systems. layercache provides multiple strategies to invalidate cached data efficiently.
+
+## Table of Contents
+
+- [Tag-Based Invalidation](#tag-based-invalidation)
+- [Batch Tag Invalidation](#batch-tag-invalidation)
+- [Pattern Invalidation](#pattern-invalidation)
+- [Prefix Invalidation](#prefix-invalidation)
+- [Generation-Based Versioning](#generation-based-versioning)
+- [Distributed Invalidation](#distributed-invalidation)
+
+---
+
+## Tag-Based Invalidation
+
+Tag keys when writing, then invalidate all keys with a given tag when data changes.
+
+### Basic Usage
+
+```ts
+import { CacheStack, MemoryLayer, RedisLayer } from 'layercache'
+
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 60 }),
+  new RedisLayer({ client: redis, ttl: 300 })
+])
+
+// Tag related data together
+await cache.set('user:123',         user,    { tags: ['user:123'] })
+await cache.set('user:123:posts',   posts,   { tags: ['user:123', 'posts'] })
+await cache.set('user:123:profile', profile, { tags: ['user:123'] })
+
+// Invalidate all data for user 123
+await cache.invalidateByTag('user:123')
+```
+
+### Multi-Tag Keys
+
+A single key can have multiple tags:
+
+```ts
+await cache.set('post:456', post, {
+  tags: ['post:456', 'author:123', 'category:tech']
+})
+
+// Invalidate by any tag
+await cache.invalidateByTag('author:123')  // Removes post:456
+await cache.invalidateByTag('category:tech')  // Removes post:456
+```
+
+### Hierarchical Tagging
+
+Use tag hierarchies for flexible invalidation:
+
+```ts
+// Product data with hierarchical tags
+await cache.set('product:123', product, {
+  tags: [
+    'product:123',           // Individual product
+    'category:electronics',  // Category
+    'brand:sony',            // Brand
+    'in-stock:true'          // Stock status
+  ]
+})
+
+// Invalidate all Sony products
+await cache.invalidateByTag('brand:sony')
+
+// Invalidate all electronics
+await cache.invalidateByTag('category:electronics')
+```
+
+---
+
+## Batch Tag Invalidation
+
+Invalidate keys matching multiple tags with `any` or `all` semantics.
+
+### Any Mode
+
+Delete keys tagged with **any** of the specified tags:
+
+```ts
+// Invalidate keys tagged with 'users' OR 'posts'
+await cache.invalidateByTags(['users', 'posts'], 'any')
+```
+
+Use case: Clear multiple related caches at once.
+
+```ts
+// Clear all user and post caches after database migration
+await cache.invalidateByTags(['users', 'posts', 'comments'], 'any')
+```
+
+### All Mode
+
+Delete keys tagged with **all** of the specified tags:
+
+```ts
+// Invalidate keys tagged with BOTH 'tenant:a' AND 'admin'
+await cache.invalidateByTags(['tenant:a', 'admin'], 'all')
+```
+
+Use case: Invalidate specific cross-cutting concerns.
+
+```ts
+// Invalidate all admin data for tenant A
+await cache.set('user:a:1', data, { tags: ['tenant:a', 'admin', 'user'] })
+await cache.set('user:a:2', data, { tags: ['tenant:a', 'admin', 'user'] })
+await cache.set('user:b:1', data, { tags: ['tenant:b', 'admin', 'user'] })
+
+await cache.invalidateByTags(['tenant:a', 'admin'], 'all')
+// Only user:a:1 and user:a:2 are deleted
+// user:b:1 remains (different tenant)
+```
+
+---
+
+## Pattern Invalidation
+
+Use glob-style patterns to match and delete keys.
+
+### Supported Patterns
+
+- `*` - Match any sequence of characters
+- `?` - Match exactly one character
+
+```ts
+// Delete all user keys
+await cache.invalidateByPattern('user:*')
+
+// Delete all keys matching a pattern
+await cache.invalidateByPattern('session:*')
+
+// Delete keys with specific format
+await cache.invalidateByPattern('report:2024-04-*')
+```
+
+### Pattern Validation
+
+Patterns must be:
+- Non-empty
+- At most 1024 characters
+- Free of control characters (except `*` and `?`)
+
+```ts
+// Valid patterns
+await cache.invalidateByPattern('user:*')
+await cache.invalidateByPattern('temp:?')
+await cache.invalidateByPattern('cache:v1:*.data')
+
+// Invalid patterns (throw)
+await cache.invalidateByPattern('')      // Empty
+await cache.invalidateByPattern('a\nb')  // Contains newline
+```
+
+### Performance Considerations
+
+Pattern invalidation requires scanning all known keys. For better performance:
+
+1. **Use prefix invalidation** when possible (faster)
+2. **Use tag-based invalidation** for complex queries (more flexible)
+3. **Avoid overly broad patterns** like `*` alone
+
+```ts
+// SLOWER: Scans all keys
+await cache.invalidateByPattern('*')
+
+// FASTER: Uses trie-based prefix search
+await cache.invalidateByPrefix('')
+
+// BEST: Uses tag index
+await cache.invalidateByTag('all')
+```
+
+---
+
+## Prefix Invalidation
+
+Hierarchical prefix-based invalidation using efficient trie structures. Prefer this over pattern invalidation for hierarchical keys.
+
+### Basic Usage
+
+```ts
+// Set up hierarchical keys
+await cache.set('user:123:profile', profileData)
+await cache.set('user:123:posts', postsData)
+await cache.set('user:123:settings', settingsData)
+await cache.set('user:456:profile', otherProfile)
+
+// Invalidate all data for user 123
+await cache.invalidateByPrefix('user:123:')
+// Deletes: user:123:profile, user:123:posts, user:123:settings
+// Keeps: user:456:profile
+```
+
+### Namespace Hierarchy
+
+Combine with namespaces for clean organization:
+
+```ts
+const tenantCache = cache.namespace('tenant:acme')
+
+await tenantCache.set('users:1', userData)
+await tenantCache.set('users:2', userData)
+await tenantCache.set('posts:1', postData)
+
+// Clear all tenant data
+await tenantCache.invalidateByPrefix('')
+```
+
+### Trie-Based Performance
+
+Prefix invalidation uses a trie data structure for O(k) lookup where k is prefix length:
+
+```ts
+// Fast: O(7) operations for 'user:123:'
+await cache.invalidateByPrefix('user:123:')
+
+// Slower: O(n) pattern matching for 'user:123:*'
+await cache.invalidateByPattern('user:123:*')
+```
+
+---
+
+## Generation-Based Versioning
+
+Add a generation prefix to every key and rotate it for instant bulk invalidation without scanning.
+
+### Basic Usage
+
+```ts
+// Create cache with generation
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 60 }),
+  new RedisLayer({ client: redis, ttl: 300 })
+], {
+  generation: 1  // Start at generation 1
+})
+
+// All keys are prefixed: "g1:user:123"
+await cache.set('user:123', userData)
+
+// Bump generation to invalidate everything
+cache.bumpGeneration()  // Now generation 2
+
+// Old keys are automatically ignored
+// New writes use "g2:user:123"
+await cache.set('user:123', newUserData)
+```
+
+### Auto-Cleanup Old Generations
+
+Automatically delete keys from previous generations:
+
+```ts
+const cache = new CacheStack([...], {
+  generation: 1,
+  generationCleanup: {
+    batchSize: 500  // Delete 500 keys per batch
+  }
+})
+
+cache.bumpGeneration()  // Cleans up g1 keys in batches
+```
+
+### Use Cases
+
+#### Deployment Invalidation
+
+```ts
+// Deploy with new generation
+const generation = process.env.DEPLOYMENT_ID ?? '1'
+
+const cache = new CacheStack([...], {
+  generation: Number.parseInt(generation)
+})
+
+// Every deployment starts with a fresh cache namespace
+```
+
+#### Feature Flag Rollout
+
+```ts
+// Rotate cache when enabling feature
+let cacheGeneration = 1
+
+async function enableNewFeature() {
+  cacheGeneration += 1
+  cache.bumpGeneration()
+
+  // All cached data is invalidated
+  // Next requests use fresh data with new feature enabled
+}
+```
+
+#### Schema Migration
+
+```ts
+// Bump generation after schema change
+async function migrateSchema() {
+  await db.migrate()
+
+  // Invalidate all cached data that uses old schema
+  cache.bumpGeneration()
+}
+```
+
+---
+
+## Distributed Invalidation
+
+For multi-instance deployments, use distributed invalidation to keep memory caches in sync across servers.
+
+### Redis Tag Index
+
+Share tag state across all servers using Redis:
+
+```ts
+import { RedisTagIndex } from 'layercache'
+
+const tagIndex = new RedisTagIndex({
+  client: redis,
+  prefix: 'myapp:tag-index',
+  scanCount: 100,
+  knownKeysShards: 8  // Distribute known keys across 8 shards
+})
+
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 60 }),
+  new RedisLayer({ client: redis, ttl: 300 })
+], {
+  tagIndex  // All servers share the same tag index
+})
+
+// Any server can invalidate by tag
+await cache.invalidateByTag('user:123')
+// All servers' memory layers are notified
+```
+
+### Redis Invalidation Bus
+
+Pub/sub-based L1 invalidation for real-time memory cache consistency:
+
+```ts
+import { RedisInvalidationBus } from 'layercache'
+
+const bus = new RedisInvalidationBus({
+  publisher: redis,           // Use existing Redis connection
+  subscriber: new Redis()     // Separate connection for subscriptions
+})
+
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 60 }),
+  new RedisLayer({ client: redis, ttl: 300 })
+], {
+  invalidationBus: bus,
+  broadcastL1Invalidation: true  // Publish writes to peer memory layers
+})
+
+// When Server A writes to cache:
+await cache.set('user:123', userData)
+// -> Publishes invalidation message to Redis
+
+// Server B's memory layer receives message:
+// -> Deletes 'user:123' from local memory
+// -> Next read fetches fresh data from Redis
+```
+
+### Full Distributed Setup
+
+Combine all distributed features for multi-instance consistency:
+
+```ts
+import {
+  CacheStack, MemoryLayer, RedisLayer,
+  RedisInvalidationBus, RedisTagIndex, RedisSingleFlightCoordinator
+} from 'layercache'
+
+const redis = new Redis()
+const bus = new RedisInvalidationBus({
+  publisher: redis,
+  subscriber: new Redis()
+})
+const tagIndex = new RedisTagIndex({
+  client: redis,
+  prefix: 'myapp:tags',
+  knownKeysShards: 8
+})
+const coordinator = new RedisSingleFlightCoordinator({
+  client: redis
+})
+
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 60, maxSize: 10_000 }),
+  new RedisLayer({ client: redis, ttl: 3600, prefix: 'myapp:cache:' })
+], {
+  invalidationBus: bus,
+  tagIndex: tagIndex,
+  singleFlightCoordinator: coordinator,
+  gracefulDegradation: { retryAfterMs: 10_000 }
+})
+```
+
+### Invalidation Flow
+
+```
+Server A                        Redis                          Server B
+  |                               |                               |
+  | cache.set('user:123', data)   |                               |
+  |------------------------------->|                               |
+  |                               | SET user:123                   |
+  |                               |                               |
+  |                               | PUBLISH invalidate user:123    |
+  |                               |------------------------------->|
+  |                               |                               | delete user:123
+  |                               |                               | (from memory)
+  |                               |                               |
+```
+
+---
+
+## Best Practices
+
+### 1. Use Tags for Related Data
+
+```ts
+// GOOD: Tag related data
+await cache.set('user:123', user, { tags: ['user:123'] })
+await cache.set('user:123:posts', posts, { tags: ['user:123'] })
+await cache.set('user:123:profile', profile, { tags: ['user:123'] })
+
+await cache.invalidateByTag('user:123')  // Invalidates all 3 keys
+```
+
+### 2. Use Prefixes for Hierarchical Data
+
+```ts
+// GOOD: Hierarchical keys with prefix invalidation
+await cache.set('tenant:acme:users:1', data)
+await cache.set('tenant:acme:posts:1', data)
+
+await cache.invalidateByPrefix('tenant:acme:')  // Fast trie lookup
+```
+
+### 3. Use Generations for Bulk Invalidation
+
+```ts
+// GOOD: Generation for instant bulk invalidation
+cache.bumpGeneration()  // Invalidates everything immediately
+```
+
+### 4. Avoid Overly Broad Patterns
+
+```ts
+// BAD: Too broad
+await cache.invalidateByPattern('*')
+
+// GOOD: Specific pattern
+await cache.invalidateByPattern('temp:*')
+
+// BETTER: Prefix
+await cache.invalidateByPrefix('temp:')
+```
+
+### 5. Clean Up Tags on Delete
+
+Tags are automatically removed when keys are deleted:
+
+```ts
+await cache.set('user:123', data, { tags: ['user:123'] })
+await cache.delete('user:123')  // Tags automatically cleaned up
+
+await cache.invalidateByTag('user:123')  // No keys found
+```

--- a/docs-web/content/docs/layers.mdx
+++ b/docs-web/content/docs/layers.mdx
@@ -1,0 +1,593 @@
+---
+title: "Cache Layers"
+description: "Deep dive into cache layer implementations and configuration"
+---
+
+# Cache Layers
+
+layercache provides several built-in cache layer implementations, each optimized for different use cases. You can also create custom layers by implementing the `CacheLayer` interface.
+
+## Table of Contents
+
+- [MemoryLayer](#memorylayer)
+- [RedisLayer](#redislayer)
+- [DiskLayer](#disklayer)
+- [MemcachedLayer](#memcachedlayer)
+- [Custom Layers](#custom-layers)
+
+---
+
+## MemoryLayer
+
+In-process cache with configurable eviction policies. Perfect for L1 caching with sub-microsecond latency.
+
+### Features
+
+- **Eviction policies**: LRU (default), LFU, or FIFO
+- **Max size enforcement**: Automatically evicts when limit reached
+- **TTL support**: Per-entry expiration with optional cleanup interval
+- **Snapshot support**: Export/import state for persistence
+- **Zero dependencies**: Pure in-memory storage
+
+### Configuration
+
+```ts
+import { MemoryLayer } from 'layercache'
+
+const memoryLayer = new MemoryLayer({
+  ttl: 60,                      // Default TTL in seconds
+  maxSize: 5_000,               // Maximum number of entries
+  name: 'memory',               // Layer name for metrics
+  evictionPolicy: 'lru',        // 'lru' | 'lfu' | 'fifo'
+  cleanupIntervalMs: 60_000,    // Expired entry cleanup interval
+  onEvict: (key, value) => {    // Optional eviction callback
+    console.log(`Evicted: ${key}`)
+  }
+})
+```
+
+### Eviction Policies
+
+#### LRU (Least Recently Used) - Default
+
+Evicts entries that haven't been accessed for the longest time. Best for general-purpose caching.
+
+```ts
+new MemoryLayer({
+  evictionPolicy: 'lru',
+  maxSize: 1_000
+})
+```
+
+#### LFU (Least Frequently Used)
+
+Evicts entries with the lowest access count. Best for workloads with hot spots.
+
+```ts
+new MemoryLayer({
+  evictionPolicy: 'lfu',
+  maxSize: 1_000
+})
+```
+
+#### FIFO (First In, First Out)
+
+Evicts the oldest entries regardless of access pattern. Best for time-series data.
+
+```ts
+new MemoryLayer({
+  evictionPolicy: 'fifo',
+  maxSize: 1_000
+})
+```
+
+### State Persistence
+
+```ts
+// Export current state
+const snapshot = memoryLayer.exportState()
+// [{ key: 'user:123', value: {...}, expiresAt: 1712847652000 }, ...]
+
+// Import state (e.g., after process restart)
+memoryLayer.importState(snapshot)
+```
+
+### Cleanup Interval
+
+MemoryLayer periodically scans for expired entries to free memory.
+
+```ts
+new MemoryLayer({
+  ttl: 300,
+  cleanupIntervalMs: 30_000  // Cleanup every 30 seconds
+})
+```
+
+Set to `0` or omit to disable periodic cleanup (entries still expire on access).
+
+---
+
+## RedisLayer
+
+Distributed caching layer backed by Redis with compression, serialization, and pipeline optimizations.
+
+### Features
+
+- **Shared state**: Multiple processes/servers share the same cache
+- **Compression**: gzip or brotli compression with configurable threshold
+- **Serializer chain**: Try multiple deserializers for smooth migrations
+- **Pipeline batch ops**: Fast multi-key reads/writes
+- **Scan-based operations**: Efficient keys/clear without blocking
+- **Prefix support**: Isolate different applications in the same Redis instance
+
+### Configuration
+
+```ts
+import { RedisLayer } from 'layercache'
+import Redis from 'ioredis'
+
+const redisLayer = new RedisLayer({
+  client: new Redis(),           // ioredis client instance
+  ttl: 300,                      // Default TTL in seconds
+  prefix: 'myapp:cache:',        // Key prefix for namespacing
+  compression: 'gzip',           // 'gzip' | 'brotli' | undefined
+  compressionThreshold: 1_024,   // Min bytes to compress (default: 1024)
+  decompressionMaxBytes: 64 * 1_024 * 1_024,  // Max decompressed size
+  serializer: new MsgpackSerializer(),  // Custom serializer
+  name: 'redis',                 // Layer name for metrics
+  allowUnprefixedClear: false,   // Require prefix for clear()
+  scanCount: 100,                // SCAN COUNT batch size
+  disconnectOnDispose: false     // Disconnect client on dispose
+})
+```
+
+### Compression
+
+Reduce Redis memory usage for large values:
+
+```ts
+// Gzip compression (faster, moderate compression)
+new RedisLayer({
+  client: redis,
+  compression: 'gzip',
+  compressionThreshold: 1_024  // Only compress >1KB values
+})
+
+// Brotli compression (slower, better compression)
+new RedisLayer({
+  client: redis,
+  compression: 'brotli',
+  compressionThreshold: 512
+})
+```
+
+### Serialization Chain
+
+Support smooth data format migrations by trying multiple deserializers:
+
+```ts
+import { JsonSerializer, MsgpackSerializer } from 'layercache'
+
+new RedisLayer({
+  client: redis,
+  serializer: [
+    new MsgpackSerializer(),  // Try MessagePack first
+    new JsonSerializer()      // Fall back to JSON
+  ]
+})
+
+// On write: always use first serializer (MessagePack)
+// On read: try each serializer until one succeeds
+// Successful reads auto-migrate to primary format
+```
+
+### Key Prefixing
+
+Isolate different applications or environments:
+
+```ts
+const productionCache = new RedisLayer({
+  client: redis,
+  prefix: 'prod:cache:'
+})
+
+const stagingCache = new RedisLayer({
+  client: redis,
+  prefix: 'staging:cache:'
+})
+```
+
+### Clear Behavior
+
+`clear()` requires a prefix by default to prevent accidental data loss:
+
+```ts
+const layer = new RedisLayer({
+  client: redis,
+  prefix: 'myapp:cache:',
+  allowUnprefixedClear: false  // Default
+})
+
+await layer.clear()  // OK - deletes "myapp:cache:*" only
+
+const unsafeLayer = new RedisLayer({
+  client: redis,
+  prefix: '',
+  allowUnprefixedClear: true  // Explicitly allow dangerous clear
+})
+
+await unsafeLayer.clear()  // DELETES EVERYTHING IN REDIS
+```
+
+### Pipeline Operations
+
+RedisLayer uses ioredis pipelines for efficient bulk operations:
+
+```ts
+// getMany() uses pipeline()
+const values = await redisLayer.getMany(['key1', 'key2', 'key3'])
+
+// setMany() uses pipeline()
+await redisLayer.setMany([
+  { key: 'key1', value: data1, ttl: 60 },
+  { key: 'key2', value: data2, ttl: 60 }
+])
+
+// deleteMany() uses pipeline()
+await redisLayer.deleteMany(['key1', 'key2', 'key3'])
+```
+
+---
+
+## DiskLayer
+
+Persistent file-based cache with atomic writes and LRU eviction. Perfect for caching across restarts without Redis.
+
+### Features
+
+- **Persistent storage**: Survives process restarts
+- **Atomic writes**: Uses temp file + rename for crash safety
+- **SHA-256 hashed filenames**: Safe for any cache key
+- **Max files enforcement**: LRU eviction when limit exceeded
+- **Size limits**: Configurable max entry size
+- **Concurrent operations**: Safe for multi-process access
+
+### Configuration
+
+```ts
+import { DiskLayer } from 'layercache'
+import { resolve } from 'node:path'
+
+const diskLayer = new DiskLayer({
+  directory: resolve('./var/cache/layercache'),  // Cache directory
+  ttl: 3600,                                     // Default TTL in seconds
+  name: 'disk',                                  // Layer name for metrics
+  maxFiles: 50_000,                              // Maximum cache files (default: 50,000)
+  maxEntryBytes: 16 * 1_024 * 1_024,             // Max 16MiB per entry
+  serializer: new JsonSerializer(),               // Optional custom serializer
+  encryptionKey: process.env.CACHE_ENCRYPTION_KEY, // Optional AES-256-GCM encryption
+  signingKey: process.env.CACHE_SIGNING_KEY        // Optional HMAC-SHA256 signing
+})
+```
+
+### At-Rest Protection
+
+DiskLayer supports optional at-rest protection for cached data using AES-256-GCM encryption or HMAC-SHA256 signing:
+
+```ts
+// Full encryption (recommended)
+new DiskLayer({
+  directory: './cache',
+  encryptionKey: process.env.CACHE_ENCRYPTION_KEY  // AES-256-GCM
+})
+
+// Signing only (integrity verification without encryption)
+new DiskLayer({
+  directory: './cache',
+  signingKey: process.env.CACHE_SIGNING_KEY  // HMAC-SHA256
+})
+
+// Both — signingKey is ignored when encryptionKey is provided
+// (encryption already provides authenticated integrity)
+new DiskLayer({
+  directory: './cache',
+  encryptionKey: process.env.CACHE_ENCRYPTION_KEY,
+  signingKey: process.env.CACHE_SIGNING_KEY
+})
+```
+
+### File Storage
+
+Each cache entry is stored as a separate file:
+
+```ts
+// Cache key -> SHA-256 hash
+'user:123:profile' -> 'a1b2c3d4...lf'
+
+// File contents (JSON)
+{
+  "key": "user:123:profile",
+  "value": { "name": "Alice", ... },
+  "expiresAt": 1712847652000
+}
+```
+
+### Atomic Writes
+
+DiskLayer uses temp file + rename for crash-safe writes:
+
+```ts
+// Write to temp file first
+await fs.writeFile('cache/a1b2...lf.tmp.12345.67890.tmp', data)
+
+// Atomic rename (fails if target exists)
+await fs.rename('cache/a1b2...lf.tmp.12345.67890.tmp', 'cache/a1b2...lf')
+```
+
+If the process crashes mid-write, the temp file is cleaned up on next access.
+
+### Max Files Enforcement
+
+When `maxFiles` is exceeded, oldest files (by mtime) are evicted:
+
+```ts
+new DiskLayer({
+  directory: './cache',
+  maxFiles: 10_000  // Keep only 10k most recent entries
+})
+```
+
+### Size Limits
+
+Prevent disk space exhaustion with entry size limits:
+
+```ts
+new DiskLayer({
+  directory: './cache',
+  maxEntryBytes: 16 * 1_024 * 1_024  // Reject entries >16MiB
+})
+
+// Disable size limit
+new DiskLayer({
+  directory: './cache',
+  maxEntryBytes: false
+})
+```
+
+Oversized entries are treated as corrupted and deleted.
+
+---
+
+## MemcachedLayer
+
+Memcached-backed cache layer with key validation and pluggable serializers.
+
+### Features
+
+- **Binary protocol**: Compatible with `memjs` and `memcache-client`
+- **Key validation**: Enforces 250-byte key limit
+- **Pluggable serializers**: JSON default, MessagePack supported
+- **Bulk operations**: getMany, deleteMany support
+
+### Configuration
+
+```ts
+import { MemcachedLayer } from 'layercache'
+import Memjs from 'memjs'
+
+const memcached = Memjs.Client.create('localhost:11211')
+
+const memcachedLayer = new MemcachedLayer({
+  client: memcached,          // Memcached client (memjs or memcache-client)
+  ttl: 300,                   // Default TTL in seconds
+  name: 'memcached',          // Layer name for metrics
+  keyPrefix: 'myapp:',        // Optional key prefix
+  serializer: new JsonSerializer()  // Optional custom serializer
+})
+```
+
+### Key Limit Validation
+
+Memcached enforces a 250-byte key limit. MemcachedLayer validates keys before sending:
+
+```ts
+// This throws: key exceeds 250 bytes
+await cache.set('a'.repeat(251), value)
+
+// This throws: key contains invalid characters
+await cache.set('key with spaces', value)
+```
+
+Use a short `keyPrefix` to reserve space for dynamic keys:
+
+```ts
+const layer = new MemcachedLayer({
+  client: memcached,
+  keyPrefix: 'app1:'  // Uses 5 bytes, leaves 245 for dynamic keys
+})
+```
+
+### Clear Not Supported
+
+Memcached doesn't support pattern-based deletion. Use key prefix rotation instead:
+
+```ts
+// DON'T do this - throws
+await memcachedLayer.clear()
+
+// DO this instead - rotate prefix
+const cache = new CacheStack([
+  new MemcachedLayer({ client: memcached, keyPrefix: 'v1:' })
+])
+
+// To invalidate all keys, deploy with new prefix
+const cache2 = new CacheStack([
+  new MemcachedLayer({ client: memcached, keyPrefix: 'v2:' })
+])
+```
+
+---
+
+## Custom Layers
+
+Implement the `CacheLayer` interface to create custom cache backends.
+
+### Interface
+
+```ts
+interface CacheLayer {
+  readonly name: string
+  readonly defaultTtl?: number
+  readonly isLocal?: boolean
+
+  // Required methods
+  get<T>(key: string): Promise<T | null>
+  set(key: string, value: unknown, ttl?: number): Promise<void>
+  delete(key: string): Promise<void>
+  clear(): Promise<void>
+
+  // Optional optimizations
+  getEntry?<T>(key: string): Promise<T | null>
+  getMany?<T>(keys: string[]): Promise<Array<T | null>>
+  setMany?(entries: Array<{ key: string; value: unknown; ttl?: number }>): Promise<void>
+  deleteMany?(keys: string[]): Promise<void>
+  keys?(): Promise<string[]>
+  forEachKey?(visitor: (key: string) => void | Promise<void>): Promise<void>
+  has?(key: string): Promise<boolean>
+  ttl?(key: string): Promise<number | null>
+  size?(): Promise<number>
+  ping?(): Promise<boolean>
+  dispose?(): Promise<void>
+}
+```
+
+### Example: Cloudflare KV Layer
+
+```ts
+interface KVLayerOptions {
+  namespace: KVNamespace
+  ttl?: number
+  name?: string
+}
+
+class KVLayer implements CacheLayer {
+  readonly name: string
+  readonly defaultTtl?: number
+  readonly isLocal = false
+
+  constructor(private options: KVLayerOptions) {
+    this.name = options.name ?? 'kv'
+    this.defaultTtl = options.ttl
+  }
+
+  async get<T>(key: string): Promise<T | null> {
+    const value = await this.options.namespace.get(key, 'json')
+    return value as T | null
+  }
+
+  async set(key: string, value: unknown, ttl?: number): Promise<void> {
+    await this.options.namespace.put(key, JSON.stringify(value), {
+      expirationTtl: ttl ?? this.defaultTtl
+    })
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.options.namespace.delete(key)
+  }
+
+  async clear(): Promise<void> {
+    // KV doesn't support clear - implement key listing if needed
+    throw new Error('KVLayer.clear() is not supported')
+  }
+
+  // Optional optimizations
+  async getMany<T>(keys: string[]): Promise<Array<T | null>> {
+    return Promise.all(keys.map(key => this.get<T>(key)))
+  }
+
+  async deleteMany(keys: string[]): Promise<void> {
+    await Promise.all(keys.map(key => this.delete(key)))
+  }
+}
+```
+
+### Example: S3 Layer
+
+```ts
+import { S3Client, GetObjectCommand, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3'
+
+class S3Layer implements CacheLayer {
+  readonly name = 's3'
+  readonly defaultTtl?: number
+  readonly isLocal = false
+
+  constructor(
+    private s3: S3Client,
+    private bucket: string,
+    private prefix: string
+  ) {}
+
+  async get<T>(key: string): Promise<T | null> {
+    try {
+      const response = await this.s3.send(new GetObjectCommand({
+        Bucket: this.bucket,
+        Key: `${this.prefix}${key}`
+      }))
+      const body = await response.Body.transformToString()
+      return JSON.parse(body) as T
+    } catch {
+      return null
+    }
+  }
+
+  async set(key: string, value: unknown, ttl?: number): Promise<void> {
+    await this.s3.send(new PutObjectCommand({
+      Bucket: this.bucket,
+      Key: `${this.prefix}${key}`,
+      Body: JSON.stringify(value),
+      Expires: ttl ? new Date(Date.now() + ttl * 1000) : undefined
+    }))
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.s3.send(new DeleteObjectCommand({
+      Bucket: this.bucket,
+      Key: `${this.prefix}${key}`
+    }))
+  }
+
+  async clear(): Promise<void> {
+    // S3 doesn't support clear - use lifecycle rules or prefix rotation
+    throw new Error('S3Layer.clear() is not supported')
+  }
+}
+```
+
+### Best Practices
+
+1. **Implement optional methods**: `getMany`, `setMany`, `deleteMany` provide significant performance improvements
+
+2. **Return correct TTL**: If your backend supports TTL, implement the `ttl()` method
+
+3. **Handle errors gracefully**: Return `null` on network errors instead of throwing
+
+4. **Use `getEntry` for metadata**: If your backend stores metadata (e.g., creation time), implement `getEntry` to support stale-while-revalidate
+
+5. **Set `isLocal` correctly**: This affects distributed invalidation behavior
+
+6. **Implement `dispose`**: Clean up resources (connections, timers) when the layer is no longer needed
+
+```ts
+class MyLayer implements CacheLayer {
+  readonly name = 'custom'
+  readonly defaultTtl = 300
+  readonly isLocal = true  // Set based on your backend
+
+  // Implement all required methods...
+
+  async dispose(): Promise<void> {
+    // Clean up connections, timers, etc.
+    await this.connection.close()
+  }
+}
+```

--- a/docs-web/content/docs/migration.mdx
+++ b/docs-web/content/docs/migration.mdx
@@ -1,0 +1,672 @@
+---
+title: "Migration Guide"
+description: "Migrate from node-cache-manager, keyv, cacheable, and other caching libraries"
+---
+
+This guide helps you migrate from popular Node.js caching libraries to Layercache. Each section includes before/after code examples, API mappings, and key differences.
+
+## From node-cache-manager
+
+### Basic Setup
+
+**Before (node-cache-manager):**
+
+```tsx
+import { caching, multiCaching } from 'cache-manager'
+import { redisStore } from 'cache-manager-redis-yet'
+
+const memoryCache = await caching('memory', { max: 100, ttl: 60 * 1000 })
+const redisCache = await caching(redisStore, {
+  url: 'redis://localhost:6379',
+  ttl: 300 * 1000
+})
+const cache = multiCaching([memoryCache, redisCache])
+```
+
+**After (layercache):**
+
+```tsx
+import { CacheStack, MemoryLayer, RedisLayer } from 'layercache'
+import Redis from 'ioredis'
+
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 60, maxSize: 100 }),
+  new RedisLayer({ client: new Redis(), ttl: 300 })
+])
+```
+
+### Read-Through Fetch
+
+**Before:**
+
+```tsx
+const user = await cache.wrap('user:123', () => db.findUser(123))
+```
+
+**After:**
+
+```tsx
+const user = await cache.get('user:123', () => db.findUser(123))
+```
+
+### Set with TTL
+
+**Before:**
+
+```tsx
+await cache.set('user:123', user, 60000)  // TTL in milliseconds
+```
+
+**After:**
+
+```tsx
+await cache.set('user:123', user, { ttl: 60 })  // TTL in seconds
+```
+
+### Delete
+
+**Before:**
+
+```tsx
+await cache.del('user:123')
+```
+
+**After:**
+
+```tsx
+await cache.delete('user:123')
+```
+
+### Clear All
+
+**Before:**
+
+```tsx
+await cache.reset()
+```
+
+**After:**
+
+```tsx
+await cache.clear()
+```
+
+### API Mapping
+
+| node-cache-manager | layercache | Notes |
+|--------------------|------------|-------|
+| `cache.wrap(key, fn)` | `cache.get(key, fn)` | Read-through fetch |
+| `cache.set(key, val, ttl)` | `cache.set(key, val, { ttl })` | TTL in seconds (not ms) |
+| `cache.get(key)` | `cache.get(key)` | Same API |
+| `cache.del(key)` | `cache.delete(key)` | Renamed |
+| `cache.reset()` | `cache.clear()` | Renamed |
+| Per-store TTL | `ttl: { memory: 60, redis: 300 }` | Per-layer TTL map |
+| - | `cache.invalidateByTag(tag)` | New: tag invalidation |
+| - | `cache.wrap(prefix, fn)` | New: transparent function caching |
+
+### Key Differences
+
+#### TTL is in Seconds
+
+**node-cache-manager uses milliseconds:**
+
+```tsx
+await cache.set('key', value, 60000)  // 60 seconds
+```
+
+**Layercache uses seconds:**
+
+```tsx
+await cache.set('key', value, { ttl: 60 })  // 60 seconds
+```
+
+#### Auto Backfill
+
+**node-cache-manager requires manual warming:**
+
+```tsx
+// After a cache miss in L1, L1 stays cold
+const value = await cache.wrap('key', fetcher)
+// Next request might still hit L2 instead of L1
+```
+
+**Layercache auto-backfills L1:**
+
+```tsx
+// After a cache miss in L1, L1 is automatically backfilled
+const value = await cache.get('key', fetcher)
+// Next request hits L1 immediately
+```
+
+#### Stampede Prevention
+
+**node-cache-manager requires plugins:**
+
+```tsx
+// No built-in stampede prevention
+// Need external solutions
+```
+
+**Layercache has built-in stampede prevention:**
+
+```tsx
+// Enabled by default
+// Multiple concurrent requests for same key share single fetcher
+```
+
+#### Tag Invalidation
+
+**node-cache-manager:**
+
+```tsx
+// Manual key tracking required
+const userKeys = [`user:${id}`, `user:${id}:posts`, `user:${id}:profile`]
+await Promise.all(userKeys.map(key => cache.del(key)))
+```
+
+**Layercache:**
+
+```tsx
+await cache.set('user:123', user, { tags: ['user:123'] })
+await cache.set('user:123:posts', posts, { tags: ['user:123'] })
+await cache.invalidateByTag('user:123')  // Deletes both
+```
+
+## From keyv
+
+### Basic Setup
+
+**Before (keyv):**
+
+```tsx
+import Keyv from 'keyv'
+import KeyvRedis from '@keyv/redis'
+
+const keyv = new Keyv({
+  store: new KeyvRedis('redis://localhost:6379')
+})
+
+await keyv.set('user:123', user, 60000)
+const user = await keyv.get('user:123')
+```
+
+**After (layercache):**
+
+```tsx
+import { CacheStack, MemoryLayer, RedisLayer } from 'layercache'
+
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 60 }),
+  new RedisLayer({ client: new Redis(), ttl: 300 })
+])
+
+await cache.set('user:123', user, { ttl: 60 })
+const user = await cache.get('user:123')
+```
+
+### Read-Through Fetch
+
+**Before:**
+
+```tsx
+// No built-in read-through
+let user = await keyv.get('user:123')
+if (!user) {
+  user = await fetchUser(123)
+  await keyv.set('user:123', user, 60000)
+}
+```
+
+**After:**
+
+```tsx
+// Built-in read-through fetch
+const user = await cache.get('user:123', () => fetchUser(123))
+```
+
+### API Mapping
+
+| keyv | layercache | Notes |
+|------|------------|-------|
+| `keyv.set(key, val, ttl)` | `cache.set(key, val, { ttl })` | TTL in seconds |
+| `keyv.get(key)` | `cache.get(key)` | Same |
+| `keyv.delete(key)` | `cache.delete(key)` | Same |
+| `keyv.clear()` | `cache.clear()` | Same |
+| Namespace via constructor | `cache.namespace(prefix)` | Scoped views |
+| - | `cache.get(key, fetcher)` | New: read-through fetch |
+| - | `cache.wrap(prefix, fn)` | New: function caching |
+
+### Key Differences
+
+#### Multi-Layer is Native
+
+**keyv requires plugins:**
+
+```tsx
+// Multi-layer is not native
+// Requires custom adapters
+```
+
+**Layercache has native multi-layer:**
+
+```tsx
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 60 }),
+  new RedisLayer({ client: redis, ttl: 300 })
+])
+// Reads cascade through layers with auto backfill
+```
+
+#### Read-Through Fetch
+
+**keyv requires manual checks:**
+
+```tsx
+let value = await keyv.get('key')
+if (value === undefined) {
+  value = await fetcher()
+  await keyv.set('key', value)
+}
+```
+
+**Layercache has built-in read-through:**
+
+```tsx
+const value = await cache.get('key', fetcher)
+```
+
+#### Namespaces
+
+**keyv:**
+
+```tsx
+const userCache = new Keyv({ namespace: 'users' })
+const postCache = new Keyv({ namespace: 'posts' })
+```
+
+**Layercache:**
+
+```tsx
+const userCache = cache.namespace('users')
+const postCache = cache.namespace('posts')
+
+// Full CacheStack API on namespaces
+await userCache.set('123', data)  // Stored as "users:123"
+await userCache.clear()           // Only deletes "users:*"
+```
+
+## From cacheable
+
+### Basic Setup
+
+**Before (cacheable):**
+
+```tsx
+import { Cacheable } from 'cacheable'
+
+const cache = new Cacheable({ ttl: '1h' })
+await cache.set('key', value)
+```
+
+**After (layercache):**
+
+```tsx
+import { CacheStack, MemoryLayer } from 'layercache'
+
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 3600 })
+])
+await cache.set('key', value)
+```
+
+### API Mapping
+
+| cacheable | layercache | Notes |
+|-----------|------------|-------|
+| `new Cacheable({ ttl: '1h' })` | `new CacheStack([{ ttl: 3600 }])` | TTL in seconds |
+| `cache.set(key, val)` | `cache.set(key, val)` | Same |
+| `cache.get(key)` | `cache.get(key)` | Same |
+| `cache.delete(key)` | `cache.delete(key)` | Same |
+| `cache.clear()` | `cache.clear()` | Same |
+
+### Key Differences
+
+#### TTL Format
+
+**cacheable uses string durations:**
+
+```tsx
+const cache = new Cacheable({ ttl: '1h' })
+```
+
+**Layercache uses numeric seconds:**
+
+```tsx
+const cache = new CacheStack([new MemoryLayer({ ttl: 3600 })])
+```
+
+#### Multi-Layer Orchestration
+
+**cacheable:**
+
+```tsx
+// Limited multi-layer support
+// Manual coordination required
+```
+
+**Layercache:**
+
+```tsx
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 60 }),
+  new RedisLayer({ client: redis, ttl: 300 }),
+  new DiskLayer({ ttl: 3600 })
+])
+// Automatic cascading reads and writes
+```
+
+#### Distributed Consistency
+
+**cacheable:**
+
+```tsx
+// No built-in distributed features
+// Manual implementation required
+```
+
+**Layercache:**
+
+```tsx
+import { RedisInvalidationBus, RedisTagIndex } from 'layercache'
+
+const bus = new RedisInvalidationBus({ publisher: redis })
+const tagIndex = new RedisTagIndex({ client: redis })
+
+const cache = new CacheStack([/* ... */], {
+  invalidationBus: bus,
+  broadcastL1Invalidation: true,
+  tagIndex
+})
+```
+
+#### Stampede Prevention
+
+**cacheable:**
+
+```tsx
+// No built-in stampede prevention
+```
+
+**Layercache:**
+
+```tsx
+const cache = new CacheStack([/* ... */], {
+  stampedePrevention: true  // Enabled by default
+})
+```
+
+## Operational Migration Tips
+
+### Replace Ad-Hoc Redis Key Scans
+
+**Before:**
+
+```bash
+# Manual Redis scans
+redis-cli --scan --pattern "user:*" | xargs redis-cli del
+```
+
+**After:**
+
+```bash
+# Use Layercache CLI
+npx layercache keys --redis redis://localhost:6379 --pattern "user:*"
+npx layercache invalidate --redis redis://localhost:6379 --pattern "user:*"
+```
+
+### Replace Manual Prefill Scripts
+
+**Before:**
+
+```tsx
+// Custom warm-up script
+for (const key of criticalKeys) {
+  const val = await fetch(key)
+  await redis.set(key, JSON.stringify(val), 'EX', 300)
+}
+```
+
+**After:**
+
+```tsx
+// Built-in warm() method
+await cache.warm(
+  criticalKeys.map(key => ({
+    key,
+    fetcher: () => fetchByKey(key),
+    priority: 10
+  })),
+  { concurrency: 4, continueOnError: true }
+)
+```
+
+### Replace Custom Stats Endpoints
+
+**Before:**
+
+```tsx
+// Custom stats endpoint
+app.get('/stats', (req, res) => {
+  res.json({
+    hits: myCounter.hits,
+    misses: myCounter.misses
+  })
+})
+```
+
+**After:**
+
+```tsx
+import { createCacheStatsHandler } from 'layercache'
+
+app.get('/cache/stats', createCacheStatsHandler(cache))
+```
+
+### Replace Manual Tag Tracking
+
+**Before:**
+
+```tsx
+// Manual tag-to-key mapping
+const tagMap = new Map()
+
+async function setWithTags(key, value, tags) {
+  await redis.set(key, JSON.stringify(value))
+  for (const tag of tags) {
+    const keys = tagMap.get(tag) || []
+    keys.push(key)
+    tagMap.set(tag, keys)
+  }
+}
+
+async function invalidateByTag(tag) {
+  const keys = tagMap.get(tag) || []
+  await Promise.all(keys.map(key => redis.del(key)))
+  tagMap.delete(tag)
+}
+```
+
+**After:**
+
+```tsx
+// Built-in tag support
+await cache.set('user:123', user, { tags: ['user:123'] })
+await cache.invalidateByTag('user:123')
+```
+
+### Replace Custom Invalidation Logic
+
+**Before:**
+
+```tsx
+// Manual prefix-based invalidation
+async function invalidatePrefix(prefix) {
+  const keys = await redis.keys(`${prefix}*`)
+  await Promise.all(keys.map(key => redis.del(key)))
+}
+```
+
+**After:**
+
+```tsx
+// Built-in prefix invalidation
+await cache.invalidateByPrefix('user:123:')
+```
+
+### Replace Custom Locking for Stampede Prevention
+
+**Before:**
+
+```tsx
+// Manual distributed locking
+async function getWithLock(key, fetcher) {
+  const lockKey = `lock:${key}`
+  const lock = await redis.set(lockKey, '1', 'PX', 5000, 'NX')
+
+  if (lock === 'OK') {
+    try {
+      const value = await fetcher()
+      await redis.set(key, JSON.stringify(value))
+      return value
+    } finally {
+      await redis.del(lockKey)
+    }
+  } else {
+    // Wait and retry
+    await sleep(100)
+    return getWithLock(key, fetcher)
+  }
+}
+```
+
+**After:**
+
+```tsx
+// Built-in distributed single-flight
+import { RedisSingleFlightCoordinator } from 'layercache'
+
+const coordinator = new RedisSingleFlightCoordinator({ client: redis })
+
+const cache = new CacheStack([/* ... */], {
+  singleFlightCoordinator: coordinator,
+  singleFlightLeaseMs: 30000
+})
+
+const value = await cache.get(key, fetcher)
+```
+
+## Migration Checklist
+
+### Phase 1: Setup
+
+- [ ] Install Layercache: `npm install layercache`
+- [ ] Create CacheStack with equivalent layers
+- [ ] Update TTL values from milliseconds to seconds
+- [ ] Configure distributed features (if needed)
+
+### Phase 2: Code Changes
+
+- [ ] Replace `cache.wrap()` with `cache.get(key, fetcher)`
+- [ ] Replace `cache.del()` with `cache.delete()`
+- [ ] Replace `cache.reset()` with `cache.clear()`
+- [ ] Update set operations to use options object: `{ ttl: 60 }`
+- [ ] Add tags for group invalidation
+
+### Phase 3: Testing
+
+- [ ] Verify cache hits/misses work correctly
+- [ ] Test tag-based invalidation
+- [ ] Test multi-layer cascading
+- [ ] Test distributed coordination (if applicable)
+- [ ] Monitor metrics and hit rates
+
+### Phase 4: Optimization
+
+- [ ] Enable stampede prevention (default)
+- [ ] Configure stale-while-revalidate
+- [ ] Set up Prometheus metrics
+- [ ] Configure health checks
+- [ ] Set up distributed single-flight (if needed)
+
+## Common Migration Issues
+
+### TTL Confusion
+
+**Issue:** Setting TTL in milliseconds instead of seconds.
+
+**Solution:**
+
+```tsx
+// Wrong
+await cache.set('key', value, { ttl: 60000 })  // 60,000 seconds = 16 hours
+
+// Correct
+await cache.set('key', value, { ttl: 60 })  // 60 seconds
+```
+
+### Missing Tags
+
+**Issue:** Unable to invalidate related keys.
+
+**Solution:**
+
+```tsx
+// Add tags when setting
+await cache.set('user:123', user, { tags: ['user:123'] })
+await cache.set('user:123:posts', posts, { tags: ['user:123'] })
+
+// Invalidate by tag
+await cache.invalidateByTag('user:123')
+```
+
+### Namespace Confusion
+
+**Issue:** Not using namespaces for scoped caches.
+
+**Solution:**
+
+```tsx
+// Use namespaces instead of separate caches
+const userCache = cache.namespace('users')
+const postCache = cache.namespace('posts')
+
+await userCache.set('123', data)  // Stored as "users:123"
+```
+
+### Not Using Read-Through
+
+**Issue:** Still using manual miss handling.
+
+**Solution:**
+
+```tsx
+// Old way
+let value = await cache.get('key')
+if (!value) {
+  value = await fetcher()
+  await cache.set('key', value)
+}
+
+// New way
+const value = await cache.get('key', fetcher)
+```
+
+## Need Help?
+
+If you run into issues during migration:
+
+1. Check the [API Reference](/docs/api) for detailed method documentation
+2. Review [examples](https://github.com/flyingsquirrel0419/layercache/tree/main/examples) for common patterns
+3. [Open an issue](https://github.com/flyingsquirrel0419/layercache/issues) with your current setup
+
+We're happy to help you find the right approach for your use case!

--- a/docs-web/content/docs/observability.mdx
+++ b/docs-web/content/docs/observability.mdx
@@ -1,0 +1,606 @@
+---
+title: "Observability and Monitoring"
+description: "Monitor cache performance, health, and metrics with built-in tools and integrations"
+---
+
+Layercache provides comprehensive observability features out of the box. Track cache performance, monitor layer health, and integrate with Prometheus and OpenTelemetry.
+
+## Metrics Overview
+
+Layercache automatically tracks detailed metrics for all cache operations:
+
+### Available Metrics
+
+- **hits** - Cache hits across all layers
+- **misses** - Cache misses (no layer had the key)
+- **fetches** - Fetcher function invocations (full misses)
+- **sets** - Write operations
+- **deletes** - Delete operations
+- **backfills** - L1/L2... automatic backfills from deeper layers
+- **invalidations** - Explicit invalidations (by tag, pattern, prefix)
+- **staleHits** - Stale-while-revalidate hits served
+- **refreshes** - Background refresh attempts
+- **refreshErrors** - Background refresh failures
+- **writeFailures** - Write operation failures
+- **singleFlightWaits** - Requests waiting for distributed lock
+- **negativeCacheHits** - Negative cache (null) results served
+- **circuitBreakerTrips** - Circuit breaker activations
+- **degradedOperations** - Operations run in degraded mode
+
+## Getting Metrics
+
+### getMetrics()
+
+Retrieve a snapshot of all metrics counters:
+
+```tsx
+import { CacheStack, MemoryLayer } from 'layercache'
+
+const cache = new CacheStack([new MemoryLayer({ ttl: 60 })])
+
+// ... use cache ...
+
+const metrics = cache.getMetrics()
+console.log(metrics)
+// {
+//   hits: 1234,
+//   misses: 56,
+//   fetches: 56,
+//   sets: 890,
+//   deletes: 12,
+//   backfills: 234,
+//   invalidations: 45,
+//   staleHits: 5,
+//   refreshes: 3,
+//   refreshErrors: 0,
+//   writeFailures: 0,
+//   singleFlightWaits: 7,
+//   negativeCacheHits: 12,
+//   circuitBreakerTrips: 0,
+//   degradedOperations: 0,
+//   hitsByLayer: { memory: 1000, redis: 234 },
+//   missesByLayer: { memory: 45, redis: 11 },
+//   latencyByLayer: {
+//     memory: { avgMs: 0.05, maxMs: 1.2, count: 1200 },
+//     redis: { avgMs: 2.3, maxMs: 15.6, count: 250 }
+//   },
+//   resetAt: 1712847654321
+// }
+```
+
+### getHitRate()
+
+Calculate cache hit rate overall and per-layer:
+
+```tsx
+const hitRate = cache.getHitRate()
+console.log(hitRate)
+// {
+//   overall: 0.956,  // 95.6% hit rate
+//   byLayer: {
+//     memory: 0.957,   // L1 hit rate
+//     redis: 0.955     // L2 hit rate
+//   }
+// }
+```
+
+### getStats()
+
+Get comprehensive stats including layer health:
+
+```tsx
+const stats = cache.getStats()
+console.log(stats)
+// {
+//   metrics: { ... },      // Same as getMetrics()
+//   layers: [
+//     {
+//       name: 'memory',
+//       isLocal: true,
+//       degradedUntil: null
+//     },
+//     {
+//       name: 'redis',
+//       isLocal: false,
+//       degradedUntil: 1712848000000  // Timestamp if degraded
+//     }
+//   ],
+//   backgroundRefreshes: 3
+// }
+```
+
+### resetMetrics()
+
+Reset all metric counters to zero:
+
+```tsx
+cache.resetMetrics()
+```
+
+## Health Checks
+
+Monitor the health of each cache layer with ping checks:
+
+### healthCheck()
+
+Check connectivity and latency for all layers:
+
+```tsx
+const health = await cache.healthCheck()
+console.log(health)
+// [
+//   {
+//     layer: 'memory',
+//     healthy: true,
+//     latencyMs: 0.03
+//   },
+//   {
+//     layer: 'redis',
+//     healthy: true,
+//     latencyMs: 2.45
+//   }
+// ]
+```
+
+### Usage in Health Endpoints
+
+```tsx
+import express from 'express'
+import { CacheStack, MemoryLayer, RedisLayer } from 'layercache'
+
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 20 }),
+  new RedisLayer({ client: redis, ttl: 300 })
+])
+
+const app = express()
+
+app.get('/health', async (req, res) => {
+  const health = await cache.healthCheck()
+  const allHealthy = health.every(h => h.healthy)
+
+  res.status(allHealthy ? 200 : 503).json({
+    status: allHealthy ? 'healthy' : 'degraded',
+    checks: health
+  })
+})
+```
+
+## Prometheus Integration
+
+Export metrics in Prometheus text format for scraping.
+
+### createPrometheusMetricsExporter()
+
+Create a Prometheus metrics exporter:
+
+```tsx
+import { createPrometheusMetricsExporter } from 'layercache'
+import http from 'node:http'
+
+const cache = new CacheStack([/* ... */])
+
+const collectMetrics = createPrometheusMetricsExporter(cache)
+
+const server = http.createServer(async (_req, res) => {
+  res.setHeader('content-type', 'text/plain; version=0.0.4; charset=utf-8')
+  res.end(collectMetrics())
+})
+
+server.listen(9091, () => {
+  console.log('Prometheus metrics exposed on :9091/metrics')
+})
+```
+
+### Multiple Cache Stacks
+
+```tsx
+const userCache = new CacheStack([/* ... */])
+const productCache = new CacheStack([/* ... */])
+
+const collectMetrics = createPrometheusMetricsExporter([
+  { stack: userCache, name: 'users' },
+  { stack: productCache, name: 'products' }
+])
+```
+
+### Example Output
+
+```
+# HELP layercache_hits_total Total number of cache hits
+# TYPE layercache_hits_total counter
+layercache_hits_total{cache="default"} 1234
+
+# HELP layercache_misses_total Total number of cache misses
+# TYPE layercache_misses_total counter
+layercache_misses_total{cache="default"} 56
+
+# HELP layercache_hit_rate Overall cache hit rate (0-1)
+# TYPE layercache_hit_rate gauge
+layercache_hit_rate{cache="default"} 0.956000
+
+# HELP layercache_hits_by_layer_total Hits broken down by layer
+# TYPE layercache_hits_by_layer_total counter
+layercache_hits_by_layer_total{cache="default",layer="memory"} 1000
+layercache_hits_by_layer_total{cache="default",layer="redis"} 234
+
+# HELP layercache_layer_latency_avg_ms Average read latency per layer in milliseconds
+# TYPE layercache_layer_latency_avg_ms gauge
+layercache_layer_latency_avg_ms{cache="default",layer="memory"} 0.0500
+layercache_layer_latency_avg_ms{cache="default",layer="redis"} 2.3000
+```
+
+## OpenTelemetry Integration
+
+Add distributed tracing to cache operations.
+
+### Setup
+
+```tsx
+import { trace } from '@opentelemetry/api'
+import { createOpenTelemetryPlugin } from 'layercache'
+
+const tracer = trace.getTracer('my-app', '1.0.0')
+const plugin = createOpenTelemetryPlugin(cache, tracer)
+```
+
+### Span Events
+
+The plugin emits two types of span events:
+
+#### operation-start
+
+```typescript
+{
+  id: number,
+  name: string,        // Operation name (e.g., "get", "set")
+  attributes: object   // Operation-specific attributes
+}
+```
+
+#### operation-end
+
+```typescript
+{
+  id: number,
+  success: boolean,
+  result?: string,     // Result type
+  error?: Error
+}
+```
+
+### Example Traced Operations
+
+```tsx
+// Each of these creates a span
+await cache.get('user:123', fetchUser)
+await cache.set('user:123', user, { ttl: 300 })
+await cache.invalidateByTag('user:123')
+```
+
+### Cleanup
+
+```tsx
+// Uninstall when shutting down
+plugin.uninstall()
+```
+
+## Event Hooks
+
+CacheStack extends EventEmitter and emits events for all operations.
+
+### Available Events
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `hit` | `{ key, layer }` | Cache hit in specific layer |
+| `miss` | `{ key }` | Full cache miss |
+| `set` | `{ key }` | Value written |
+| `delete` | `{ key }` | Key deleted |
+| `backfill` | `{ key, fromLayer, toLayer }` | Upper layer filled from lower |
+| `stale-serve` | `{ key, state, layer }` | Stale value served |
+| `stampede-dedupe` | `{ key }` | Request deduplicated |
+| `warm` | `{ key }` | Cache warmed |
+| `error` | `{ event, context }` | Operation error |
+
+### Subscribing to Events
+
+```tsx
+cache.on('hit', ({ key, layer }) => {
+  console.log(`Cache hit for ${key} in ${layer}`)
+  metrics.inc('cache.hit', { layer })
+})
+
+cache.on('miss', ({ key }) => {
+  console.log(`Cache miss for ${key}`)
+  metrics.inc('cache.miss')
+})
+
+cache.on('error', ({ event, context }) => {
+  console.error(`Cache error on ${event}:`, context)
+})
+```
+
+### Backfill Tracking
+
+```tsx
+cache.on('backfill', ({ key, fromLayer, toLayer }) => {
+  console.log(`Backfilled ${key} from ${fromLayer} to ${toLayer}`)
+})
+```
+
+### Error Handling
+
+```tsx
+cache.on('error', ({ event, context }) => {
+  if (event === 'set') {
+    logger.error('Failed to set cache value', context)
+  }
+})
+```
+
+## HTTP Stats Handler
+
+Expose cache statistics via a simple HTTP handler.
+
+### Basic Usage
+
+```tsx
+import { createCacheStatsHandler } from 'layercache'
+import http from 'node:http'
+
+const handler = createCacheStatsHandler(cache)
+
+const server = http.createServer(handler)
+server.listen(9090)
+```
+
+### With Express
+
+```tsx
+import express from 'express'
+import { createCacheStatsHandler } from 'layercache'
+
+const app = express()
+
+app.get('/cache/stats', createCacheStatsHandler(cache))
+```
+
+### With Authorization
+
+```tsx
+const handler = createCacheStatsHandler(cache, {
+  authorize: async (req) => {
+    const apiKey = req.headers['x-api-key']
+    return apiKey === process.env.STATS_API_KEY
+  },
+  unauthorizedStatusCode: 401
+})
+```
+
+### Response Format
+
+```json
+{
+  "metrics": {
+    "hits": 1234,
+    "misses": 56,
+    "fetches": 56,
+    "sets": 890,
+    "deletes": 12,
+    "backfills": 234,
+    "invalidations": 45,
+    "staleHits": 5,
+    "refreshes": 3,
+    "refreshErrors": 0,
+    "writeFailures": 0,
+    "singleFlightWaits": 7,
+    "negativeCacheHits": 12,
+    "circuitBreakerTrips": 0,
+    "degradedOperations": 0,
+    "hitsByLayer": {
+      "memory": 1000,
+      "redis": 234
+    },
+    "missesByLayer": {
+      "memory": 45,
+      "redis": 11
+    },
+    "latencyByLayer": {
+      "memory": {
+        "avgMs": 0.05,
+        "maxMs": 1.2,
+        "count": 1200
+      },
+      "redis": {
+        "avgMs": 2.3,
+        "maxMs": 15.6,
+        "count": 250
+      }
+    },
+    "resetAt": 1712847654321
+  },
+  "layers": [
+    {
+      "name": "memory",
+      "isLocal": true,
+      "degradedUntil": null
+    },
+    {
+      "name": "redis",
+      "isLocal": false,
+      "degradedUntil": null
+    }
+  ],
+  "backgroundRefreshes": 3
+}
+```
+
+## Admin CLI
+
+Inspect and manage caches from the command line.
+
+### Installation
+
+```bash
+npm install -g layercache
+```
+
+Or use via npx:
+
+```bash
+npx layercache stats --redis redis://localhost:6379
+```
+
+### Commands
+
+#### stats
+
+Show cache statistics:
+
+```bash
+layercache stats --redis redis://localhost:6379 --pattern "user:*"
+```
+
+Response:
+
+```json
+{
+  "totalKeys": 1234,
+  "pattern": "user:*"
+}
+```
+
+#### keys
+
+List cached keys:
+
+```bash
+layercache keys --redis redis://localhost:6379 --pattern "user:*"
+```
+
+Output:
+
+```
+user:1
+user:2
+user:3
+...
+```
+
+#### inspect
+
+Inspect a specific key:
+
+```bash
+layercache inspect --redis redis://localhost:6379 --key "user:123"
+```
+
+Response:
+
+```json
+{
+  "key": "user:123",
+  "exists": true,
+  "ttlSeconds": 245,
+  "sizeBytes": 1024,
+  "isEnvelope": true,
+  "state": "fresh",
+  "preview": {
+    "kind": "fresh",
+    "freshUntil": 1712848000000,
+    "staleUntil": 1712848300000,
+    "errorUntil": 1712848900000
+  }
+}
+```
+
+#### invalidate
+
+Invalidate cached data:
+
+```bash
+# By pattern
+layercache invalidate --redis redis://localhost:6379 --pattern "user:*"
+
+# By tag
+layercache invalidate --redis redis://localhost:6379 --tag "user:123"
+```
+
+### Options
+
+- `--redis <url>` - Redis connection URL (required)
+- `--pattern <glob>` - Glob pattern for filtering keys
+- `--key <key>` - Exact key for inspect command
+- `--tag <tag>` - Tag for invalidate command
+- `--tag-index-prefix <prefix>` - Redis key prefix for tag index
+
+## Monitoring Best Practices
+
+### 1. Track Hit Rate
+
+Monitor hit rate to ensure cache effectiveness:
+
+```tsx
+setInterval(() => {
+  const { overall, byLayer } = cache.getHitRate()
+  console.log(`Overall hit rate: ${(overall * 100).toFixed(2)}%`)
+  console.log(`Memory hit rate: ${(byLayer.memory * 100).toFixed(2)}%`)
+  console.log(`Redis hit rate: ${(byLayer.redis * 100).toFixed(2)}%`)
+}, 60000)
+```
+
+### 2. Alert on Degraded Layers
+
+```tsx
+cache.on('error', ({ event, context }) => {
+  if (context.layer === 'redis') {
+    alerting.send(`Redis layer degraded: ${context.error}`)
+  }
+})
+```
+
+### 3. Monitor Latency
+
+```tsx
+const metrics = cache.getMetrics()
+for (const [layer, latency] of Object.entries(metrics.latencyByLayer)) {
+  if (latency.maxMs > 100) {
+    console.warn(`High latency in ${layer}: ${latency.maxMs}ms`)
+  }
+}
+```
+
+### 4. Track Circuit Breaker
+
+```tsx
+cache.on('error', ({ event, context }) => {
+  if (context.operation === 'circuitBreakerTrip') {
+    alerting.send(`Circuit breaker tripped for ${context.key}`)
+  }
+})
+```
+
+### 5. Export to Prometheus
+
+```tsx
+// Expose metrics for Prometheus scraping
+const collectMetrics = createPrometheusMetricsExporter(cache)
+http.createServer(async (_req, res) => {
+  res.setHeader('content-type', 'text/plain; version=0.0.4')
+  res.end(collectMetrics())
+}).listen(9091)
+```
+
+### 6. Distributed Tracing
+
+```tsx
+// Add OpenTelemetry tracing
+const plugin = createOpenTelemetryPlugin(cache, tracer)
+
+// Clean up on shutdown
+process.on('SIGTERM', async () => {
+  plugin.uninstall()
+  await cache.disconnect()
+})
+```

--- a/docs-web/content/docs/resilience.mdx
+++ b/docs-web/content/docs/resilience.mdx
@@ -1,0 +1,647 @@
+---
+title: "Resilience Features"
+description: "Build fault-tolerant caches with graceful degradation and circuit breakers"
+---
+
+# Resilience Features
+
+Build fault-tolerant caches that handle failures gracefully without cascading errors to your application.
+
+## Table of Contents
+
+- [Graceful Degradation](#graceful-degradation)
+- [Circuit Breaker](#circuit-breaker)
+- [Write Policies](#write-policies)
+- [Write Strategies](#write-strategies)
+- [Fetcher Rate Limiting](#fetcher-rate-limiting)
+
+---
+
+## Graceful Degradation
+
+When a cache layer fails (e.g., Redis connection timeout), skip it temporarily instead of failing every request.
+
+### Configuration
+
+```ts
+import { CacheStack, MemoryLayer, RedisLayer } from 'layercache'
+
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 60 }),
+  new RedisLayer({ client: redis, ttl: 300 })
+], {
+  gracefulDegradation: {
+    retryAfterMs: 10_000  // Retry failed layer after 10 seconds
+  }
+})
+```
+
+### How It Works
+
+1. **First failure**: Layer operation fails (e.g., Redis timeout)
+2. **Mark degraded**: Layer is marked as degraded for `retryAfterMs`
+3. **Skip layer**: Subsequent operations skip the degraded layer
+4. **Retry after cooldown**: After `retryAfterMs`, operations retry the layer
+5. **Recover on success**: First successful operation clears degraded state
+
+### Example
+
+```ts
+// Redis is healthy
+const user1 = await cache.get('user:1')
+// -> Reads from memory (miss)
+// -> Reads from Redis (hit)
+// -> Backfills memory
+
+// Redis connection times out
+const user2 = await cache.get('user:2')
+// -> Reads from memory (miss)
+// -> Redis fails (timeout)
+// -> Falls back to fetcher
+// -> Marks Redis as degraded for 10 seconds
+
+// Within 10 second cooldown
+const user3 = await cache.get('user:3')
+// -> Reads from memory (miss)
+// -> Skips Redis (degraded)
+// -> Falls back to fetcher
+// -> Writes to memory only
+
+// After 10 seconds, Redis recovers
+const user4 = await cache.get('user:4')
+// -> Retries Redis
+// -> If successful: clears degraded state
+// -> If failed: restarts cooldown
+```
+
+### Per-Layer Degradation
+
+Each layer degrades independently:
+
+```ts
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 60 }),
+  new RedisLayer({ client: redis1, ttl: 300 }),  // L2
+  new DiskLayer({ directory: './cache', ttl: 3600 })  // L3
+], {
+  gracefulDegradation: { retryAfterMs: 10_000 }
+})
+
+// Redis fails but disk is healthy
+const data = await cache.get('key')
+// -> Memory: miss
+// -> Redis: degraded (skip)
+// -> Disk: hit
+// -> Backfills memory
+```
+
+### Monitoring Degradation
+
+```ts
+const stats = cache.getStats()
+
+for (const layer of stats.layers) {
+  console.log(`${layer.name}:`, {
+    healthy: !layer.degradedUntil,
+    degradedUntil: layer.degradedUntil
+      ? new Date(layer.degradedUntil).toISOString()
+      : 'N/A'
+  })
+}
+
+// Output:
+// memory: { healthy: true, degradedUntil: 'N/A' }
+// redis: { healthy: false, degradedUntil: '2024-04-11T12:34:56.789Z' }
+```
+
+### Health Checks
+
+Use `healthCheck()` to proactively detect layer issues:
+
+```ts
+const health = await cache.healthCheck()
+
+for (const result of health) {
+  if (!result.healthy) {
+    console.warn(`Layer ${result.layer} is unhealthy: ${result.error}`)
+  }
+}
+
+// Output:
+// [
+//   { layer: 'memory', healthy: true, latencyMs: 0.03 },
+//   { layer: 'redis',  healthy: false, latencyMs: 5000, error: 'Connection timeout' }
+// ]
+```
+
+---
+
+## Circuit Breaker
+
+Stop hammering broken upstream services after repeated failures. Prevents cascading failures and reduces load on struggling systems.
+
+### Configuration
+
+```ts
+const cache = new CacheStack([...], {
+  circuitBreaker: {
+    failureThreshold: 5,      // Trip after 5 consecutive failures
+    cooldownMs: 30_000        // Retry after 30 seconds
+  }
+})
+```
+
+### How It Works
+
+1. **Closed state**: Requests pass through normally
+2. **Failures increment**: Each failure increments a counter
+3. **Trip**: When failures reach `failureThreshold`, circuit trips
+4. **Open state**: Requests fail immediately without calling upstream
+5. **Cooldown**: After `cooldownMs`, enter half-open state
+6. **Half-open**: Allow one request to test recovery
+7. **Recover**: On success, close circuit (reset counter)
+8. **Fail again**: On failure, reopen circuit
+
+### Example
+
+```ts
+let dbFailures = 0
+const fetchUser = async (id: number) => {
+  dbFailures++
+  if (dbFailures <= 7) {
+    throw new Error('Database connection failed')
+  }
+  return { id, name: `User ${id}` }
+}
+
+const cache = new CacheStack([...], {
+  circuitBreaker: {
+    failureThreshold: 5,
+    cooldownMs: 30_000
+  }
+})
+
+// First 5 calls: fail, increment counter
+for (let i = 0; i < 5; i++) {
+  await cache.get(`user:${i}`, fetchUser)
+  // Circuit state: CLOSED -> still trying
+}
+
+// 6th call: trips circuit
+await cache.get('user:6', fetchUser)
+// Circuit state: OPEN -> fails immediately without calling fetcher
+
+// 7th call: circuit still open (within cooldown)
+await cache.get('user:7', fetchUser)
+// Circuit state: OPEN -> fails immediately
+
+// After 30 seconds: circuit enters half-open
+await cache.get('user:8', fetchUser)
+// Circuit state: HALF_OPEN -> tries one request
+// -> Fails (dbFailures = 7)
+// Circuit state: OPEN -> trips again
+
+// After another 30 seconds: circuit enters half-open
+await cache.get('user:9', fetchUser)
+// Circuit state: HALF_OPEN -> tries one request
+// -> Succeeds (dbFailures = 8, database recovered)
+// Circuit state: CLOSED -> circuit resets
+```
+
+### Per-Operation Circuit Breaker
+
+Configure circuit breaker for specific operations:
+
+```ts
+// Global circuit breaker
+const cache = new CacheStack([...], {
+  circuitBreaker: {
+    failureThreshold: 10,
+    cooldownMs: 60_000
+  }
+})
+
+// Override for fragile operation
+await cache.get('fragile-key', fetchFragileData, {
+  circuitBreaker: {
+    failureThreshold: 3,    // Trip after 3 failures
+    cooldownMs: 10_000      // Retry after 10 seconds
+  }
+})
+```
+
+### Circuit Breaker Events
+
+Monitor circuit breaker state changes:
+
+```ts
+cache.on('error', ({ event, context }) => {
+  if (event === 'circuit-breaker-trip') {
+    console.error(`Circuit tripped for key: ${context.key}`)
+  }
+  if (event === 'circuit-breaker-reset') {
+    console.log(`Circuit reset for key: ${context.key}`)
+  }
+})
+```
+
+### Metrics
+
+```ts
+const metrics = cache.getMetrics()
+console.log(`Circuit breaker trips: ${metrics.circuitBreakerTrips}`)
+```
+
+---
+
+## Write Policies
+
+Control how write failures are handled when some cache layers fail.
+
+### Strict Mode (Default)
+
+Fail if **any** layer fails to write:
+
+```ts
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 60 }),
+  new RedisLayer({ client: redis, ttl: 300 })
+], {
+  writePolicy: 'strict'  // Default
+})
+
+// Redis fails -> entire write fails
+try {
+  await cache.set('user:123', userData)
+} catch (err) {
+  console.error('Write failed: Redis unavailable')
+}
+```
+
+### Best-Effort Mode
+
+Succeed if **at least one** layer writes successfully:
+
+```ts
+const cache = new CacheStack([...], {
+  writePolicy: 'best-effort'
+})
+
+// Redis fails -> memory write succeeds
+await cache.set('user:123', userData)
+// No error thrown
+// Data is cached in memory only
+```
+
+### Use Cases
+
+#### Strict Mode
+
+Use when cache consistency is critical:
+
+```ts
+// Financial data: must be consistent across all layers
+const priceCache = new CacheStack([...], {
+  writePolicy: 'strict'
+})
+```
+
+#### Best-Effort Mode
+
+Use when cache availability is more important than consistency:
+
+```ts
+// Session data: better to cache in memory than not at all
+const sessionCache = new CacheStack([...], {
+  writePolicy: 'best-effort'
+})
+```
+
+### Per-Operation Override
+
+```ts
+// Global: best-effort
+const cache = new CacheStack([...], {
+  writePolicy: 'best-effort'
+})
+
+// Override: strict for critical data
+await cache.set('critical:config', config, {
+  writePolicy: 'strict'  // Override global setting
+})
+```
+
+---
+
+## Write Strategies
+
+Control how writes are executed: immediately (write-through) or batched (write-behind).
+
+### Write-Through (Default)
+
+Write to all layers immediately before returning:
+
+```ts
+const cache = new CacheStack([...], {
+  writeStrategy: 'write-through'  // Default
+})
+
+// Blocks until all layers confirm write
+await cache.set('user:123', userData)
+// -> Write to memory: 0.01ms
+// -> Write to Redis: 0.5ms
+// -> Total: ~0.51ms
+```
+
+### Write-Behind
+
+Queue writes and flush them in batches:
+
+```ts
+const cache = new CacheStack([...], {
+  writeStrategy: 'write-behind',
+  writeBehind: {
+    maxQueueSize: 1000,       // Max pending writes
+    flushIntervalMs: 100,     // Flush every 100ms
+    flushOnOverflow: true     // Flush when queue is full
+  }
+})
+
+// Returns immediately, writes are queued
+await cache.set('user:123', userData)
+// -> Returns in <0.01ms
+// -> Write queued in memory
+// -> Flushed to all layers within 100ms
+```
+
+### Write-Behind Configuration
+
+```ts
+const cache = new CacheStack([...], {
+  writeStrategy: 'write-behind',
+  writeBehind: {
+    maxQueueSize: 1000,       // Maximum queued writes
+    flushIntervalMs: 100,     // Auto-flush interval
+    flushOnOverflow: true,    // Flush when queue is full
+    maxFlushBatchSize: 100    // Max writes per flush
+  }
+})
+```
+
+### Use Cases
+
+#### Write-Through
+
+Use for data that must be persisted immediately:
+
+```ts
+// User payments: write to cache immediately
+const paymentCache = new CacheStack([...], {
+  writeStrategy: 'write-through'
+})
+```
+
+#### Write-Behind
+
+Use for high-volume writes where slight delay is acceptable:
+
+```ts
+// Analytics events: batch writes for performance
+const analyticsCache = new CacheStack([...], {
+  writeStrategy: 'write-behind',
+  writeBehind: {
+    maxQueueSize: 10_000,
+    flushIntervalMs: 1000
+  }
+})
+```
+
+### Manual Flush
+
+Manually trigger write-behind flush:
+
+```ts
+await cache.set('user:123', userData)
+await cache.set('user:456', userData)
+
+// Manually flush pending writes
+await cache.flushWriteBehindQueue()
+```
+
+---
+
+## Fetcher Rate Limiting
+
+Prevent thundering herd problems by limiting concurrent fetcher executions.
+
+### Configuration
+
+```ts
+const cache = new CacheStack([...], {
+  fetcherRateLimit: {
+    maxConcurrent: 10,    // Max 10 concurrent fetchers
+    intervalMs: 1000,     // Reset limit every second
+    scope: 'global'       // 'global' | 'key' | 'fetcher'
+  }
+})
+```
+
+### Scope Options
+
+#### Global Scope
+
+Limit total concurrent fetchers across all keys:
+
+```ts
+const cache = new CacheStack([...], {
+  fetcherRateLimit: {
+    maxConcurrent: 10,
+    scope: 'global'
+  }
+})
+
+// Only 10 fetchers running at once, regardless of key
+await Promise.all([
+  cache.get('key1', fetch1),
+  cache.get('key2', fetch2),
+  // ... 100 more requests
+])
+// -> 10 fetchers run immediately
+// -> 90 wait in queue
+```
+
+#### Key Scope
+
+Limit concurrent fetchers **per key**:
+
+```ts
+const cache = new CacheStack([...], {
+  fetcherRateLimit: {
+    maxConcurrent: 1,
+    scope: 'key'
+  }
+})
+
+// Only 1 fetcher per key
+await Promise.all([
+  cache.get('user:123', fetchUser123),  // Running
+  cache.get('user:123', fetchUser123),  // Queued
+  cache.get('user:456', fetchUser456)   // Running (different key)
+])
+```
+
+#### Fetcher Scope
+
+Limit concurrent fetchers **per unique fetcher function**:
+
+```ts
+const fetchUser = (id: number) => db.findUser(id)
+const fetchPost = (id: number) => db.findPost(id)
+
+const cache = new CacheStack([...], {
+  fetcherRateLimit: {
+    maxConcurrent: 5,
+    scope: 'fetcher'
+  }
+})
+
+// 5 fetchUser calls run concurrently
+// 5 fetchPost calls run concurrently
+await Promise.all([
+  cache.get('user:1', fetchUser),
+  cache.get('user:2', fetchUser),
+  // ... more fetchUser calls
+
+  cache.get('post:1', fetchPost),
+  cache.get('post:2', fetchPost),
+  // ... more fetchPost calls
+])
+```
+
+### Per-Operation Override
+
+```ts
+// Global: no rate limiting
+const cache = new CacheStack([...])
+
+// Override: rate limit specific operation
+await cache.get('expensive-key', fetchExpensiveData, {
+  fetcherRateLimit: {
+    maxConcurrent: 1,
+    scope: 'key'
+  }
+})
+```
+
+### Queue Behavior
+
+When rate limit is reached, requests queue and wait:
+
+```ts
+const cache = new CacheStack([...], {
+  fetcherRateLimit: {
+    maxConcurrent: 2,
+    scope: 'global'
+  }
+})
+
+// First 2 requests start immediately
+const p1 = cache.get('key1', fetch1)  // Running
+const p2 = cache.get('key2', fetch2)  // Running
+
+// Next request queues
+const p3 = cache.get('key3', fetch3)  // Queued
+
+// When p1 or p2 completes, p3 starts
+```
+
+### Combining with Stampede Prevention
+
+Fetcher rate limiting works with stampede prevention:
+
+```ts
+const cache = new CacheStack([...], {
+  stampedePrevention: true,  // Dedupe concurrent requests for same key
+  fetcherRateLimit: {
+    maxConcurrent: 10,
+    scope: 'key'
+  }
+})
+
+// 100 concurrent requests for 'user:123'
+await Promise.all(
+  Array.from({ length: 100 }, () =>
+    cache.get('user:123', () => db.findUser(123))
+  )
+)
+
+// Result:
+// -> 1 fetcher runs (stampede prevention)
+// -> Rate limit not reached (only 1 concurrent fetcher)
+```
+
+---
+
+## Best Practices
+
+### 1. Enable Graceful Degradation
+
+```ts
+// GOOD: Always enable graceful degradation
+const cache = new CacheStack([...], {
+  gracefulDegradation: { retryAfterMs: 10_000 }
+})
+```
+
+### 2. Use Circuit Breakers for Fragile Dependencies
+
+```ts
+// GOOD: Protect fragile upstreams
+const cache = new CacheStack([...], {
+  circuitBreaker: {
+    failureThreshold: 5,
+    cooldownMs: 30_000
+  }
+})
+
+await cache.get('fragile-api-key', fetchFromApi, {
+  circuitBreaker: {
+    failureThreshold: 3,
+    cooldownMs: 10_000
+  }
+})
+```
+
+### 3. Use Best-Effort for Non-Critical Data
+
+```ts
+// GOOD: Use best-effort for non-critical data
+const analyticsCache = new CacheStack([...], {
+  writePolicy: 'best-effort'
+})
+```
+
+### 4. Use Write-Behind for High-Volume Writes
+
+```ts
+// GOOD: Batch high-volume writes
+const eventCache = new CacheStack([...], {
+  writeStrategy: 'write-behind',
+  writeBehind: {
+    maxQueueSize: 10_000,
+    flushIntervalMs: 1000
+  }
+})
+```
+
+### 5. Rate Limit Expensive Operations
+
+```ts
+// GOOD: Rate limit expensive fetchers
+await cache.get('expensive-report', generateReport, {
+  fetcherRateLimit: {
+    maxConcurrent: 1,
+    scope: 'key'
+  }
+})
+```

--- a/docs-web/content/docs/serialization.mdx
+++ b/docs-web/content/docs/serialization.mdx
@@ -1,0 +1,663 @@
+---
+title: "Serialization & Compression"
+description: "Configure data serialization and compression for cache layers"
+---
+
+# Serialization & Compression
+
+Control how data is serialized and compressed in cache layers for optimal performance and storage efficiency.
+
+## Table of Contents
+
+- [JSON Serializer](#json-serializer)
+- [MessagePack Serializer](#messagepack-serializer)
+- [Custom Serializers](#custom-serializers)
+- [Prototype Pollution Protection](#prototype-pollution-protection)
+- [Compression](#compression)
+- [Serializer Chain](#serializer-chain)
+
+---
+
+## JSON Serializer
+
+Default serializer for all cache layers. Uses `JSON.stringify` and `JSON.parse` with prototype pollution protection.
+
+### Usage
+
+```ts
+import { JsonSerializer } from 'layercache'
+
+const serializer = new JsonSerializer()
+
+// Serialize
+const payload = serializer.serialize({ foo: 'bar' })
+// '{"foo":"bar"}'
+
+// Deserialize
+const data = serializer.deserialize('{"foo":"bar"}')
+// { foo: 'bar' }
+```
+
+### Built-In Usage
+
+JSON serialization is used by default:
+
+```ts
+import { MemoryLayer, RedisLayer, DiskLayer } from 'layercache'
+
+// All use JsonSerializer by default
+const memory = new MemoryLayer({ ttl: 60 })
+const redis = new RedisLayer({ client: redis, ttl: 300 })
+const disk = new DiskLayer({ directory: './cache' })
+
+// Explicitly specify JSON serializer
+const redisJson = new RedisLayer({
+  client: redis,
+  ttl: 300,
+  serializer: new JsonSerializer()
+})
+```
+
+### Handling Special Values
+
+```ts
+const serializer = new JsonSerializer()
+
+// Dates become ISO strings
+serializer.serialize({ date: new Date('2024-04-11') })
+// '{"date":"2024-04-11T00:00:00.000Z"}'
+
+// undefined becomes null (or omitted)
+serializer.serialize({ foo: undefined })
+// '{"foo":null}' or '{}'
+
+// Functions are removed
+serializer.serialize({ foo: () => {} })
+// '{}'
+```
+
+### Prototype Pollution Protection
+
+All deserialized data is sanitized to prevent prototype pollution attacks:
+
+```ts
+const serializer = new JsonSerializer()
+
+// Attempted prototype pollution is blocked
+const data = serializer.deserialize('{"__proto__":{"polluted":true}}')
+// -> Sanitized to: {}
+// -> Object.prototype.polluted remains undefined
+```
+
+---
+
+## MessagePack Serializer
+
+Binary serialization format that's more compact and faster than JSON.
+
+### Installation
+
+```bash
+npm install @msgpack/msgpack
+```
+
+### Usage
+
+```ts
+import { MsgpackSerializer } from 'layercache'
+
+const serializer = new MsgpackSerializer()
+
+// Serialize
+const payload = serializer.serialize({ foo: 'bar', num: 42 })
+// Buffer <81 a3 66 6f 6f a3 62 61 72 a3 6e 75 6d 2a>
+
+// Deserialize
+const data = serializer.deserialize(payload)
+// { foo: 'bar', num: 42 }
+```
+
+### Use with Cache Layers
+
+```ts
+import { RedisLayer, DiskLayer } from 'layercache'
+
+const redis = new RedisLayer({
+  client: redis,
+  ttl: 300,
+  serializer: new MsgpackSerializer()
+})
+
+const disk = new DiskLayer({
+  directory: './cache',
+  serializer: new MsgpackSerializer()
+})
+```
+
+### Benefits
+
+- **Smaller size**: ~30-50% smaller than JSON for typical data
+- **Faster**: Binary parsing is faster than JSON
+- **Type preservation**: Preserves binary data, dates, etc.
+
+### Comparison
+
+```ts
+import { JsonSerializer, MsgpackSerializer } from 'layercache'
+
+const data = {
+  id: 123,
+  name: 'Alice',
+  email: 'alice@example.com',
+  tags: ['user', 'active'],
+  created: new Date()
+}
+
+const jsonSerializer = new JsonSerializer()
+const msgpackSerializer = new MsgpackSerializer()
+
+const jsonPayload = jsonSerializer.serialize(data)
+// '{"id":123,"name":"Alice","email":"alice@example.com","tags":["user","active"],"created":"2024-04-11T00:00:00.000Z"}'
+// Length: ~140 bytes
+
+const msgpackPayload = msgpackSerializer.serialize(data)
+// Binary buffer
+// Length: ~95 bytes (32% smaller)
+
+console.log(`JSON size: ${jsonPayload.length} bytes`)
+console.log(`MessagePack size: ${msgpackPayload.length} bytes`)
+```
+
+---
+
+## Custom Serializers
+
+Implement the `CacheSerializer` interface to create custom serialization logic.
+
+### Interface
+
+```ts
+interface CacheSerializer {
+  serialize(value: unknown): string | Buffer
+  deserialize<T>(payload: string | Buffer): T
+}
+```
+
+### Example: CBOR Serializer
+
+```ts
+import { encode, decode } from 'cbor'
+
+class CborSerializer implements CacheSerializer {
+  serialize(value: unknown): Buffer {
+    return Buffer.from(encode(value))
+  }
+
+  deserialize<T>(payload: string | Buffer): T {
+    const buffer = Buffer.isBuffer(payload) ? payload : Buffer.from(payload, 'binary')
+    return decode(buffer) as T
+  }
+}
+
+// Usage
+const redis = new RedisLayer({
+  client: redis,
+  ttl: 300,
+  serializer: new CborSerializer()
+})
+```
+
+### Example: Base64 JSON Serializer
+
+```ts
+class Base64JsonSerializer implements CacheSerializer {
+  serialize(value: unknown): string {
+    const json = JSON.stringify(value)
+    return Buffer.from(json).toString('base64')
+  }
+
+  deserialize<T>(payload: string | Buffer): T {
+    const normalized = typeof payload === 'string' ? payload : payload.toString('binary')
+    const json = Buffer.from(normalized, 'base64').toString('utf8')
+    return JSON.parse(json) as T
+  }
+}
+
+// Usage
+const memcached = new MemcachedLayer({
+  client: memcached,
+  ttl: 300,
+  serializer: new Base64JsonSerializer()
+})
+```
+
+### Example: Compressing Serializer
+
+```ts
+import { gzip, ungzip } from 'node:zlib'
+import { promisify } from 'node:util'
+
+const gzipAsync = promisify(gzip)
+const ungzipAsync = promisify(ungzip)
+
+class GzipJsonSerializer implements CacheSerializer {
+  async serialize(value: unknown): Promise<Buffer> {
+    const json = JSON.stringify(value)
+    return await gzipAsync(Buffer.from(json))
+  }
+
+  async deserialize<T>(payload: string | Buffer): Promise<T> {
+    const buffer = Buffer.isBuffer(payload) ? payload : Buffer.from(payload)
+    const decompressed = await ungzipAsync(buffer)
+    return JSON.parse(decompressed.toString('utf8')) as T
+  }
+
+  // Note: This returns Promise<Buffer> but interface expects sync
+  // For async serialization, use a wrapper layer
+}
+```
+
+---
+
+## Prototype Pollution Protection
+
+All built-in serializers protect against prototype pollution attacks by sanitizing deserialized data.
+
+### What is Prototype Pollution?
+
+Prototype pollution is a vulnerability where attackers modify `Object.prototype` to affect all objects in the application:
+
+```json
+{
+  "__proto__": {
+    "admin": true
+  }
+}
+```
+
+Without protection, this could make every object have `admin: true`.
+
+### How layercache Protects
+
+layercache uses `StructuredDataSanitizer` to:
+
+1. **Block dangerous keys**: Removes `__proto__`, `constructor`, `prototype`
+2. **Limit depth**: Prevents deeply nested objects (default: 200 levels)
+3. **Limit nodes**: Prevents excessive object size (default: 10,000 nodes)
+
+### Configuration
+
+```ts
+import { JsonSerializer } from 'layercache'
+
+const serializer = new JsonSerializer()
+
+// Default limits
+const data = serializer.deserialize(payload)
+// -> maxDepth: 200
+// -> maxNodes: 10,000
+
+// Custom limits (not exposed in API, defaults are safe)
+// JsonSerializer uses built-in safe defaults
+```
+
+### Example: Blocked Attack
+
+```ts
+const serializer = new JsonSerializer()
+
+const maliciousPayload = JSON.stringify({
+  user: 'alice',
+  __proto__:: { admin: true }
+})
+
+const data = serializer.deserialize(maliciousPayload)
+// -> { user: 'alice' }
+// -> __proto__ is removed
+// -> Object.prototype.admin remains undefined
+
+console.log(({} as any).admin)  // undefined (safe!)
+```
+
+### MessagePack Protection
+
+MessagePack serializer also sanitizes data:
+
+```ts
+import { MsgpackSerializer } from 'layercache'
+
+const serializer = new MsgpackSerializer()
+
+// MessagePack payloads are sanitized on deserialize
+const data = serializer.deserialize(maliciousMsgpackBuffer)
+// -> Dangerous keys removed
+// -> Depth and size limits enforced
+```
+
+---
+
+## Compression
+
+Reduce memory usage and network bandwidth by compressing cached values. Supported in `RedisLayer`.
+
+### Gzip Compression
+
+```ts
+import { RedisLayer } from 'layercache'
+
+const redis = new RedisLayer({
+  client: redis,
+  ttl: 300,
+  compression: 'gzip',
+  compressionThreshold: 1_024  // Only compress values >1KB
+})
+
+// Large values are compressed automatically
+await cache.set('large-data', largeObject)
+// -> Serialized to JSON (or MessagePack)
+// -> Compressed with gzip if >1KB
+// -> Stored in Redis
+
+// Decompression is automatic on read
+const data = await cache.get('large-data')
+// -> Fetched from Redis
+// -> Decompressed
+// -> Deserialized
+```
+
+### Brotli Compression
+
+```ts
+const redis = new RedisLayer({
+  client: redis,
+  ttl: 300,
+  compression: 'brotli',
+  compressionThreshold: 512  // Compress values >512 bytes
+})
+```
+
+### Compression Threshold
+
+Skip compression for small values (overhead isn't worth it):
+
+```ts
+const redis = new RedisLayer({
+  client: redis,
+  ttl: 300,
+  compression: 'gzip',
+  compressionThreshold: 1_024  // 1KB threshold
+})
+
+// Small values: not compressed
+await cache.set('small', { id: 1 })
+// Serialized: ~15 bytes
+// Stored: ~15 bytes (not compressed)
+
+// Large values: compressed
+await cache.set('large', largeArray)
+// Serialized: ~10KB
+// Stored: ~3KB (compressed)
+```
+
+### Decompression Max Bytes
+
+Prevent decompression bomb attacks:
+
+```ts
+const redis = new RedisLayer({
+  client: redis,
+  ttl: 300,
+  compression: 'gzip',
+  compressionThreshold: 1_024,
+  decompressionMaxBytes: 64 * 1_024 * 1_024  // 64MiB limit
+})
+
+// If decompressed data exceeds 64MiB, read fails and key is deleted
+const data = await cache.get('malicious-key')
+// -> Throws error
+// -> Key is deleted from Redis
+```
+
+### Compression Format
+
+Compressed values use a custom header format:
+
+```
+LCZ1:<algorithm>:<compressed-data>
+
+Examples:
+LCZ1:gzip:<gzip-data>
+LCZ1:brotli:<brotli-data>
+```
+
+This header allows:
+- Format detection on read
+- Future algorithm support
+- Backward compatibility
+
+### Performance Considerations
+
+**Compression tradeoffs:**
+
+| Factor | Gzip | Brotli | No Compression |
+|---|---|---|---|
+| Compression speed | Fast | Slow | N/A |
+| Decompression speed | Fast | Medium | N/A |
+| Compression ratio | Medium | High | N/A |
+| CPU usage | Low | Medium | None |
+| Best for | General use | Storage-constrained | Small values |
+
+**Recommendations:**
+
+```ts
+// Use gzip for most cases (balanced)
+const redis = new RedisLayer({
+  client: redis,
+  compression: 'gzip',
+  compressionThreshold: 1_024
+})
+
+// Use brotli for storage-constrained environments
+const redis = new RedisLayer({
+  client: redis,
+  compression: 'brotli',
+  compressionThreshold: 512
+})
+
+// Disable compression for low-latency requirements
+const redis = new RedisLayer({
+  client: redis,
+  compression: undefined  // No compression
+})
+```
+
+---
+
+## Serializer Chain
+
+Try multiple deserializers in sequence for smooth data format migrations.
+
+### Configuration
+
+```ts
+import { RedisLayer, JsonSerializer, MsgpackSerializer } from 'layercache'
+
+const redis = new RedisLayer({
+  client: redis,
+  ttl: 300,
+  serializer: [
+    new MsgpackSerializer(),  // Try MessagePack first
+    new JsonSerializer()      // Fall back to JSON
+  ]
+})
+```
+
+### How It Works
+
+**On write:** Always use the first serializer
+
+```ts
+await cache.set('user:123', userData)
+// Serialized with MsgpackSerializer (first in array)
+```
+
+**On read:** Try each serializer until one succeeds
+
+```ts
+const data = await cache.get('user:123')
+// Try MsgpackSerializer.deserialize()
+// -> If success: return data
+// -> If error: try JsonSerializer.deserialize()
+// -> If success: return data, migrate to MessagePack
+// -> If error: delete key and return null
+```
+
+### Auto-Migration
+
+When a value is successfully deserialized with a non-primary serializer, it's automatically rewritten with the primary serializer:
+
+```ts
+// Old data in Redis: JSON format
+const oldData = '{"id":123,"name":"Alice"}'
+
+// Read with serializer chain
+const data = await cache.get('user:123')
+// -> Try MessagePack: fails
+// -> Try JSON: succeeds, returns { id: 123, name: 'Alice' }
+// -> Rewrites with MessagePack
+// -> Next read is faster (MessagePack is first)
+```
+
+### Migration Example
+
+```ts
+// Phase 1: Deploy with JSON only
+const redis = new RedisLayer({
+  client: redis,
+  serializer: new JsonSerializer()
+})
+
+// Phase 2: Deploy with MessagePack, keep JSON fallback
+const redis = new RedisLayer({
+  client: redis,
+  serializer: [
+    new MsgpackSerializer(),  // New format
+    new JsonSerializer()      // Old format
+  ]
+})
+
+// Phase 3: Data auto-migrates on access
+// -> Existing JSON keys work fine
+// -> On first read, rewritten as MessagePack
+// -> New keys written as MessagePack
+
+// Phase 4: Remove JSON fallback (after all data migrated)
+const redis = new RedisLayer({
+  client: redis,
+  serializer: new MsgpackSerializer()
+})
+```
+
+### Complex Chain
+
+```ts
+import {
+  MsgpackSerializer,
+  JsonSerializer,
+  CborSerializer
+} from 'layercache'
+
+const redis = new RedisLayer({
+  client: redis,
+  serializer: [
+    new MsgpackSerializer(),  // Current format
+    new CborSerializer(),     // Previous format
+    new JsonSerializer()      // Legacy format
+  ]
+})
+
+// Tries formats in order:
+// 1. MessagePack (current)
+// 2. CBOR (previous)
+// 3. JSON (legacy)
+// 4. Delete if all fail
+```
+
+---
+
+## Best Practices
+
+### 1. Use MessagePack for Large Data
+
+```ts
+// GOOD: MessagePack for large datasets
+const cache = new RedisLayer({
+  client: redis,
+  serializer: new MsgpackSerializer(),
+  compression: 'gzip',
+  compressionThreshold: 1_024
+})
+```
+
+### 2. Enable Compression for Redis
+
+```ts
+// GOOD: Reduce Redis memory usage
+const redis = new RedisLayer({
+  client: redis,
+  compression: 'gzip',
+  compressionThreshold: 1_024
+})
+```
+
+### 3. Use Serializer Chain for Migrations
+
+```ts
+// GOOD: Support multiple formats during migration
+const redis = new RedisLayer({
+  client: redis,
+  serializer: [
+    new MsgpackSerializer(),  // New
+    new JsonSerializer()      // Old
+  ]
+})
+```
+
+### 4. Set Compression Threshold Appropriately
+
+```ts
+// GOOD: Avoid compressing small values
+const redis = new RedisLayer({
+  client: redis,
+  compression: 'gzip',
+  compressionThreshold: 1_024  // Only compress >1KB
+})
+```
+
+### 5. Protect Against Decompression Bombs
+
+```ts
+// GOOD: Set decompression limit
+const redis = new RedisLayer({
+  client: redis,
+  compression: 'gzip',
+  decompressionMaxBytes: 64 * 1_024 * 1_024  // 64MiB
+})
+```
+
+### 6. Don't Compress Already-Compressed Data
+
+```ts
+// BAD: Compressing already compressed data
+const cache = new RedisLayer({
+  client: redis,
+  serializer: new MsgpackSerializer(),  // Binary
+  compression: 'gzip'                   // Compressing binary
+})
+
+// GOOD: Skip compression for binary data
+const cache = new RedisLayer({
+  client: redis,
+  serializer: new MsgpackSerializer()  // No compression needed
+})
+```

--- a/docs-web/content/docs/tutorial.mdx
+++ b/docs-web/content/docs/tutorial.mdx
@@ -1,0 +1,290 @@
+---
+title: "Tutorial"
+description: "A step-by-step guide to setting up and operating layercache in production"
+---
+
+# Tutorial: Getting Started with layercache
+
+A step-by-step guide to setting up and operating layercache in production.
+
+## Table of Contents
+
+1. [Create a Cache Stack](#1-create-a-cache-stack)
+2. [Basic Read-Through Caching](#2-basic-read-through-caching)
+3. [Warm Critical Keys at Startup](#3-warm-critical-keys-at-startup)
+4. [Wrap Service Methods](#4-wrap-service-methods)
+5. [Use Namespaces for Organization](#5-use-namespaces-for-organization)
+6. [Set Up Tag-Based Invalidation](#6-set-up-tag-based-invalidation)
+7. [Configure Stale Serving](#7-configure-stale-serving)
+8. [Add Resilience](#8-add-resilience)
+9. [Monitor with Stats & Metrics](#9-monitor-with-stats--metrics)
+10. [Snapshot Before Deploys](#10-snapshot-before-deploys)
+
+---
+
+## 1. Create a Cache Stack
+
+Start with a two-layer setup: fast in-memory L1 and shared Redis L2.
+
+```ts
+import { CacheStack, MemoryLayer, RedisLayer } from 'layercache'
+import Redis from 'ioredis'
+
+const cache = new CacheStack([
+  new MemoryLayer({ ttl: 60, maxSize: 5_000 }),
+  new RedisLayer({
+    client: new Redis(),
+    ttl: 300,
+    prefix: 'myapp:cache:',
+    compression: 'gzip'
+  })
+], {
+  gracefulDegradation: { retryAfterMs: 10_000 },
+  stampedePrevention: true  // on by default
+})
+```
+
+**Why this setup?**
+- Memory (L1) handles repeated reads with ~0.01ms latency
+- Redis (L2) provides shared state across instances with ~0.5ms latency
+- Compression reduces Redis memory usage for large values
+- Graceful degradation keeps the cache working even if Redis goes down
+
+---
+
+## 2. Basic Read-Through Caching
+
+The simplest pattern: fetch on miss, cache automatically.
+
+```ts
+// Fetcher runs once on miss, result fills all layers
+const user = await cache.get<User>('user:123', () => db.findUser(123))
+
+// Subsequent calls hit L1 (memory) - no DB or Redis call
+const sameUser = await cache.get<User>('user:123')
+```
+
+With options:
+
+```ts
+const user = await cache.get<User>('user:123', () => db.findUser(123), {
+  ttl: { memory: 30, redis: 600 },  // short L1, longer L2
+  tags: ['user', 'user:123'],       // for bulk invalidation later
+  ttlJitter: 5                      // prevent synchronized expiry
+})
+```
+
+---
+
+## 3. Warm Critical Keys at Startup
+
+Pre-populate the cache before traffic arrives:
+
+```ts
+await cache.warm(
+  [
+    { key: 'config:flags',    fetcher: () => fetchFlags(),    priority: 10 },
+    { key: 'catalog:top-100', fetcher: () => fetchCatalog(),  priority: 5 },
+    { key: 'pricing:matrix',  fetcher: () => fetchPricing(),  priority: 5 },
+  ],
+  { concurrency: 4, continueOnError: true }
+)
+```
+
+Higher `priority` values load first. `continueOnError` ensures one failed fetch doesn't block the rest.
+
+---
+
+## 4. Wrap Service Methods
+
+Turn any async function into a cached function with automatic key derivation:
+
+```ts
+const getUser = cache.wrap('user', (id: number) => db.findUser(id), {
+  ttl: 60,
+  tags: ['users']
+})
+
+// Calls are automatically cached with key "user:123"
+const user = await getUser(123)
+```
+
+With a custom key resolver:
+
+```ts
+const searchProducts = cache.wrap(
+  'search',
+  (query: string, page: number) => db.search(query, page),
+  { keyResolver: (query, page) => `${query}:p${page}`, ttl: 30 }
+)
+```
+
+---
+
+## 5. Use Namespaces for Organization
+
+Scope cache operations to avoid key collisions:
+
+```ts
+const users = cache.namespace('users')
+const posts = cache.namespace('posts')
+
+await users.set('123', userData)   // stored as "users:123"
+await posts.set('456', postData)   // stored as "posts:456"
+
+// Clear only user cache
+await users.clear()                // deletes "users:*" only
+
+// Nested namespaces for multi-tenancy
+const tenant = cache.namespace('tenant:acme')
+const tenantUsers = tenant.namespace('users')
+await tenantUsers.set('1', data)   // stored as "tenant:acme:users:1"
+```
+
+---
+
+## 6. Set Up Tag-Based Invalidation
+
+Tag keys when writing, invalidate groups when data changes:
+
+```ts
+// Tag related data together
+await cache.set('user:123',         user,    { tags: ['user:123'] })
+await cache.set('user:123:posts',   posts,   { tags: ['user:123', 'posts'] })
+await cache.set('user:123:profile', profile, { tags: ['user:123'] })
+
+// When user 123 updates their profile, invalidate everything related
+await cache.invalidateByTag('user:123')
+// All three keys are deleted across all layers
+
+// Batch invalidation
+await cache.invalidateByTags(['users', 'posts'], 'any')   // either tag
+await cache.invalidateByTags(['tenant:a', 'users'], 'all') // both tags
+```
+
+For multi-instance deployments, use `RedisTagIndex` so all servers share the same tag state:
+
+```ts
+import { RedisTagIndex } from 'layercache'
+
+const tagIndex = new RedisTagIndex({ client: redis, prefix: 'myapp:tags' })
+const cache = new CacheStack([...], { tagIndex })
+```
+
+---
+
+## 7. Configure Stale Serving
+
+Keep serving cached data even after expiry while refreshing in the background:
+
+```ts
+const config = await cache.get('app:config', fetchConfig, {
+  ttl: 60,
+  staleWhileRevalidate: 30,  // serve stale for 30s while refreshing
+  staleIfError: 300           // serve stale for 5min if refresh fails
+})
+```
+
+Combined with **refresh-ahead** to proactively refresh before expiry:
+
+```ts
+const leaderboard = await cache.get('leaderboard', fetchLeaderboard, {
+  ttl: 120,
+  refreshAhead: 30    // start refreshing when <= 30s remain
+})
+```
+
+---
+
+## 8. Add Resilience
+
+Protect your app from cascading failures:
+
+```ts
+const cache = new CacheStack([...], {
+  // Skip failed layers temporarily
+  gracefulDegradation: { retryAfterMs: 10_000 },
+
+  // Stop hammering broken upstreams
+  circuitBreaker: { failureThreshold: 5, cooldownMs: 30_000 },
+
+  // Rate limit fetcher calls
+  fetcherRateLimit: { maxConcurrent: 10 },
+
+  // Don't fail writes if one layer is down
+  writePolicy: 'best-effort'
+})
+```
+
+---
+
+## 9. Monitor with Stats & Metrics
+
+### Quick stats check
+
+```ts
+const stats = cache.getStats()
+console.log(stats.metrics)  // { hits, misses, fetches, staleHits, ... }
+console.log(stats.layers)   // [{ name, isLocal, degradedUntil }]
+```
+
+### HTTP stats endpoint
+
+```ts
+import { createCacheStatsHandler } from 'layercache'
+
+app.get('/cache/stats', createCacheStatsHandler(cache))
+```
+
+### Health checks
+
+```ts
+const health = await cache.healthCheck()
+// [{ layer: 'memory', healthy: true, latencyMs: 0.03 },
+//  { layer: 'redis',  healthy: true, latencyMs: 0.41 }]
+```
+
+### Event-based monitoring
+
+```ts
+cache.on('hit',   ({ key, layer }) => metrics.inc('cache.hit', { layer }))
+cache.on('miss',  ({ key })        => metrics.inc('cache.miss'))
+cache.on('error', ({ event, ctx }) => logger.error(event, ctx))
+```
+
+### Admin CLI
+
+```bash
+npx layercache stats --redis redis://localhost:6379
+npx layercache keys  --redis redis://localhost:6379 --pattern "user:*"
+```
+
+---
+
+## 10. Snapshot Before Deploys
+
+Save cache state before restarting:
+
+```ts
+// Before shutdown
+await cache.persistToFile('./cache-snapshot.json')
+
+// After restart
+await cache.restoreFromFile('./cache-snapshot.json')
+```
+
+Or transfer between instances in-memory:
+
+```ts
+const snapshot = await cache.exportState()
+await anotherCache.importState(snapshot)
+```
+
+---
+
+## Next Steps
+
+- [API Reference](/docs/api) - Full API documentation
+- [Migration Guide](/docs/migration-guide) - Switching from another library
+- [Comparison](/docs/comparison) - Feature comparison with alternatives
+- [Benchmarking](/docs/benchmarking) - Performance measurement guide

--- a/docs-web/lib/docs-config.ts
+++ b/docs-web/lib/docs-config.ts
@@ -1,0 +1,52 @@
+export type NavItem = {
+  title: string;
+  slug: string;
+  children?: NavItem[];
+};
+
+export const docsNav: NavItem[] = [
+  { title: "Overview", slug: "" },
+  { title: "Getting Started", slug: "getting-started" },
+  {
+    title: "Guides",
+    slug: "",
+    children: [
+      { title: "Tutorial", slug: "tutorial" },
+      { title: "Migration Guide", slug: "migration" },
+      { title: "CLI Tool", slug: "cli" },
+    ],
+  },
+  {
+    title: "API Reference",
+    slug: "",
+    children: [
+      { title: "CacheStack", slug: "api" },
+      { title: "Cache Layers", slug: "layers" },
+      { title: "Invalidation", slug: "invalidation" },
+      { title: "Resilience", slug: "resilience" },
+      { title: "Serialization", slug: "serialization" },
+    ],
+  },
+  {
+    title: "Integrations",
+    slug: "",
+    children: [
+      { title: "Frameworks", slug: "integrations" },
+      { title: "Observability", slug: "observability" },
+      { title: "Distributed", slug: "distributed" },
+    ],
+  },
+];
+
+export function getAllSlugs(): string[] {
+  const slugs: string[] = [];
+  for (const item of docsNav) {
+    if (item.slug) slugs.push(item.slug);
+    if (item.children) {
+      for (const child of item.children) {
+        if (child.slug) slugs.push(child.slug);
+      }
+    }
+  }
+  return slugs;
+}

--- a/docs-web/lib/docs/search-modal-state.mjs
+++ b/docs-web/lib/docs/search-modal-state.mjs
@@ -1,0 +1,25 @@
+/**
+ * @param {number} currentIndex
+ * @param {number} delta
+ * @param {number} resultCount
+ * @returns {number}
+ */
+export function getNextSelectedIndex(currentIndex, delta, resultCount) {
+  if (resultCount <= 0) {
+    return 0;
+  }
+
+  return Math.min(Math.max(currentIndex + delta, 0), resultCount - 1);
+}
+
+/**
+ * @param {{ isOpen: boolean; latestRequestId: number; requestId: number }} params
+ * @returns {boolean}
+ */
+export function shouldApplySearchResponse({
+  isOpen,
+  latestRequestId,
+  requestId,
+}) {
+  return isOpen && latestRequestId === requestId;
+}

--- a/docs-web/lib/docs/sidebar-state.mjs
+++ b/docs-web/lib/docs/sidebar-state.mjs
@@ -1,0 +1,19 @@
+/**
+ * @typedef {{ title: string; slug: string; children?: Array<{ title: string; slug: string }> }} NavItem
+ */
+
+/**
+ * @param {NavItem[]} navItems
+ * @param {string} currentSlug
+ * @returns {string[]}
+ */
+export function getOpenGroupsForSlug(navItems, currentSlug) {
+  if (!currentSlug) {
+    return [];
+  }
+
+  return navItems.flatMap((item) => {
+    const hasMatch = item.children?.some((child) => child.slug === currentSlug);
+    return hasMatch ? [item.title] : [];
+  });
+}

--- a/docs-web/lib/mdx.ts
+++ b/docs-web/lib/mdx.ts
@@ -1,0 +1,60 @@
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
+
+const contentDir = path.join(process.cwd(), "content/docs");
+
+export type DocMeta = {
+  title: string;
+  description: string;
+  slug: string;
+};
+
+export type DocData = {
+  meta: DocMeta;
+  content: string;
+  headings: { id: string; text: string; level: number }[];
+};
+
+export function getDocBySlug(slug: string): DocData {
+  const fileName = slug || "index";
+  const filePath = path.join(contentDir, `${fileName}.mdx`);
+  const source = fs.readFileSync(filePath, "utf-8");
+  const { data, content } = matter(source);
+  const headings = extractHeadings(content);
+
+  return {
+    meta: {
+      title: data.title || fileName,
+      description: data.description || "",
+      slug,
+    },
+    content,
+    headings,
+  };
+}
+
+export function getAllDocs(): DocMeta[] {
+  const files = fs.readdirSync(contentDir).filter((f) => f.endsWith(".mdx"));
+  return files.map((file) => {
+    const source = fs.readFileSync(path.join(contentDir, file), "utf-8");
+    const { data } = matter(source);
+    return {
+      title: data.title || file.replace(".mdx", ""),
+      description: data.description || "",
+      slug: file.replace(".mdx", ""),
+    };
+  });
+}
+
+function extractHeadings(content: string): { id: string; text: string; level: number }[] {
+  const headingRegex = /^(#{2,3})\s+(.+)$/gm;
+  const headings: { id: string; text: string; level: number }[] = [];
+  let match;
+  while ((match = headingRegex.exec(content)) !== null) {
+    const text = match[2].trim();
+    const id = text.toLowerCase().replace(/[^\w]+/g, "-");
+    headings.push({ id, text, level: match[1].length });
+  }
+  return headings;
+}

--- a/docs-web/lib/playground/mock-layers.ts
+++ b/docs-web/lib/playground/mock-layers.ts
@@ -1,0 +1,181 @@
+// Simple in-memory cache layer mock
+export class MockCacheLayer {
+  private store = new Map<string, { value: unknown; expiresAt: number }>();
+  readonly name: string;
+  readonly latencyMs: number;
+
+  constructor(name: string, latencyMs: number) {
+    this.name = name;
+    this.latencyMs = latencyMs;
+  }
+
+  async get(key: string): Promise<unknown> {
+    await this.simulateLatency();
+    const entry = this.store.get(key);
+    if (!entry) return undefined;
+    if (Date.now() > entry.expiresAt) {
+      this.store.delete(key);
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  async set(key: string, value: unknown, ttlSeconds: number): Promise<void> {
+    await this.simulateLatency();
+    this.store.set(key, { value, expiresAt: Date.now() + ttlSeconds * 1000 });
+  }
+
+  async delete(key: string): Promise<boolean> {
+    await this.simulateLatency();
+    return this.store.delete(key);
+  }
+
+  async clear(): Promise<void> {
+    await this.simulateLatency();
+    this.store.clear();
+  }
+
+  size(): number {
+    return this.store.size;
+  }
+
+  keys(): string[] {
+    return Array.from(this.store.keys());
+  }
+
+  private simulateLatency(): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, this.latencyMs));
+  }
+}
+
+// Mock CacheStack that simulates the real behavior
+export class MockCacheStack {
+  private layers: MockCacheLayer[];
+  private tags = new Map<string, Set<string>>(); // tag -> keys
+  private keyTags = new Map<string, Set<string>>(); // key -> tags
+  private stats = { hits: 0, misses: 0, sets: 0, deletes: 0, backfills: 0 };
+  private inFlight = new Map<string, Promise<unknown>>();
+  private onLog?: (message: string) => void;
+
+  constructor(layers: MockCacheLayer[], options?: { onLog?: (message: string) => void }) {
+    this.layers = layers;
+    this.onLog = options?.onLog;
+  }
+
+  async get<T>(key: string, fetcher?: () => Promise<T>, ttlSeconds = 60): Promise<T | undefined> {
+    // Try each layer
+    for (const layer of this.layers) {
+      const value = await layer.get(key);
+      if (value !== undefined) {
+        this.stats.hits++;
+        this.log(`[${layer.name}] HIT for key "${key}"`);
+        return value as T;
+      }
+    }
+
+    this.stats.misses++;
+    this.log(`[MISS] Key "${key}" not found in any layer`);
+
+    // Stampede prevention: reuse in-flight fetcher for same key
+    if (fetcher) {
+      const existing = this.inFlight.get(key);
+      if (existing) {
+        this.log(`[STAMPEDE-PREVENT] Deduplicating request for "${key}"`);
+        return existing as Promise<T>;
+      }
+
+      this.log(`[FETCH] Calling fetcher for "${key}"...`);
+      const fetchPromise = (async () => {
+        try {
+          const value = await fetcher();
+          if (value !== undefined) {
+            await this.set(key, value, ttlSeconds);
+            this.stats.backfills++;
+            this.log(`[BACKFILL] Stored "${key}" in all layers`);
+          }
+          return value;
+        } finally {
+          this.inFlight.delete(key);
+        }
+      })();
+
+      this.inFlight.set(key, fetchPromise);
+      return fetchPromise as Promise<T>;
+    }
+
+    return undefined;
+  }
+
+  async set<T>(key: string, value: T, ttlSeconds = 60): Promise<void> {
+    this.stats.sets++;
+    for (const layer of this.layers) {
+      await layer.set(key, value, ttlSeconds);
+    }
+    this.log(`[SET] Stored "${key}" in ${this.layers.length} layers`);
+  }
+
+  async delete(key: string): Promise<void> {
+    this.stats.deletes++;
+    for (const layer of this.layers) {
+      await layer.delete(key);
+    }
+    // Clean up tags
+    const keyTagSet = this.keyTags.get(key);
+    if (keyTagSet) {
+      for (const tag of keyTagSet) {
+        this.tags.get(tag)?.delete(key);
+      }
+      this.keyTags.delete(key);
+    }
+    this.log(`[DELETE] Removed "${key}" from all layers`);
+  }
+
+  async invalidateByTag(tag: string): Promise<number> {
+    const keys = this.tags.get(tag);
+    if (!keys || keys.size === 0) return 0;
+    const count = keys.size;
+    for (const key of keys) {
+      await this.delete(key);
+    }
+    this.log(`[INVALIDATE] Removed ${count} keys with tag "${tag}"`);
+    return count;
+  }
+
+  async tag(key: string, ...tags: string[]): Promise<void> {
+    if (!this.keyTags.has(key)) this.keyTags.set(key, new Set());
+    for (const tag of tags) {
+      if (!this.tags.has(tag)) this.tags.set(tag, new Set());
+      this.tags.get(tag)!.add(key);
+      this.keyTags.get(key)!.add(tag);
+    }
+    this.log(`[TAG] Tagged "${key}" with: ${tags.join(", ")}`);
+  }
+
+  async warm(entries: Array<{ key: string; value: unknown; ttlSeconds?: number }>): Promise<void> {
+    for (const entry of entries) {
+      await this.set(entry.key, entry.value, entry.ttlSeconds ?? 60);
+    }
+    this.log(`[WARM] Warmed ${entries.length} keys`);
+  }
+
+  getStats() {
+    return { ...this.stats, layerSizes: this.layers.map((l) => ({ name: l.name, size: l.size() })) };
+  }
+
+  getLayerInfo() {
+    return this.layers.map((l) => ({ name: l.name, latencyMs: l.latencyMs, size: l.size(), keys: l.keys() }));
+  }
+
+  private log(message: string) {
+    this.onLog?.(message);
+  }
+}
+
+// Factory function to create a typical setup
+export function createPlaygroundCache(onLog?: (message: string) => void) {
+  const memory = new MockCacheLayer("Memory", 1);
+  const redis = new MockCacheLayer("Redis", 5);
+  const disk = new MockCacheLayer("Disk", 20);
+  const cache = new MockCacheStack([memory, redis, disk], { onLog });
+  return { cache, layers: { memory, redis, disk } };
+}

--- a/docs-web/lib/playground/presets.ts
+++ b/docs-web/lib/playground/presets.ts
@@ -1,0 +1,231 @@
+export type Preset = {
+  id: string;
+  title: string;
+  description: string;
+  code: string;
+};
+
+export const presets: Preset[] = [
+  {
+    id: "basic",
+    title: "Basic Get/Set",
+    description: "Simple cache read-through pattern",
+    code: `// Basic get/set operations
+const { cache } = createPlaygroundCache();
+
+// Set a value
+await cache.set("user:1", { name: "Alice", role: "admin" });
+console.log("Set user:1");
+
+// Get it back
+const user = await cache.get("user:1");
+console.log("Got user:", JSON.stringify(user));
+
+// Check stats
+console.log("Stats:", JSON.stringify(cache.getStats()));`,
+  },
+  {
+    id: "multi-layer",
+    title: "Multi-Layer Stack",
+    description: "See how data flows across memory, Redis, and disk",
+    code: `// Multi-layer cache with backfill
+const { cache, layers } = createPlaygroundCache();
+
+// First request - cache miss, fetcher runs
+const data = await cache.get("api:products", async () => {
+  console.log("Fetcher called - fetching from database...");
+  return [{ id: 1, name: "Widget" }, { id: 2, name: "Gadget" }];
+}, 120);
+
+console.log("Result:", JSON.stringify(data));
+
+// Second request - cache hit
+const cached = await cache.get("api:products");
+console.log("Cached result:", JSON.stringify(cached));
+
+// Check each layer
+console.log("Layer info:", JSON.stringify(cache.getLayerInfo(), null, 2));`,
+  },
+  {
+    id: "swr",
+    title: "Stale-While-Revalidate",
+    description: "Serve stale data while refreshing in background",
+    code: `// Simulating stale-while-revalidate pattern
+const { cache } = createPlaygroundCache();
+let fetchCount = 0;
+
+// Initial fetch
+const data1 = await cache.get("dashboard:metrics", async () => {
+  fetchCount++;
+  console.log(\`Fetch #\${fetchCount}: Loading metrics...\`);
+  return { views: 1250, users: 89, revenue: 45000 };
+}, 10);
+console.log("First load:", JSON.stringify(data1));
+
+// Second request - should hit cache
+const data2 = await cache.get("dashboard:metrics", async () => {
+  fetchCount++;
+  console.log(\`Fetch #\${fetchCount}: Refreshing metrics...\`);
+  return { views: 1300, users: 92, revenue: 47000 };
+}, 10);
+console.log("Cache hit:", JSON.stringify(data2));
+
+console.log("Total fetcher calls:", fetchCount);
+console.log("Stats:", JSON.stringify(cache.getStats()));`,
+  },
+  {
+    id: "tag-invalidation",
+    title: "Tag Invalidation",
+    description: "Invalidate cache entries by tag",
+    code: `// Tag-based cache invalidation
+const { cache } = createPlaygroundCache();
+
+// Set values with tags
+await cache.set("product:1", { name: "Widget", price: 9.99 });
+await cache.tag("product:1", "products", "catalog");
+
+await cache.set("product:2", { name: "Gadget", price: 19.99 });
+await cache.tag("product:2", "products", "catalog");
+
+await cache.set("page:home", { title: "Home", layout: "full" });
+await cache.tag("page:home", "pages", "catalog");
+
+console.log("Before invalidation:");
+console.log("Stats:", JSON.stringify(cache.getStats()));
+
+// Invalidate all products
+const removed = await cache.invalidateByTag("products");
+console.log(\`\\nInvalidated \${removed} entries with tag "products"\`);
+
+console.log("\\nAfter invalidation:");
+console.log("Stats:", JSON.stringify(cache.getStats()));
+console.log("Layer info:", JSON.stringify(cache.getLayerInfo()));`,
+  },
+  {
+    id: "namespaces",
+    title: "Namespaces",
+    description: "Organize cache with key prefixes",
+    code: `// Namespace-like key organization
+const { cache } = createPlaygroundCache();
+
+// User namespace
+await cache.set("users:1", { name: "Alice" });
+await cache.set("users:2", { name: "Bob" });
+
+// Session namespace
+await cache.set("sessions:abc123", { userId: 1, expires: "2025-12-31" });
+await cache.set("sessions:def456", { userId: 2, expires: "2025-12-31" });
+
+// API namespace
+await cache.set("api:/products", { items: [1, 2, 3] });
+
+console.log("All cached:");
+cache.getLayerInfo()[0].keys.forEach(k => console.log(\`  \${k}\`));
+
+console.log("\\nStats:", JSON.stringify(cache.getStats()));`,
+  },
+  {
+    id: "stampede",
+    title: "Stampede Prevention",
+    description: "Concurrent request deduplication",
+    code: `// Simulating stampede prevention
+const { cache } = createPlaygroundCache();
+let fetchCount = 0;
+
+async function fetchData(key) {
+  return cache.get(key, async () => {
+    fetchCount++;
+    console.log(\`Fetcher #\${fetchCount} called for "\${key}"\`);
+    // Simulate slow fetch
+    await new Promise(r => setTimeout(r, 100));
+    return { data: \`Result for \${key}\`, fetchedAt: Date.now() };
+  }, 60);
+}
+
+// Fire 5 concurrent requests for the same key
+console.log("Firing 5 concurrent requests...");
+const results = await Promise.all([
+  fetchData("hot:key"),
+  fetchData("hot:key"),
+  fetchData("hot:key"),
+  fetchData("hot:key"),
+  fetchData("hot:key"),
+]);
+
+console.log("\\nAll results identical:", results.every(r => JSON.stringify(r) === JSON.stringify(results[0])));
+console.log("Fetcher called:", fetchCount, "time(s)");
+console.log("Stats:", JSON.stringify(cache.getStats()));`,
+  },
+  {
+    id: "circuit-breaker",
+    title: "Circuit Breaker",
+    description: "Failure threshold and recovery",
+    code: `// Simulating circuit breaker behavior
+const { cache } = createPlaygroundCache();
+let attempts = 0;
+let successes = 0;
+
+console.log("Simulating failing fetcher...\\n");
+
+// Attempt multiple fetches - simulate failures
+for (let i = 0; i < 5; i++) {
+  attempts++;
+  try {
+    const result = await cache.get(\`key:\${i}\`, async () => {
+      if (i < 3) {
+        console.log(\`  Attempt \${i + 1}: Fetcher FAILED\`);
+        throw new Error("Database connection failed");
+      }
+      console.log(\`  Attempt \${i + 1}: Fetcher succeeded\`);
+      return { value: \`data-\${i}\` };
+    }, 30);
+    successes++;
+  } catch (e) {
+    console.log(\`  -> Error caught (attempt \${i + 1})\`);
+  }
+}
+
+console.log(\`\\nResults: \${successes}/\${attempts} successful\`);
+console.log("Stats:", JSON.stringify(cache.getStats()));`,
+  },
+  {
+    id: "write-behind",
+    title: "Write-Behind",
+    description: "Deferred writes with batch flush",
+    code: `// Simulating write-behind pattern
+const { cache } = createPlaygroundCache();
+const writeQueue = [];
+
+// Fast local write
+async function setLocal(key, value) {
+  await cache.set(key, value);
+  writeQueue.push({ key, value });
+  console.log(\`Queued write for "\${key}" (queue: \${writeQueue.length})\`);
+}
+
+// Batch flush to "remote" layers
+async function flushWrites() {
+  if (writeQueue.length === 0) return;
+  console.log(\`\\nFlushing \${writeQueue.length} writes to remote...\`);
+  const batch = [...writeQueue];
+  writeQueue.length = 0;
+
+  for (const entry of batch) {
+    console.log(\`  Flushed: \${entry.key}\`);
+  }
+  console.log(\`Flushed \${batch.length} entries\`);
+}
+
+// Simulate rapid writes
+await setLocal("user:1", { name: "Alice" });
+await setLocal("user:2", { name: "Bob" });
+await setLocal("user:3", { name: "Charlie" });
+
+console.log("\\nCache stats before flush:");
+console.log(JSON.stringify(cache.getStats()));
+
+await flushWrites();
+
+console.log("\\nFinal stats:", JSON.stringify(cache.getStats()));`,
+  },
+];

--- a/docs-web/lib/playground/reporting-cache-state.mjs
+++ b/docs-web/lib/playground/reporting-cache-state.mjs
@@ -1,0 +1,13 @@
+export function createReportingCacheState(initialCache) {
+  let activeCache = initialCache;
+
+  return {
+    track(cache) {
+      activeCache = cache;
+      return cache;
+    },
+    getActiveCache() {
+      return activeCache;
+    },
+  };
+}

--- a/docs-web/lib/playground/run-timeout-controller.mjs
+++ b/docs-web/lib/playground/run-timeout-controller.mjs
@@ -1,0 +1,28 @@
+export const RUN_TIMEOUT_MS = 30000;
+
+export function clearRunTimeout(timeoutRef, clearTimer = clearTimeout) {
+  if (timeoutRef.current === null) {
+    return;
+  }
+
+  clearTimer(timeoutRef.current);
+  timeoutRef.current = null;
+}
+
+export function armRunTimeout({
+  timeoutRef,
+  onTimeout,
+  ms = RUN_TIMEOUT_MS,
+  setTimer = setTimeout,
+  clearTimer = clearTimeout,
+}) {
+  clearRunTimeout(timeoutRef, clearTimer);
+
+  const timerId = setTimer(() => {
+    timeoutRef.current = null;
+    onTimeout();
+  }, ms);
+
+  timeoutRef.current = timerId;
+  return timerId;
+}

--- a/docs-web/lib/playground/worker.ts
+++ b/docs-web/lib/playground/worker.ts
@@ -30,10 +30,15 @@ ctx.onmessage = async (event: MessageEvent) => {
       const { cache } = createPlaygroundCache((message: string) => {
         postLog("cache", message);
       });
+      let activeCache = cache;
 
       const sandbox = {
         cache,
-        createPlaygroundCache: () => createPlaygroundCache((msg: string) => postLog("cache", msg)),
+        createPlaygroundCache: () => {
+          const instance = createPlaygroundCache((msg: string) => postLog("cache", msg));
+          activeCache = instance.cache;
+          return instance;
+        },
         console,
         setTimeout,
         clearTimeout,
@@ -61,8 +66,8 @@ ctx.onmessage = async (event: MessageEvent) => {
 
       ctx.postMessage({
         type: "done",
-        layerInfo: cache.getLayerInfo(),
-        stats: cache.getStats(),
+        layerInfo: activeCache.getLayerInfo(),
+        stats: activeCache.getStats(),
       });
     } catch (error) {
       postLog("error", error instanceof Error ? error.message : String(error));

--- a/docs-web/lib/playground/worker.ts
+++ b/docs-web/lib/playground/worker.ts
@@ -1,0 +1,75 @@
+// Web Worker for playground execution
+import { createPlaygroundCache } from "./mock-layers";
+
+const ctx = self as unknown as Worker;
+
+ctx.onmessage = async (event: MessageEvent) => {
+  const { type, code } = event.data;
+
+  if (type === "run") {
+    const startTime = Date.now();
+
+    const postLog = (type: "log" | "error" | "cache", message: string) => {
+      const timestamp = Date.now();
+      ctx.postMessage({ type, message, timestamp });
+    };
+
+    // Capture console
+    const originalLog = console.log;
+    const originalError = console.error;
+    console.log = (...args: unknown[]) => {
+      const message = args.map((a) => (typeof a === "object" ? JSON.stringify(a) : String(a))).join(" ");
+      postLog("log", message);
+    };
+    console.error = (...args: unknown[]) => {
+      const message = args.map((a) => (typeof a === "object" ? JSON.stringify(a) : String(a))).join(" ");
+      postLog("error", message);
+    };
+
+    try {
+      const { cache } = createPlaygroundCache((message: string) => {
+        postLog("cache", message);
+      });
+
+      const sandbox = {
+        cache,
+        createPlaygroundCache: () => createPlaygroundCache((msg: string) => postLog("cache", msg)),
+        console,
+        setTimeout,
+        clearTimeout,
+        setInterval,
+        clearInterval,
+        Promise,
+        JSON,
+        Date,
+        Map,
+        Set,
+        Array,
+        Object,
+        Math,
+        Error,
+        TypeError,
+        RangeError,
+      };
+
+      const asyncFn = new Function(
+        ...Object.keys(sandbox),
+        `return (async () => {\n${code}\n})();`
+      );
+
+      await asyncFn(...Object.values(sandbox));
+
+      ctx.postMessage({
+        type: "done",
+        layerInfo: cache.getLayerInfo(),
+        stats: cache.getStats(),
+      });
+    } catch (error) {
+      postLog("error", error instanceof Error ? error.message : String(error));
+      ctx.postMessage({ type: "done", layerInfo: undefined, stats: undefined });
+    } finally {
+      console.log = originalLog;
+      console.error = originalError;
+    }
+  }
+};

--- a/docs-web/lib/search-index.ts
+++ b/docs-web/lib/search-index.ts
@@ -1,0 +1,77 @@
+import { Index } from "flexsearch";
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
+
+const contentDir = path.join(process.cwd(), "content/docs");
+
+export type SearchResult = {
+  title: string;
+  slug: string;
+  snippet: string;
+};
+
+let index: Index | null = null;
+let documents: Map<number, { title: string; slug: string; content: string }> = new Map();
+
+function buildIndex() {
+  if (index) return;
+
+  index = new Index({
+    preset: "match",
+    tokenize: "forward",
+    resolution: 9,
+  });
+
+  const files = fs.readdirSync(contentDir).filter((f) => f.endsWith(".mdx"));
+
+  files.forEach((file, i) => {
+    const source = fs.readFileSync(path.join(contentDir, file), "utf-8");
+    const { data, content } = matter(source);
+    let slug = file.replace(".mdx", "");
+
+    // Normalize "index" to empty string so routes resolve to /docs not /docs/index
+    if (slug === "index") slug = "";
+
+    documents.set(i, {
+      title: data.title || slug,
+      slug,
+      content,
+    });
+
+    if (index) {
+      index.add(i, `${data.title} ${data.description || ""} ${content}`);
+    }
+  });
+}
+
+export function search(query: string): SearchResult[] {
+  buildIndex();
+
+  if (!index || !query.trim()) return [];
+
+  const results = index.search(query, { limit: 10 }) as number[];
+
+  return results.map((id) => {
+    const doc = documents.get(id as number);
+    if (!doc) return null;
+
+    // Extract a snippet around the first match
+    const lowerContent = doc.content.toLowerCase();
+    const matchIndex = lowerContent.indexOf(query.toLowerCase());
+    let snippet = "";
+    if (matchIndex >= 0) {
+      const start = Math.max(0, matchIndex - 60);
+      const end = Math.min(doc.content.length, matchIndex + query.length + 60);
+      snippet = (start > 0 ? "..." : "") + doc.content.slice(start, end).replace(/\n/g, " ") + (end < doc.content.length ? "..." : "");
+    } else {
+      snippet = doc.content.slice(0, 120).replace(/\n/g, " ") + "...";
+    }
+
+    return {
+      title: doc.title,
+      slug: doc.slug,
+      snippet,
+    };
+  }).filter(Boolean) as SearchResult[];
+}

--- a/docs-web/next-env.d.ts
+++ b/docs-web/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/docs-web/next.config.ts
+++ b/docs-web/next.config.ts
@@ -1,0 +1,19 @@
+import type { NextConfig } from "next";
+import createMDX from "@next/mdx";
+
+const nextConfig: NextConfig = {
+  pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
+  experimental: {
+    mdxRs: true,
+  },
+};
+
+const withMDX = createMDX({
+  extension: /\.mdx?$/,
+  options: {
+    remarkPlugins: [],
+    rehypePlugins: [],
+  },
+});
+
+export default withMDX(nextConfig);

--- a/docs-web/package-lock.json
+++ b/docs-web/package-lock.json
@@ -1,0 +1,4184 @@
+{
+  "name": "site",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "site",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@mdx-js/loader": "^3.1.1",
+        "@mdx-js/react": "^3.1.1",
+        "@next/mdx": "^16.2.3",
+        "flexsearch": "^0.8.212",
+        "framer-motion": "^12.38.0",
+        "gray-matter": "^4.0.3",
+        "next": "^16.2.3",
+        "next-mdx-remote": "^6.0.0",
+        "next-themes": "^0.4.6",
+        "react": "^19.2.5",
+        "react-dom": "^19.2.5",
+        "rehype-highlight": "^7.0.2",
+        "rehype-slug": "^6.0.0",
+        "shiki": "^4.0.2"
+      },
+      "devDependencies": {
+        "@codemirror/lang-javascript": "^6.2.5",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.41.0",
+        "@tailwindcss/postcss": "^4.2.2",
+        "@types/node": "^25.6.0",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "postcss": "^8.5.9",
+        "tailwindcss": "^4.2.2",
+        "typescript": "^6.0.2"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
+      "integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
+      "integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
+      "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.41.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.0.tgz",
+      "integrity": "sha512-6H/qadXsVuDY219Yljhohglve8xf4B8xJkVOEWfA5uiYKiTFppjqsvsfR5iPA0RbvRBoOyTZpbLIxe9+0UR8xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
+      "integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@mdx-js/loader": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-3.1.1.tgz",
+      "integrity": "sha512-0TTacJyZ9mDmY+VefuthVshaNIyCGZHJG2fMnGaDttCt8HmjUF7SizlHJpaCDoGnN635nK1wpzfpx/Xx5S4WnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdx-js/mdx": "^3.0.0",
+        "source-map": "^0.7.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "webpack": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mdx-js/mdx": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-3.1.1.tgz",
+      "integrity": "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdx": "^2.0.0",
+        "acorn": "^8.0.0",
+        "collapse-white-space": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "estree-util-scope": "^1.0.0",
+        "estree-walker": "^3.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "markdown-extensions": "^2.0.0",
+        "recma-build-jsx": "^1.0.0",
+        "recma-jsx": "^1.0.0",
+        "recma-stringify": "^1.0.0",
+        "rehype-recma": "^1.0.0",
+        "remark-mdx": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "source-map": "^0.7.0",
+        "unified": "^11.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@mdx-js/react": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
+      "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdx": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16",
+        "react": ">=16"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.3.tgz",
+      "integrity": "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==",
+      "license": "MIT"
+    },
+    "node_modules/@next/mdx": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/mdx/-/mdx-16.2.3.tgz",
+      "integrity": "sha512-mm7XNfPagSIcN8jFtozB9toeh5ESES0KCLRoo0gu6xydijvnIrV7dRIK3akNL3Tecc8AHX1FNzYZOZTeFU6RCw==",
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "^0.7.0"
+      },
+      "peerDependencies": {
+        "@mdx-js/loader": ">=0.15.0",
+        "@mdx-js/react": ">=0.15.0"
+      },
+      "peerDependenciesMeta": {
+        "@mdx-js/loader": {
+          "optional": true
+        },
+        "@mdx-js/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.3.tgz",
+      "integrity": "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.3.tgz",
+      "integrity": "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.3.tgz",
+      "integrity": "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.3.tgz",
+      "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.3.tgz",
+      "integrity": "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.3.tgz",
+      "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.3.tgz",
+      "integrity": "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.3.tgz",
+      "integrity": "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@shikijs/core": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.2.tgz",
+      "integrity": "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.0.2.tgz",
+      "integrity": "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.0.2.tgz",
+      "integrity": "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.0.2.tgz",
+      "integrity": "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.0.2.tgz",
+      "integrity": "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.2.tgz",
+      "integrity": "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
+      "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
+      "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-x64": "4.2.2",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.2",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.2",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.2",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
+      "integrity": "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz",
+      "integrity": "sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
+      "integrity": "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
+      "integrity": "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
+      "integrity": "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
+      "integrity": "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
+      "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
+      "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
+      "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
+      "integrity": "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
+      "integrity": "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
+      "integrity": "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.2.tgz",
+      "integrity": "sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.2.2",
+        "@tailwindcss/oxide": "4.2.2",
+        "postcss": "^8.5.6",
+        "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdx": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.13.tgz",
+      "integrity": "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.17",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.17.tgz",
+      "integrity": "sha512-HdrkN8eVG2CXxeifv/VdJ4A4RSra1DTW8dc/hdxzhGHN8QePs6gKaWM9pHPcpCoxYZJuOZ8drHmbdpLHjCYjLA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001787",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
+      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/collapse-white-space": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
+      "integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/esast-util-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/esast-util-from-estree/-/esast-util-from-estree-2.0.0.tgz",
+      "integrity": "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/esast-util-from-js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esast-util-from-js/-/esast-util-from-js-2.0.1.tgz",
+      "integrity": "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "acorn": "^8.0.0",
+        "esast-util-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estree-util-attach-comments": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-3.0.0.tgz",
+      "integrity": "sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-build-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/estree-util-build-jsx/-/estree-util-build-jsx-3.0.1.tgz",
+      "integrity": "sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "estree-walker": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-scope": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-scope/-/estree-util-scope-1.0.0.tgz",
+      "integrity": "sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-to-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-to-js/-/estree-util-to-js-2.0.0.tgz",
+      "integrity": "sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "astring": "^1.8.0",
+        "source-map": "^0.7.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-visit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
+      "integrity": "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/flexsearch": {
+      "version": "0.8.212",
+      "resolved": "https://registry.npmjs.org/flexsearch/-/flexsearch-0.8.212.tgz",
+      "integrity": "sha512-wSyJr1GUWoOOIISRu+X2IXiOcVfg9qqBRyCPRUdLMIGJqPzMo+jMRlvE83t14v1j0dRMEaBbER/adQjp6Du2pw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/ts-thomas"
+        },
+        {
+          "type": "paypal",
+          "url": "https://www.paypal.com/donate/?hosted_button_id=GEVR88FC9BWRW"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/flexsearch"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/user?u=96245532"
+        },
+        {
+          "type": "liberapay",
+          "url": "https://liberapay.com/ts-thomas"
+        }
+      ],
+      "license": "Apache-2.0"
+    },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "license": "ISC"
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/hast-util-heading-rank": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
+      "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-estree": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz",
+      "integrity": "sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-attach-comments": "^3.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/lowlight": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
+      "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.0.0",
+        "highlight.js": "~11.11.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/markdown-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-2.0.0.tgz",
+      "integrity": "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
+      "integrity": "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-mdx-expression": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.1.tgz",
+      "integrity": "sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-mdx-jsx": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.2.tgz",
+      "integrity": "sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdx-md": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz",
+      "integrity": "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz",
+      "integrity": "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.0.0",
+        "acorn-jsx": "^5.0.0",
+        "micromark-extension-mdx-expression": "^3.0.0",
+        "micromark-extension-mdx-jsx": "^3.0.0",
+        "micromark-extension-mdx-md": "^2.0.0",
+        "micromark-extension-mdxjs-esm": "^3.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs-esm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz",
+      "integrity": "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-mdx-expression": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.3.tgz",
+      "integrity": "sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-events-to-acorn": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.3.tgz",
+      "integrity": "sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      }
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.3.tgz",
+      "integrity": "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "16.2.3",
+        "@swc/helpers": "0.5.15",
+        "baseline-browser-mapping": "^2.9.19",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "16.2.3",
+        "@next/swc-darwin-x64": "16.2.3",
+        "@next/swc-linux-arm64-gnu": "16.2.3",
+        "@next/swc-linux-arm64-musl": "16.2.3",
+        "@next/swc-linux-x64-gnu": "16.2.3",
+        "@next/swc-linux-x64-musl": "16.2.3",
+        "@next/swc-win32-arm64-msvc": "16.2.3",
+        "@next/swc-win32-x64-msvc": "16.2.3",
+        "sharp": "^0.34.5"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-mdx-remote": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/next-mdx-remote/-/next-mdx-remote-6.0.0.tgz",
+      "integrity": "sha512-cJEpEZlgD6xGjB4jL8BnI8FaYdN9BzZM4NwadPe1YQr7pqoWjg9EBCMv3nXBkuHqMRfv2y33SzUsuyNh9LFAQQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@babel/code-frame": "^7.23.5",
+        "@mdx-js/mdx": "^3.0.1",
+        "@mdx-js/react": "^3.0.1",
+        "unist-util-remove": "^4.0.0",
+        "unist-util-visit": "^5.1.0",
+        "vfile": "^6.0.1",
+        "vfile-matter": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=7"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/next/node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
+      "integrity": "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.5.tgz",
+      "integrity": "sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.1",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.5"
+      }
+    },
+    "node_modules/recma-build-jsx": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
+      "integrity": "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-util-build-jsx": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/recma-jsx": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/recma-jsx/-/recma-jsx-1.0.1.tgz",
+      "integrity": "sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn-jsx": "^5.0.0",
+        "estree-util-to-js": "^2.0.0",
+        "recma-parse": "^1.0.0",
+        "recma-stringify": "^1.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/recma-parse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-parse/-/recma-parse-1.0.0.tgz",
+      "integrity": "sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "esast-util-from-js": "^2.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/recma-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-stringify/-/recma-stringify-1.0.0.tgz",
+      "integrity": "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-util-to-js": "^2.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
+    },
+    "node_modules/rehype-highlight": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-highlight/-/rehype-highlight-7.0.2.tgz",
+      "integrity": "sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "lowlight": "^3.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-recma": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-recma/-/rehype-recma-1.0.0.tgz",
+      "integrity": "sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "hast-util-to-estree": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-slug": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
+      "integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "github-slugger": "^2.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-mdx": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.1.tgz",
+      "integrity": "sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-mdx": "^3.0.0",
+        "micromark-extension-mdxjs": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.0.2.tgz",
+      "integrity": "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.0.2",
+        "@shikijs/engine-javascript": "4.0.2",
+        "@shikijs/engine-oniguruma": "4.0.2",
+        "@shikijs/langs": "4.0.2",
+        "@shikijs/themes": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
+      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz",
+      "integrity": "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-4.0.0.tgz",
+      "integrity": "sha512-b4gokeGId57UVRX/eVKej5gXqGlc9+trkORhFJpu9raqZkZhU0zm8Doi05+HaiBsMEIJowL+2WtQ5ItjsngPXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-matter": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/vfile-matter/-/vfile-matter-5.0.1.tgz",
+      "integrity": "sha512-o6roP82AiX0XfkyTHyRCMXgHfltUNlXSEqCIS80f+mbAyiQBE2fxtDVMtseyytGx75sihiJFo/zR6r/4LTs2Cw==",
+      "license": "MIT",
+      "dependencies": {
+        "vfile": "^6.0.0",
+        "yaml": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/docs-web/package.json
+++ b/docs-web/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "site",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "tsc --noEmit"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@mdx-js/loader": "^3.1.1",
+    "@mdx-js/react": "^3.1.1",
+    "@next/mdx": "^16.2.3",
+    "flexsearch": "^0.8.212",
+    "framer-motion": "^12.38.0",
+    "gray-matter": "^4.0.3",
+    "next": "^16.2.3",
+    "next-mdx-remote": "^6.0.0",
+    "next-themes": "^0.4.6",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "rehype-highlight": "^7.0.2",
+    "rehype-slug": "^6.0.0",
+    "shiki": "^4.0.2"
+  },
+  "devDependencies": {
+    "@codemirror/lang-javascript": "^6.2.5",
+    "@codemirror/state": "^6.6.0",
+    "@codemirror/view": "^6.41.0",
+    "@tailwindcss/postcss": "^4.2.2",
+    "@types/node": "^25.6.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "postcss": "^8.5.9",
+    "tailwindcss": "^4.2.2",
+    "typescript": "^6.0.2"
+  }
+}

--- a/docs-web/postcss.config.mjs
+++ b/docs-web/postcss.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('postcss-load-config').Config} */
+const config = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};
+
+export default config;

--- a/docs-web/proxy.ts
+++ b/docs-web/proxy.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const HOMEPAGE_LINKS = [
+  '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"',
+  '</.well-known/agent-card.json>; rel="service-desc"; type="application/json"; title="A2A Agent Card"',
+  '</.well-known/mcp/server-card.json>; rel="service-desc"; type="application/json"; title="MCP Server Card"',
+  '</.well-known/agent-skills/index.json>; rel="agent-skills"; type="application/json"',
+  '</docs/api>; rel="service-doc"; type="text/html"; title="Layercache API Reference"',
+  '</docs>; rel="help"; type="text/html"; title="Layercache Documentation"',
+  '<https://github.com/flyingsquirrel0419/layercache>; rel="vcs-repository"',
+  '<https://github.com/flyingsquirrel0419/layercache/issues>; rel="issues"',
+];
+
+const DOCS_LINKS = [
+  '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"',
+  '</docs/api>; rel="service-doc"; type="text/html"',
+  '</>; rel="home"',
+];
+
+function shouldNegotiateMarkdown(accept: string | null): boolean {
+  if (!accept) return false;
+  const tokens = accept.split(",").map((t) => t.trim().toLowerCase());
+  const mdQ = tokens
+    .filter((t) => t.startsWith("text/markdown") || t.startsWith("text/x-markdown"))
+    .map((t) => {
+      const q = /;\s*q=([0-9.]+)/.exec(t);
+      return q ? parseFloat(q[1]) : 1;
+    })
+    .reduce((a, b) => Math.max(a, b), 0);
+  const htmlQ = tokens
+    .filter((t) => t.startsWith("text/html") || t.startsWith("application/xhtml"))
+    .map((t) => {
+      const q = /;\s*q=([0-9.]+)/.exec(t);
+      return q ? parseFloat(q[1]) : 1;
+    })
+    .reduce((a, b) => Math.max(a, b), 0);
+  return mdQ > 0 && mdQ >= htmlQ;
+}
+
+export function proxy(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+  const accept = req.headers.get("accept");
+
+  if (shouldNegotiateMarkdown(accept) && !pathname.startsWith("/api/markdown")) {
+    const rewriteUrl = req.nextUrl.clone();
+    rewriteUrl.pathname = `/api/markdown${pathname === "/" ? "" : pathname}`;
+    const res = NextResponse.rewrite(rewriteUrl);
+    res.headers.set("Vary", "Accept");
+    return res;
+  }
+
+  const res = NextResponse.next();
+  res.headers.append("Vary", "Accept");
+
+  if (pathname === "/") {
+    res.headers.set("Link", HOMEPAGE_LINKS.join(", "));
+  } else if (pathname === "/docs" || pathname.startsWith("/docs/")) {
+    res.headers.set("Link", DOCS_LINKS.join(", "));
+  }
+
+  return res;
+}
+
+export const config = {
+  matcher: ["/((?!_next/|favicon.ico|logo.svg|sitemap.xml|robots.txt).*)"],
+};

--- a/docs-web/public/logo.svg
+++ b/docs-web/public/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" fill="none">
+  <rect x="4" y="4" width="32" height="8" rx="3" fill="#6366f1" opacity="0.5"/>
+  <rect x="4" y="16" width="32" height="8" rx="3" fill="#6366f1" opacity="0.75"/>
+  <rect x="4" y="28" width="32" height="8" rx="3" fill="#6366f1"/>
+</svg>

--- a/docs-web/tailwind.config.ts
+++ b/docs-web/tailwind.config.ts
@@ -1,0 +1,30 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  darkMode: "class",
+  content: [
+    "./app/**/*.{js,jsx,ts,tsx,md,mdx}",
+    "./components/**/*.{js,jsx,ts,tsx,md,mdx}",
+    "./content/**/*.{js,jsx,ts,tsx,md,mdx}",
+  ],
+  theme: {
+    extend: {
+      colors: {
+        background: "var(--color-background)",
+        surface: "var(--color-surface)",
+        border: "var(--color-border)",
+        "text-primary": "var(--color-text-primary)",
+        "text-secondary": "var(--color-text-secondary)",
+        accent: "var(--color-accent)",
+        "accent-light": "var(--color-accent-light)",
+      },
+      fontFamily: {
+        sans: ["var(--font-inter)", "system-ui", "sans-serif"],
+        mono: ["var(--font-jetbrains)", "monospace"],
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/docs-web/tests/docs-ui-state.test.mjs
+++ b/docs-web/tests/docs-ui-state.test.mjs
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { getOpenGroupsForSlug } from "../lib/docs/sidebar-state.mjs";
+import {
+  getNextSelectedIndex,
+  shouldApplySearchResponse,
+} from "../lib/docs/search-modal-state.mjs";
+
+const docsNav = [
+  { title: "Overview", slug: "" },
+  { title: "Getting Started", slug: "getting-started" },
+  {
+    title: "Guides",
+    slug: "",
+    children: [
+      { title: "Tutorial", slug: "tutorial" },
+      { title: "Migration Guide", slug: "migration" },
+      { title: "CLI Tool", slug: "cli" },
+    ],
+  },
+];
+
+test("getOpenGroupsForSlug opens the parent group for the active child slug", () => {
+  const openGroups = getOpenGroupsForSlug(docsNav, "tutorial");
+
+  assert.deepEqual(openGroups, ["Guides"]);
+});
+
+test("getOpenGroupsForSlug returns an empty list for top-level pages", () => {
+  const openGroups = getOpenGroupsForSlug(docsNav, "getting-started");
+
+  assert.deepEqual(openGroups, []);
+});
+
+test("getNextSelectedIndex stays at zero when there are no results", () => {
+  assert.equal(getNextSelectedIndex(0, 1, 0), 0);
+  assert.equal(getNextSelectedIndex(0, -1, 0), 0);
+});
+
+test("getNextSelectedIndex clamps within the result bounds", () => {
+  assert.equal(getNextSelectedIndex(0, 1, 3), 1);
+  assert.equal(getNextSelectedIndex(2, 1, 3), 2);
+  assert.equal(getNextSelectedIndex(0, -1, 3), 0);
+});
+
+test("shouldApplySearchResponse only accepts the latest open request", () => {
+  assert.equal(
+    shouldApplySearchResponse({ isOpen: true, latestRequestId: 2, requestId: 2 }),
+    true
+  );
+  assert.equal(
+    shouldApplySearchResponse({ isOpen: true, latestRequestId: 2, requestId: 1 }),
+    false
+  );
+  assert.equal(
+    shouldApplySearchResponse({ isOpen: false, latestRequestId: 2, requestId: 2 }),
+    false
+  );
+});

--- a/docs-web/tests/playground-timeout-e2e.mjs
+++ b/docs-web/tests/playground-timeout-e2e.mjs
@@ -1,0 +1,41 @@
+import process from "node:process";
+import { chromium } from "playwright";
+
+const baseUrl = process.env.BASE_URL || "http://127.0.0.1:3000";
+const browser = await chromium.launch({ headless: true });
+const page = await browser.newPage();
+
+try {
+  await page.goto(`${baseUrl}/playground`, { waitUntil: "networkidle" });
+
+  const editor = page.locator("textarea");
+  await editor.fill("while (true) {}");
+
+  const runButton = page.getByRole("button", { name: "Run", exact: true });
+  await runButton.click();
+
+  await page.getByRole("button", { name: "Running...", exact: true }).waitFor({
+    state: "visible",
+    timeout: 5000,
+  });
+
+  await page.waitForFunction(
+    () => {
+      const buttons = Array.from(document.querySelectorAll("button"));
+      return buttons.some(
+        (button) =>
+          button.textContent?.trim() === "Run" &&
+          !button.hasAttribute("disabled")
+      );
+    },
+    { timeout: 35000 }
+  );
+
+  await page
+    .locator("text=Execution timed out (30s limit) — worker terminated")
+    .waitFor({ state: "visible", timeout: 5000 });
+
+  console.log("E2E timeout recovery verified");
+} finally {
+  await browser.close();
+}

--- a/docs-web/tests/reporting-cache-state.test.mjs
+++ b/docs-web/tests/reporting-cache-state.test.mjs
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReportingCacheState } from "../lib/playground/reporting-cache-state.mjs";
+
+test("returns the initial cache when no playground cache factory is called", () => {
+  const initialCache = { name: "initial" };
+  const state = createReportingCacheState(initialCache);
+
+  assert.equal(state.getActiveCache(), initialCache);
+});
+
+test("reports the most recently created cache instance", () => {
+  const initialCache = { name: "initial" };
+  const latestCache = { name: "latest" };
+  const state = createReportingCacheState(initialCache);
+
+  state.track(latestCache);
+
+  assert.equal(state.getActiveCache(), latestCache);
+});

--- a/docs-web/tests/run-timeout-controller.test.mjs
+++ b/docs-web/tests/run-timeout-controller.test.mjs
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  RUN_TIMEOUT_MS,
+  armRunTimeout,
+  clearRunTimeout,
+} from "../lib/playground/run-timeout-controller.mjs";
+
+test("clearRunTimeout clears the active timer and resets the ref", () => {
+  const timeoutRef = { current: "timer-1" };
+  const cleared = [];
+
+  clearRunTimeout(timeoutRef, (timerId) => {
+    cleared.push(timerId);
+  });
+
+  assert.deepEqual(cleared, ["timer-1"]);
+  assert.equal(timeoutRef.current, null);
+});
+
+test("armRunTimeout clears an existing timer before scheduling a new one", () => {
+  const timeoutRef = { current: "timer-1" };
+  const cleared = [];
+  const scheduled = [];
+
+  const timerId = armRunTimeout({
+    timeoutRef,
+    onTimeout: () => {},
+    setTimer: (callback, ms) => {
+      scheduled.push({ callback, ms });
+      return "timer-2";
+    },
+    clearTimer: (existingTimerId) => {
+      cleared.push(existingTimerId);
+    },
+  });
+
+  assert.equal(timerId, "timer-2");
+  assert.deepEqual(cleared, ["timer-1"]);
+  assert.equal(scheduled[0]?.ms, RUN_TIMEOUT_MS);
+  assert.equal(timeoutRef.current, "timer-2");
+});
+
+test("armRunTimeout resets the ref before invoking the timeout callback", () => {
+  const timeoutRef = { current: null };
+  const states = [];
+  let scheduledCallback;
+
+  armRunTimeout({
+    timeoutRef,
+    onTimeout: () => {
+      states.push(timeoutRef.current);
+    },
+    setTimer: (callback) => {
+      scheduledCallback = callback;
+      return "timer-3";
+    },
+    clearTimer: () => {},
+  });
+
+  assert.equal(timeoutRef.current, "timer-3");
+  scheduledCallback();
+
+  assert.deepEqual(states, [null]);
+  assert.equal(timeoutRef.current, null);
+});

--- a/docs-web/tsconfig.json
+++ b/docs-web/tsconfig.json
@@ -1,0 +1,41 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     setupFiles: ['./tests/setup.ts'],
+    exclude: ['**/node_modules/**', '**/dist/**', '**/docs-web/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov', 'html'],


### PR DESCRIPTION
## Summary

- Move the standalone layercache-docs Next.js site into the main repository under `docs-web/`
- Single-source documentation management — docs live alongside the code they document
- Synced to layercache v1.3.4 main branch (529 tests badge, latest API options, DiskLayer at-rest protection, CLI safety guards, NestJS package removal)

## What's included

- **Landing page** with animated Hero, feature comparison table, and CTA
- **13 MDX doc pages** — getting-started, tutorial, API reference, layers, resilience, invalidation, distributed, serialization, observability, CLI, integrations, migration, index
- **Interactive Playground** with mock 3-layer cache, 8 presets (basic get/set, multi-layer, stale-while-revalidate, tag invalidation, namespaces, stampede prevention, circuit breaker, write-behind)
- **Framework integrations** — Express, Fastify, NestJS, Hono, tRPC, GraphQL, OpenTelemetry
- **Prometheus metrics exporter** and HTTP stats handler docs
- **Search**, TOC, sidebar navigation, dark mode

## Updated to match current main

- CacheStackOptions: added `stampedeMaxInFlight`, `stampedeEntryTimeoutMs`, `negativeTtl`, `snapshotMaxBytes`, `snapshotMaxEntries`, `invalidationMaxKeys`; fixed type variants for `adaptiveTtl`, `gracefulDegradation`, `generationCleanup`, `staleWhileRevalidate`, `staleIfError`
- CacheLayer interface: `defaultTtl` and `isLocal` are now optional; added `forEachKey`
- DiskLayer: at-rest protection (`encryptionKey`/`signingKey`), `maxFiles` default updated to 50,000
- CLI: `--require-tls` and `--force` safety options documented
- NestJS: replaced removed `@cachestack/nestjs` with direct `CacheStack` usage
- Hero badges: v1.3.4, 529 tests

Refs #26

> **Note:** VitePress was also suggested in #26. This PR keeps the existing Next.js site but the question of VitePress vs Next.js is orthogonal — happy to discuss in the issue.