### PR TITLE
Add type definition descriptions

### DIFF
--- a/src/CacheNamespace.ts
+++ b/src/CacheNamespace.ts
@@ -21,10 +21,19 @@ import type {
   CacheWriteOptions
 } from './types'
 
+/**
+ * Prefix-scoped view over a `CacheStack`.
+ *
+ * All keys and tags passed through the namespace are qualified with the
+ * namespace prefix, while metrics are tracked separately for namespace usage.
+ */
 export class CacheNamespace {
   private static readonly metricsMutexes = new WeakMap<CacheStack, Mutex>()
   private metrics: CacheMetricsSnapshot = createEmptyNamespaceMetrics()
 
+  /**
+   * Creates a namespace backed by an existing cache stack.
+   */
   constructor(
     private readonly cache: CacheStack,
     private readonly prefix: string
@@ -32,10 +41,17 @@ export class CacheNamespace {
     validateNamespaceKey(prefix)
   }
 
+  /**
+   * Reads a key inside this namespace and optionally runs a read-through fetcher
+   * on miss or refresh.
+   */
   async get<T>(key: string, fetcher?: CacheFetcher<T>, options?: CacheGetOptions): Promise<T | null> {
     return this.trackMetrics(() => this.cache.get(this.qualify(key), fetcher, this.qualifyGetOptions(options)))
   }
 
+  /**
+   * Alias for `get(key, fetcher, options)` that makes the get-or-set behavior explicit.
+   */
   async getOrSet<T>(key: string, fetcher: CacheFetcher<T>, options?: CacheGetOptions): Promise<T | null> {
     return this.trackMetrics(() => this.cache.getOrSet(this.qualify(key), fetcher, this.qualifyGetOptions(options)))
   }
@@ -47,30 +63,51 @@ export class CacheNamespace {
     return this.trackMetrics(() => this.cache.getOrThrow(this.qualify(key), fetcher, this.qualifyGetOptions(options)))
   }
 
+  /**
+   * Returns true when the namespaced key exists and has not expired in any layer.
+   */
   async has(key: string): Promise<boolean> {
     return this.trackMetrics(() => this.cache.has(this.qualify(key)))
   }
 
+  /**
+   * Returns the remaining TTL in milliseconds for the namespaced key.
+   */
   async ttl(key: string): Promise<number | null> {
     return this.trackMetrics(() => this.cache.ttl(this.qualify(key)))
   }
 
+  /**
+   * Stores a value under a namespaced key.
+   */
   async set<T>(key: string, value: T, options?: CacheWriteOptions): Promise<void> {
     await this.trackMetrics(() => this.cache.set(this.qualify(key), value, this.qualifyWriteOptions(options)))
   }
 
+  /**
+   * Deletes a namespaced key from all layers.
+   */
   async delete(key: string): Promise<void> {
     await this.trackMetrics(() => this.cache.delete(this.qualify(key)))
   }
 
+  /**
+   * Deletes multiple namespaced keys from all layers.
+   */
   async mdelete(keys: string[]): Promise<void> {
     await this.trackMetrics(() => this.cache.mdelete(keys.map((k) => this.qualify(k))))
   }
 
+  /**
+   * Clears all keys in this namespace by invalidating the namespace prefix.
+   */
   async clear(): Promise<void> {
     await this.trackMetrics(() => this.cache.invalidateByPrefix(this.prefix))
   }
 
+  /**
+   * Reads many namespaced keys concurrently.
+   */
   async mget<T>(entries: CacheMGetEntry<T>[]): Promise<Array<T | null>> {
     return this.trackMetrics(() =>
       this.cache.mget(
@@ -83,6 +120,9 @@ export class CacheNamespace {
     )
   }
 
+  /**
+   * Writes many namespaced entries concurrently.
+   */
   async mset<T>(entries: CacheMSetEntry<T>[]): Promise<void> {
     await this.trackMetrics(() =>
       this.cache.mset(
@@ -95,14 +135,23 @@ export class CacheNamespace {
     )
   }
 
+  /**
+   * Deletes keys associated with a tag scoped to this namespace.
+   */
   async invalidateByTag(tag: string): Promise<void> {
     await this.trackMetrics(() => this.cache.invalidateByTag(this.qualifyTag(tag)))
   }
 
+  /**
+   * Expires keys associated with a tag scoped to this namespace while preserving stale windows.
+   */
   async expireByTag(tag: string): Promise<void> {
     await this.trackMetrics(() => this.cache.expireByTag(this.qualifyTag(tag)))
   }
 
+  /**
+   * Deletes keys associated with any or all namespace-scoped tags.
+   */
   async invalidateByTags(tags: string[], mode: 'any' | 'all' = 'any'): Promise<void> {
     await this.trackMetrics(() =>
       this.cache.invalidateByTags(
@@ -112,6 +161,9 @@ export class CacheNamespace {
     )
   }
 
+  /**
+   * Expires keys associated with any or all namespace-scoped tags while preserving stale windows.
+   */
   async expireByTags(tags: string[], mode: 'any' | 'all' = 'any'): Promise<void> {
     await this.trackMetrics(() =>
       this.cache.expireByTags(
@@ -121,18 +173,30 @@ export class CacheNamespace {
     )
   }
 
+  /**
+   * Deletes namespaced keys matching a wildcard pattern.
+   */
   async invalidateByPattern(pattern: string): Promise<void> {
     await this.trackMetrics(() => this.cache.invalidateByPattern(this.qualify(pattern)))
   }
 
+  /**
+   * Expires namespaced keys matching a wildcard pattern while preserving stale windows.
+   */
   async expireByPattern(pattern: string): Promise<void> {
     await this.trackMetrics(() => this.cache.expireByPattern(this.qualify(pattern)))
   }
 
+  /**
+   * Deletes namespaced keys with the provided prefix.
+   */
   async invalidateByPrefix(prefix: string): Promise<void> {
     await this.trackMetrics(() => this.cache.invalidateByPrefix(this.qualify(prefix)))
   }
 
+  /**
+   * Expires namespaced keys with the provided prefix while preserving stale windows.
+   */
   async expireByPrefix(prefix: string): Promise<void> {
     await this.trackMetrics(() => this.cache.expireByPrefix(this.qualify(prefix)))
   }
@@ -154,6 +218,9 @@ export class CacheNamespace {
     }
   }
 
+  /**
+   * Returns a cached wrapper whose generated keys are scoped to this namespace.
+   */
   wrap<TArgs extends unknown[], TResult>(
     keyPrefix: string,
     fetcher: (...args: TArgs) => Promise<TResult>,
@@ -162,6 +229,9 @@ export class CacheNamespace {
     return this.cache.wrap(`${this.prefix}:${keyPrefix}`, fetcher, this.qualifyWrapOptions(options))
   }
 
+  /**
+   * Warms entries after qualifying each key and tag with this namespace prefix.
+   */
   warm(entries: CacheWarmEntry[], options?: CacheWarmOptions): Promise<void> {
     return this.cache.warm(
       entries.map((entry) => ({
@@ -173,10 +243,16 @@ export class CacheNamespace {
     )
   }
 
+  /**
+   * Returns metrics accumulated by operations performed through this namespace.
+   */
   getMetrics(): CacheMetricsSnapshot {
     return cloneNamespaceMetrics(this.metrics)
   }
 
+  /**
+   * Returns hit-rate statistics for operations performed through this namespace.
+   */
   getHitRate(): CacheHitRateSnapshot {
     return computeNamespaceHitRate(this.metrics)
   }
@@ -195,6 +271,9 @@ export class CacheNamespace {
     return new CacheNamespace(this.cache, `${this.prefix}:${childPrefix}`)
   }
 
+  /**
+   * Qualifies a raw key with this namespace prefix.
+   */
   qualify(key: string): string {
     return `${this.prefix}:${key}`
   }

--- a/src/CacheStack.ts
+++ b/src/CacheStack.ts
@@ -121,15 +121,28 @@ class DebugLogger implements CacheLogger {
 
 /** Typed overloads for EventEmitter so callers get autocomplete on event names. */
 export interface CacheStack {
+  /** Register a typed CacheStack event listener. */
   on<K extends keyof CacheStackEvents>(event: K, listener: (data: CacheStackEvents[K]) => void): this
+  /** Register a typed CacheStack event listener that runs once. */
   once<K extends keyof CacheStackEvents>(event: K, listener: (data: CacheStackEvents[K]) => void): this
+  /** Remove a typed CacheStack event listener. */
   off<K extends keyof CacheStackEvents>(event: K, listener: (data: CacheStackEvents[K]) => void): this
+  /** Remove all listeners, optionally only for one typed CacheStack event. */
   removeAllListeners<K extends keyof CacheStackEvents>(event?: K): this
+  /** Return listeners registered for a typed CacheStack event. */
   listeners<K extends keyof CacheStackEvents>(event: K): Array<(data: CacheStackEvents[K]) => void>
+  /** Return the listener count for a typed CacheStack event. */
   listenerCount<K extends keyof CacheStackEvents>(event: K): number
+  /** Emit a typed CacheStack event. Mostly useful for custom integrations. */
   emit<K extends keyof CacheStackEvents>(event: K, data: CacheStackEvents[K]): boolean
 }
 
+/**
+ * Multi-layer read-through cache coordinator.
+ *
+ * Layers are checked from fastest to slowest, partial hits are backfilled into
+ * faster layers, and misses can be resolved by read-through fetchers.
+ */
 export class CacheStack extends EventEmitter {
   private readonly stampedeGuard: StampedeGuard
   private readonly metricsCollector = new MetricsCollector()
@@ -154,6 +167,9 @@ export class CacheStack extends EventEmitter {
   private readonly reader: CacheStackReader
   private disconnectPromise?: Promise<void>
 
+  /**
+   * Creates a cache stack from ordered layers and optional global behavior settings.
+   */
   constructor(
     private readonly layers: CacheLayer[],
     private readonly options: CacheStackOptions = {}
@@ -425,6 +441,10 @@ export class CacheStack extends EventEmitter {
     })
   }
 
+  /**
+   * Clears every configured layer, removes tag metadata, resets internal TTL
+   * profiles, and broadcasts a clear invalidation message.
+   */
   async clear(): Promise<void> {
     await this.awaitStartup('clear')
     this.maintenance.beginClearEpoch()
@@ -456,6 +476,10 @@ export class CacheStack extends EventEmitter {
     })
   }
 
+  /**
+   * Reads many keys concurrently. Simple reads use layer-level bulk fast paths;
+   * entries with fetchers or options fall back to per-entry read-through logic.
+   */
   async mget<T>(entries: CacheMGetEntry<T>[]): Promise<Array<T | null>> {
     return this.observeOperation('layercache.mget', undefined, async () => {
       this.assertActive('mget')
@@ -567,6 +591,10 @@ export class CacheStack extends EventEmitter {
     })
   }
 
+  /**
+   * Writes many entries concurrently using each layer's bulk write fast path
+   * when available.
+   */
   async mset<T>(entries: CacheMSetEntry<T>[]): Promise<void> {
     await this.observeOperation('layercache.mset', undefined, async () => {
       this.assertActive('mset')
@@ -580,6 +608,10 @@ export class CacheStack extends EventEmitter {
     })
   }
 
+  /**
+   * Pre-populates cache entries by running their fetchers with bounded
+   * concurrency. Higher-priority entries run first.
+   */
   async warm(entries: CacheWarmEntry[], options: CacheWarmOptions = {}): Promise<void> {
     this.assertActive('warm')
     const concurrency = Math.max(1, options.concurrency ?? 4)
@@ -641,6 +673,10 @@ export class CacheStack extends EventEmitter {
     return new CacheNamespace(this, prefix)
   }
 
+  /**
+   * Deletes every key currently associated with `tag` and broadcasts an
+   * invalidation message.
+   */
   async invalidateByTag(tag: string): Promise<void> {
     await this.observeOperation('layercache.invalidate_by_tag', undefined, async () => {
       validateTag(tag)
@@ -651,6 +687,10 @@ export class CacheStack extends EventEmitter {
     })
   }
 
+  /**
+   * Marks every key associated with `tag` as expired while preserving stale
+   * windows for stale serving.
+   */
   async expireByTag(tag: string): Promise<void> {
     await this.observeOperation('layercache.expire_by_tag', undefined, async () => {
       validateTag(tag)
@@ -661,6 +701,10 @@ export class CacheStack extends EventEmitter {
     })
   }
 
+  /**
+   * Deletes keys associated with any or all of the provided tags and broadcasts
+   * an invalidation message.
+   */
   async invalidateByTags(tags: string[], mode: 'any' | 'all' = 'any'): Promise<void> {
     await this.observeOperation('layercache.invalidate_by_tags', undefined, async () => {
       if (tags.length === 0) {
@@ -680,6 +724,10 @@ export class CacheStack extends EventEmitter {
     })
   }
 
+  /**
+   * Marks keys associated with any or all of the provided tags as expired while
+   * preserving stale windows for stale serving.
+   */
   async expireByTags(tags: string[], mode: 'any' | 'all' = 'any'): Promise<void> {
     await this.observeOperation('layercache.expire_by_tags', undefined, async () => {
       if (tags.length === 0) {
@@ -699,6 +747,9 @@ export class CacheStack extends EventEmitter {
     })
   }
 
+  /**
+   * Deletes keys matching a wildcard pattern such as `user:*`.
+   */
   async invalidateByPattern(pattern: string): Promise<void> {
     await this.observeOperation('layercache.invalidate_by_pattern', undefined, async () => {
       validatePattern(pattern)
@@ -712,6 +763,10 @@ export class CacheStack extends EventEmitter {
     })
   }
 
+  /**
+   * Marks keys matching a wildcard pattern as expired while preserving stale
+   * windows for stale serving.
+   */
   async expireByPattern(pattern: string): Promise<void> {
     await this.observeOperation('layercache.expire_by_pattern', undefined, async () => {
       validatePattern(pattern)
@@ -725,6 +780,9 @@ export class CacheStack extends EventEmitter {
     })
   }
 
+  /**
+   * Deletes keys that start with the provided prefix.
+   */
   async invalidateByPrefix(prefix: string): Promise<void> {
     await this.observeOperation('layercache.invalidate_by_prefix', undefined, async () => {
       await this.awaitStartup('invalidateByPrefix')
@@ -735,6 +793,10 @@ export class CacheStack extends EventEmitter {
     })
   }
 
+  /**
+   * Marks keys that start with the provided prefix as expired while preserving
+   * stale windows for stale serving.
+   */
   async expireByPrefix(prefix: string): Promise<void> {
     await this.observeOperation('layercache.expire_by_prefix', undefined, async () => {
       await this.awaitStartup('expireByPrefix')
@@ -745,10 +807,16 @@ export class CacheStack extends EventEmitter {
     })
   }
 
+  /**
+   * Returns cumulative cache metrics since startup or the last `resetMetrics()`.
+   */
   getMetrics(): CacheMetricsSnapshot {
     return this.metricsCollector.snapshot
   }
 
+  /**
+   * Returns metrics plus layer degradation state and active background refresh count.
+   */
   getStats(): CacheStatsSnapshot {
     return {
       metrics: this.getMetrics(),
@@ -761,6 +829,9 @@ export class CacheStack extends EventEmitter {
     }
   }
 
+  /**
+   * Resets cumulative metrics counters.
+   */
   resetMetrics(): void {
     this.metricsCollector.reset()
   }
@@ -772,6 +843,10 @@ export class CacheStack extends EventEmitter {
     return this.metricsCollector.hitRate()
   }
 
+  /**
+   * Runs each layer's `ping()` hook when available and returns per-layer health
+   * and latency information.
+   */
   async healthCheck(): Promise<CacheHealthCheckResult[]> {
     await this.startup
 
@@ -874,26 +949,42 @@ export class CacheStack extends EventEmitter {
     return { key: userKey, foundInLayers, freshTtlMs, staleTtlMs, errorTtlMs, isStale, tags }
   }
 
+  /**
+   * Exports cache entries from configured layers for process-local snapshots.
+   */
   async exportState(): Promise<CacheSnapshotEntry[]> {
     await this.awaitStartup('exportState')
     return this.snapshots.exportState(this.snapshotMaxEntries())
   }
 
+  /**
+   * Imports entries produced by `exportState()` into the configured layers.
+   */
   async importState(entries: CacheSnapshotEntry[]): Promise<void> {
     await this.awaitStartup('importState')
     await this.snapshots.importState(entries)
   }
 
+  /**
+   * Writes a snapshot file containing current cache entries.
+   */
   async persistToFile(filePath: string): Promise<void> {
     this.assertActive('persistToFile')
     await this.snapshots.persistToFile(filePath, this.options.snapshotBaseDir, this.snapshotMaxEntries())
   }
 
+  /**
+   * Restores cache entries from a snapshot file.
+   */
   async restoreFromFile(filePath: string): Promise<void> {
     this.assertActive('restoreFromFile')
     await this.snapshots.restoreFromFile(filePath, this.options.snapshotBaseDir, this.snapshotMaxBytes())
   }
 
+  /**
+   * Flushes background work, unsubscribes from buses, disposes timers, and then
+   * disposes each layer that provides `dispose()`.
+   */
   async disconnect(): Promise<void> {
     if (!this.disconnectPromise) {
       this.isDisconnecting = true

--- a/src/decorators/createCachedMethodDecorator.ts
+++ b/src/decorators/createCachedMethodDecorator.ts
@@ -2,10 +2,15 @@ import type { CacheStack } from '../CacheStack'
 import type { CacheWrapOptions } from '../types'
 
 interface CachedMethodDecoratorOptions<TArgs extends unknown[]> extends CacheWrapOptions<TArgs> {
+  /** Returns the CacheStack instance used for the decorated object instance. */
   cache: (instance: unknown) => CacheStack
+  /** Cache key prefix for the method. Defaults to the decorated property name. */
   prefix?: string
 }
 
+/**
+ * Creates a method decorator that caches async method results per instance.
+ */
 export function createCachedMethodDecorator<TArgs extends unknown[] = unknown[]>(
   options: CachedMethodDecoratorOptions<TArgs>
 ): MethodDecorator {

--- a/src/http/createCacheStatsHandler.ts
+++ b/src/http/createCacheStatsHandler.ts
@@ -7,10 +7,15 @@ interface CacheStatsHandlerOptions {
    * future release.
    */
   allowPublicAccess?: boolean
+  /** Authorize requests before returning cache stats. Required unless `allowPublicAccess` is true. */
   authorize?: (request: unknown) => boolean | Promise<boolean>
+  /** Status code returned when a request is unauthorized. Defaults to 403. */
   unauthorizedStatusCode?: number
 }
 
+/**
+ * Creates a small Node HTTP handler that returns `cache.getStats()` as JSON.
+ */
 export function createCacheStatsHandler(cache: CacheStack, options: CacheStatsHandlerOptions = {}) {
   if (options.allowPublicAccess === true) {
     console.warn(

--- a/src/integrations/fastify.ts
+++ b/src/integrations/fastify.ts
@@ -12,7 +12,9 @@ interface FastifyLikeReply {
 }
 
 interface FastifyLayercachePluginOptions {
+  /** Register an HTTP route that returns `cache.getStats()`. Disabled by default. */
   exposeStatsRoute?: boolean
+  /** Path for the stats route when `exposeStatsRoute` is enabled. Defaults to `/cache/stats`. */
   statsPath?: string
   /**
    * @deprecated Exposing cache stats without authentication is a security risk.
@@ -20,10 +22,15 @@ interface FastifyLayercachePluginOptions {
    * removed in a future release.
    */
   allowPublicStatsRoute?: boolean
+  /** Authorize requests to the stats route. Required unless `allowPublicStatsRoute` is true. */
   authorizeStatsRoute?: (request: unknown) => boolean | Promise<boolean>
+  /** Status code returned when a stats route request is unauthorized. Defaults to 403. */
   unauthorizedStatusCode?: number
 }
 
+/**
+ * Fastify plugin that decorates the server with `cache` and can expose a protected stats route.
+ */
 export function createFastifyLayercachePlugin(cache: CacheStack, options: FastifyLayercachePluginOptions = {}) {
   if (options.exposeStatsRoute === true && options.allowPublicStatsRoute === true) {
     console.warn(

--- a/src/integrations/graphql.ts
+++ b/src/integrations/graphql.ts
@@ -2,10 +2,15 @@ import type { CacheStack } from '../CacheStack'
 import type { CacheGetOptions } from '../types'
 
 interface GraphqlCacheOptions<TArgs extends unknown[]> extends CacheGetOptions {
+  /** Converts resolver arguments into a stable cache key suffix. */
   keyResolver?: (...args: TArgs) => string
+  /** Allow fallback key generation from resolver args when no `keyResolver` is provided. */
   allowImplicitContextCaching?: boolean
 }
 
+/**
+ * Wraps a GraphQL resolver with read-through caching.
+ */
 export function cacheGraphqlResolver<TArgs extends unknown[], TResult>(
   cache: CacheStack,
   prefix: string,

--- a/src/integrations/hono.ts
+++ b/src/integrations/hono.ts
@@ -17,11 +17,20 @@ interface HonoLikeContext {
 }
 
 interface HonoCacheMiddlewareOptions extends CacheGetOptions {
+  /**
+   * Resolves a cache key from the incoming Hono request. Defaults to
+   * `GET:<normalized path>` when `allowPrivateCaching` is enabled.
+   */
   keyResolver?: (request: HonoLikeRequest) => string
+  /** Only cache responses for these HTTP methods. Defaults to `['GET']`. */
   methods?: string[]
+  /** Explicitly allow URL-only implicit cache keys. Disabled by default. */
   allowPrivateCaching?: boolean
 }
 
+/**
+ * Hono-compatible middleware that caches JSON responses for selected methods.
+ */
 export function createHonoCacheMiddleware(cache: CacheStack, options: HonoCacheMiddlewareOptions = {}) {
   const allowedMethods = new Set((options.methods ?? ['GET']).map((method) => method.toUpperCase()))
 

--- a/src/integrations/trpc.ts
+++ b/src/integrations/trpc.ts
@@ -2,17 +2,26 @@ import type { CacheStack } from '../CacheStack'
 import type { CacheGetOptions } from '../types'
 
 interface TrpcCacheMiddlewareContext<TInput = unknown, TResult = unknown> {
+  /** Procedure path, when supplied by the adapter. */
   path?: string
+  /** Procedure type, such as query or mutation. */
   type?: string
+  /** Raw procedure input used by the key resolver. */
   rawInput?: TInput
+  /** Runs the next tRPC middleware or resolver. */
   next: () => Promise<{ ok: boolean; data?: TResult }>
 }
 
 interface TrpcCacheMiddlewareOptions<TInput> extends CacheGetOptions {
+  /** Converts procedure input and metadata into a stable cache key suffix. */
   keyResolver?: (input: TInput, path?: string, type?: string) => string
+  /** Allow fallback key generation from procedure path and raw input. */
   allowImplicitContextCaching?: boolean
 }
 
+/**
+ * Creates a tRPC middleware that caches successful procedure results.
+ */
 export function createTrpcCacheMiddleware<TInput = unknown, TResult = unknown>(
   cache: CacheStack,
   prefix: string,

--- a/src/invalidation/RedisInvalidationBus.ts
+++ b/src/invalidation/RedisInvalidationBus.ts
@@ -3,9 +3,13 @@ import { sanitizeStructuredData } from '../internal/StructuredDataSanitizer'
 import type { CacheLogger, InvalidationBus, InvalidationMessage } from '../types'
 
 interface RedisInvalidationBusOptions {
+  /** Redis client used to publish invalidation messages. */
   publisher: Redis
+  /** Redis client used for subscriptions. Defaults to `publisher.duplicate()`. */
   subscriber?: Redis
+  /** Pub/sub channel name. Defaults to `layercache:invalidation`. */
   channel?: string
+  /** Optional logger for invalid payloads or subscriber errors. */
   logger?: CacheLogger
 }
 
@@ -32,6 +36,9 @@ export class RedisInvalidationBus implements InvalidationBus {
     this.logger = options.logger
   }
 
+  /**
+   * Subscribes to invalidation messages and returns an unsubscribe function.
+   */
   async subscribe(handler: (message: InvalidationMessage) => Promise<void> | void): Promise<() => Promise<void>> {
     // Serialize concurrent subscribe() calls to prevent race conditions.
     // Chain onto the existing promise so late callers wait for earlier ones.
@@ -73,6 +80,9 @@ export class RedisInvalidationBus implements InvalidationBus {
     }
   }
 
+  /**
+   * Publishes an invalidation message to other subscribers.
+   */
   async publish(message: InvalidationMessage): Promise<void> {
     await this.publisher.publish(this.channel, JSON.stringify(message))
   }

--- a/src/invalidation/RedisTagIndex.ts
+++ b/src/invalidation/RedisTagIndex.ts
@@ -3,9 +3,13 @@ import type { CacheTagIndex } from '../types'
 import { PatternMatcher } from './PatternMatcher'
 
 interface RedisTagIndexOptions {
+  /** Redis client used for tag and known-key sets. */
   client: Redis
+  /** Redis key prefix for index data. Defaults to `layercache:tag-index`. */
   prefix?: string
+  /** Redis SCAN count hint used by pattern and prefix discovery. Defaults to 100. */
   scanCount?: number
+  /** Number of shards for known-key sets. Defaults to 16. */
   knownKeysShards?: number
 }
 
@@ -22,10 +26,16 @@ export class RedisTagIndex implements CacheTagIndex {
     this.knownKeysShards = normalizeKnownKeysShards(options.knownKeysShards)
   }
 
+  /**
+   * Records a key as known without changing tag assignments.
+   */
   async touch(key: string): Promise<void> {
     await this.client.sadd(this.knownKeysKeyFor(key), key)
   }
 
+  /**
+   * Replaces the tags associated with a key and records the key as known.
+   */
   async track(key: string, tags: string[]): Promise<void> {
     const keyTagsKey = this.keyTagsKey(key)
     const existingTags = await this.client.smembers(keyTagsKey)
@@ -49,6 +59,9 @@ export class RedisTagIndex implements CacheTagIndex {
     await pipeline.exec()
   }
 
+  /**
+   * Removes a key from all tag mappings and known-key tracking.
+   */
   async remove(key: string): Promise<void> {
     const keyTagsKey = this.keyTagsKey(key)
     const existingTags = await this.client.smembers(keyTagsKey)
@@ -64,10 +77,16 @@ export class RedisTagIndex implements CacheTagIndex {
     await pipeline.exec()
   }
 
+  /**
+   * Returns keys currently associated with a tag.
+   */
   async keysForTag(tag: string): Promise<string[]> {
     return this.client.smembers(this.tagKeysKey(tag))
   }
 
+  /**
+   * Visits keys currently associated with a tag.
+   */
   async forEachKeyForTag(tag: string, visitor: (key: string) => void | Promise<void>): Promise<void> {
     let cursor = '0'
     const tagKey = this.tagKeysKey(tag)
@@ -81,6 +100,9 @@ export class RedisTagIndex implements CacheTagIndex {
     } while (cursor !== '0')
   }
 
+  /**
+   * Returns known keys that start with a prefix.
+   */
   async keysForPrefix(prefix: string): Promise<string[]> {
     const matches: string[] = []
     for (const knownKeysKey of this.knownKeysKeys()) {
@@ -96,6 +118,9 @@ export class RedisTagIndex implements CacheTagIndex {
     return matches
   }
 
+  /**
+   * Visits known keys that start with a prefix.
+   */
   async forEachKeyForPrefix(prefix: string, visitor: (key: string) => void | Promise<void>): Promise<void> {
     for (const knownKeysKey of this.knownKeysKeys()) {
       let cursor = '0'
@@ -112,10 +137,16 @@ export class RedisTagIndex implements CacheTagIndex {
     }
   }
 
+  /**
+   * Returns the tags currently associated with a key.
+   */
   async tagsForKey(key: string): Promise<string[]> {
     return this.client.smembers(this.keyTagsKey(key))
   }
 
+  /**
+   * Returns known keys matching a wildcard pattern.
+   */
   async matchPattern(pattern: string): Promise<string[]> {
     const matches: string[] = []
     for (const knownKeysKey of this.knownKeysKeys()) {
@@ -138,6 +169,9 @@ export class RedisTagIndex implements CacheTagIndex {
     return matches
   }
 
+  /**
+   * Visits known keys matching a wildcard pattern.
+   */
   async forEachKeyMatchingPattern(pattern: string, visitor: (key: string) => void | Promise<void>): Promise<void> {
     for (const knownKeysKey of this.knownKeysKeys()) {
       let cursor = '0'
@@ -161,6 +195,9 @@ export class RedisTagIndex implements CacheTagIndex {
     }
   }
 
+  /**
+   * Clears all Redis tag-index state under this prefix.
+   */
   async clear(): Promise<void> {
     const indexKeys = await this.scanIndexKeys()
     if (indexKeys.length === 0) {

--- a/src/invalidation/TagIndex.ts
+++ b/src/invalidation/TagIndex.ts
@@ -29,11 +29,17 @@ export class TagIndex implements CacheTagIndex {
     this.maxKnownKeys = options.maxKnownKeys ?? 100_000
   }
 
+  /**
+   * Records a key as known without changing tag assignments.
+   */
   async touch(key: string): Promise<void> {
     this.insertKnownKey(key)
     this.pruneKnownKeysIfNeeded()
   }
 
+  /**
+   * Replaces the tags associated with a key and records the key as known.
+   */
   async track(key: string, tags: string[]): Promise<void> {
     this.insertKnownKey(key)
     this.pruneKnownKeysIfNeeded()
@@ -59,20 +65,32 @@ export class TagIndex implements CacheTagIndex {
     }
   }
 
+  /**
+   * Removes a key from all tag mappings and known-key tracking.
+   */
   async remove(key: string): Promise<void> {
     this.removeKey(key)
   }
 
+  /**
+   * Returns keys currently associated with a tag.
+   */
   async keysForTag(tag: string): Promise<string[]> {
     return [...(this.tagToKeys.get(tag) ?? new Set<string>())]
   }
 
+  /**
+   * Visits keys currently associated with a tag.
+   */
   async forEachKeyForTag(tag: string, visitor: (key: string) => void | Promise<void>): Promise<void> {
     for (const key of this.tagToKeys.get(tag) ?? new Set<string>()) {
       await visitor(key)
     }
   }
 
+  /**
+   * Returns known keys that start with a prefix.
+   */
   async keysForPrefix(prefix: string): Promise<string[]> {
     const node = this.findNode(prefix)
     if (!node) {
@@ -84,6 +102,9 @@ export class TagIndex implements CacheTagIndex {
     return matches
   }
 
+  /**
+   * Visits known keys that start with a prefix.
+   */
   async forEachKeyForPrefix(prefix: string, visitor: (key: string) => void | Promise<void>): Promise<void> {
     const node = this.findNode(prefix)
     if (!node) {
@@ -93,16 +114,25 @@ export class TagIndex implements CacheTagIndex {
     await this.visitFromNode(node, prefix, visitor)
   }
 
+  /**
+   * Returns the tags currently associated with a key.
+   */
   async tagsForKey(key: string): Promise<string[]> {
     return [...(this.keyToTags.get(key) ?? new Set<string>())]
   }
 
+  /**
+   * Returns known keys matching a wildcard pattern.
+   */
   async matchPattern(pattern: string): Promise<string[]> {
     const matches = new Set<string>()
     this.collectPatternMatches(this.root, '', pattern, 0, matches, new Set<string>(), 0)
     return [...matches]
   }
 
+  /**
+   * Visits known keys matching a wildcard pattern.
+   */
   async forEachKeyMatchingPattern(pattern: string, visitor: (key: string) => void | Promise<void>): Promise<void> {
     const matches = await this.matchPattern(pattern)
     for (const key of matches) {
@@ -110,6 +140,9 @@ export class TagIndex implements CacheTagIndex {
     }
   }
 
+  /**
+   * Clears all tag and known-key index state.
+   */
   async clear(): Promise<void> {
     this.tagToKeys.clear()
     this.keyToTags.clear()

--- a/src/layers/DiskLayer.ts
+++ b/src/layers/DiskLayer.ts
@@ -7,9 +7,13 @@ import { JsonSerializer } from '../serialization/JsonSerializer'
 import type { CacheLayer, CacheLayerSetManyEntry, CacheSerializer } from '../types'
 
 interface DiskLayerOptions {
+  /** Directory where cache entry files are stored. */
   directory: string
+  /** Default TTL in milliseconds for writes that do not provide an explicit TTL. */
   ttl?: number
+  /** Layer name used for metrics and per-layer TTL maps. Defaults to `disk`. */
   name?: string
+  /** Serializer used to encode values before writing them to disk. */
   serializer?: CacheSerializer
   /**
    * Maximum number of cache files to store on disk. When exceeded, the oldest
@@ -71,6 +75,9 @@ export class DiskLayer implements CacheLayer {
   private readonly protection: PayloadProtection
   private writeQueue = Promise.resolve()
 
+  /**
+   * Creates a disk-backed cache layer.
+   */
   constructor(options: DiskLayerOptions) {
     this.directory = this.resolveDirectory(options.directory)
     this.defaultTtl = options.ttl
@@ -84,10 +91,16 @@ export class DiskLayer implements CacheLayer {
     })
   }
 
+  /**
+   * Reads and unwraps a fresh value from disk.
+   */
   async get<T>(key: string): Promise<T | null> {
     return unwrapStoredValue<T>(await this.getEntry(key))
   }
 
+  /**
+   * Reads the raw stored value or envelope from disk.
+   */
   async getEntry<T = unknown>(key: string): Promise<T | null> {
     const filePath = this.keyToPath(key)
     const raw = await this.readEntryFile(filePath)
@@ -111,6 +124,9 @@ export class DiskLayer implements CacheLayer {
     return entry.value as T
   }
 
+  /**
+   * Stores a value on disk using the provided TTL or layer default TTL.
+   */
   async set(key: string, value: unknown, ttl = this.defaultTtl): Promise<void> {
     await this.enqueueWrite(async () => {
       await fs.mkdir(this.directory, { recursive: true })
@@ -138,19 +154,31 @@ export class DiskLayer implements CacheLayer {
     })
   }
 
+  /**
+   * Reads many raw entries from disk.
+   */
   async getMany<T>(keys: string[]): Promise<Array<T | null>> {
     return Promise.all(keys.map((key) => this.getEntry<T>(key)))
   }
 
+  /**
+   * Writes many entries to disk.
+   */
   async setMany(entries: CacheLayerSetManyEntry[]): Promise<void> {
     await Promise.all(entries.map((entry) => this.set(entry.key, entry.value, entry.ttl)))
   }
 
+  /**
+   * Returns true when the key exists and has not expired.
+   */
   async has(key: string): Promise<boolean> {
     const value = await this.getEntry(key)
     return value !== null
   }
 
+  /**
+   * Returns remaining TTL in milliseconds, or null when absent or non-expiring.
+   */
   async ttl(key: string): Promise<number | null> {
     const filePath = this.keyToPath(key)
     const raw = await this.readEntryFile(filePath)
@@ -177,16 +205,25 @@ export class DiskLayer implements CacheLayer {
     return remaining
   }
 
+  /**
+   * Deletes a key from disk.
+   */
   async delete(key: string): Promise<void> {
     await this.enqueueWrite(() => this.safeDelete(this.keyToPath(key)))
   }
 
+  /**
+   * Deletes multiple keys from disk.
+   */
   async deleteMany(keys: string[]): Promise<void> {
     await this.enqueueWrite(async () => {
       await this.deletePathsWithConcurrency(keys.map((key) => this.keyToPath(key)))
     })
   }
 
+  /**
+   * Removes all cache entry files from this layer's directory.
+   */
   async clear(): Promise<void> {
     await this.enqueueWrite(async () => {
       let entries: string[]
@@ -214,12 +251,18 @@ export class DiskLayer implements CacheLayer {
     return keys
   }
 
+  /**
+   * Visits all non-expired keys stored on disk.
+   */
   async forEachKey(visitor: (key: string) => void | Promise<void>): Promise<void> {
     await this.scanEntries(async (entry) => {
       await visitor(entry.key)
     })
   }
 
+  /**
+   * Returns the number of non-expired entries stored on disk.
+   */
   async size(): Promise<number> {
     let count = 0
     await this.scanEntries(async () => {
@@ -228,6 +271,9 @@ export class DiskLayer implements CacheLayer {
     return count
   }
 
+  /**
+   * Verifies the cache directory can be created.
+   */
   async ping(): Promise<boolean> {
     try {
       await fs.mkdir(this.directory, { recursive: true })
@@ -237,6 +283,9 @@ export class DiskLayer implements CacheLayer {
     }
   }
 
+  /**
+   * Reserved for interface compatibility; DiskLayer does not hold persistent handles.
+   */
   async dispose(): Promise<void> {}
 
   private keyToPath(key: string): string {

--- a/src/layers/MemcachedLayer.ts
+++ b/src/layers/MemcachedLayer.ts
@@ -11,16 +11,24 @@ import type { CacheLayer, CacheSerializer } from '../types'
  *   npm install memcache-client
  */
 export interface MemcachedClient {
+  /** Read a raw value for `key`, returning null on miss. */
   get(key: string): Promise<{ value: Buffer | null } | null>
+  /** Store a raw value with optional expiration in seconds. */
   set(key: string, value: string | Buffer, options?: { expires?: number }): Promise<boolean | undefined>
+  /** Delete a raw key. */
   delete(key: string): Promise<boolean | undefined>
 }
 
 interface MemcachedLayerOptions {
+  /** Memcached-compatible client implementation. */
   client: MemcachedClient
+  /** Default TTL in milliseconds for writes that do not provide an explicit TTL. */
   ttl?: number
+  /** Layer name used for metrics and per-layer TTL maps. Defaults to `memcached`. */
   name?: string
+  /** Prefix prepended to every Memcached key. */
   keyPrefix?: string
+  /** Serializer used to encode values before storing them in Memcached. */
   serializer?: CacheSerializer
 }
 
@@ -51,6 +59,9 @@ export class MemcachedLayer implements CacheLayer {
   private readonly keyPrefix: string
   private readonly serializer: CacheSerializer
 
+  /**
+   * Creates a Memcached cache layer using a compatible client.
+   */
   constructor(options: MemcachedLayerOptions) {
     this.client = options.client
     this.defaultTtl = options.ttl
@@ -59,10 +70,16 @@ export class MemcachedLayer implements CacheLayer {
     this.serializer = options.serializer ?? new JsonSerializer()
   }
 
+  /**
+   * Reads and unwraps a fresh value from Memcached.
+   */
   async get<T>(key: string): Promise<T | null> {
     return unwrapStoredValue<T>(await this.getEntry<T>(key))
   }
 
+  /**
+   * Reads the raw stored value or envelope from Memcached.
+   */
   async getEntry<T = unknown>(key: string): Promise<T | null> {
     this.validateKey(key)
     const result = await this.client.get(this.withPrefix(key))
@@ -77,10 +94,16 @@ export class MemcachedLayer implements CacheLayer {
     }
   }
 
+  /**
+   * Reads many raw entries from Memcached.
+   */
   async getMany<T>(keys: string[]): Promise<Array<T | null>> {
     return Promise.all(keys.map((key) => this.getEntry<T>(key)))
   }
 
+  /**
+   * Stores a value in Memcached using the provided TTL or layer default TTL.
+   */
   async set(key: string, value: unknown, ttl = this.defaultTtl): Promise<void> {
     this.validateKey(key)
     const payload = this.serializer.serialize(value)
@@ -89,21 +112,33 @@ export class MemcachedLayer implements CacheLayer {
     })
   }
 
+  /**
+   * Returns true when the key exists in Memcached.
+   */
   async has(key: string): Promise<boolean> {
     this.validateKey(key)
     const result = await this.client.get(this.withPrefix(key))
     return result !== null && result.value !== null
   }
 
+  /**
+   * Deletes a key from Memcached.
+   */
   async delete(key: string): Promise<void> {
     this.validateKey(key)
     await this.client.delete(this.withPrefix(key))
   }
 
+  /**
+   * Deletes multiple keys from Memcached.
+   */
   async deleteMany(keys: string[]): Promise<void> {
     await Promise.all(keys.map((key) => this.delete(key)))
   }
 
+  /**
+   * Always throws because Memcached has no safe prefix clear primitive.
+   */
   async clear(): Promise<void> {
     // Memcached does not support pattern-based deletion.
     // Callers should use a key prefix and rotate it as a workaround.

--- a/src/layers/MemoryLayer.ts
+++ b/src/layers/MemoryLayer.ts
@@ -2,8 +2,11 @@ import { unwrapStoredValue } from '../internal/StoredValue'
 import type { CacheLayer, CacheLayerSetManyEntry } from '../types'
 
 export interface MemoryLayerSnapshotEntry {
+  /** Cache key stored in the snapshot. */
   key: string
+  /** Stored raw value or envelope. */
   value: unknown
+  /** Absolute expiry timestamp in milliseconds, or null for no expiry. */
   expiresAt: number | null
 }
 
@@ -16,11 +19,17 @@ export interface MemoryLayerSnapshotEntry {
 export type EvictionPolicy = 'lru' | 'lfu' | 'fifo'
 
 export interface MemoryLayerOptions {
+  /** Default TTL in milliseconds for entries written without an explicit TTL. */
   ttl?: number
+  /** Maximum number of entries retained in memory. Defaults to 1,000. */
   maxSize?: number
+  /** Layer name used for metrics and per-layer TTL maps. Defaults to `memory`. */
   name?: string
+  /** Eviction policy used when `maxSize` is exceeded. Defaults to `lru`. */
   evictionPolicy?: EvictionPolicy
+  /** Milliseconds between automatic expired-entry cleanup passes. Disabled when omitted. */
   cleanupIntervalMs?: number
+  /** Called with the key and unwrapped value whenever an entry is evicted. */
   onEvict?: (key: string, value: unknown) => void
 }
 
@@ -33,6 +42,9 @@ interface MemoryEntry {
   insertedAt: number
 }
 
+/**
+ * In-process cache layer with TTL support and bounded-size eviction.
+ */
 export class MemoryLayer implements CacheLayer {
   readonly name: string
   readonly defaultTtl?: number
@@ -44,6 +56,9 @@ export class MemoryLayer implements CacheLayer {
   private readonly entries = new Map<string, MemoryEntry>()
   private cleanupTimer?: ReturnType<typeof setInterval>
 
+  /**
+   * Creates an in-memory cache layer.
+   */
   constructor(options: MemoryLayerOptions = {}) {
     this.name = options.name ?? 'memory'
     this.defaultTtl = options.ttl
@@ -59,11 +74,17 @@ export class MemoryLayer implements CacheLayer {
     }
   }
 
+  /**
+   * Reads and unwraps a fresh value from memory.
+   */
   async get<T>(key: string): Promise<T | null> {
     const value = await this.getEntry(key)
     return unwrapStoredValue<T>(value)
   }
 
+  /**
+   * Reads the raw stored value or envelope from memory.
+   */
   async getEntry<T = unknown>(key: string): Promise<T | null> {
     const entry = this.entries.get(key)
     if (!entry) {
@@ -89,14 +110,23 @@ export class MemoryLayer implements CacheLayer {
     return entry.value as T
   }
 
+  /**
+   * Reads many raw entries from memory.
+   */
   async getMany<T>(keys: string[]): Promise<Array<T | null>> {
     return Promise.all(keys.map((key) => this.getEntry<T>(key)))
   }
 
+  /**
+   * Writes many entries to memory.
+   */
   async setMany(entries: CacheLayerSetManyEntry[]): Promise<void> {
     await Promise.all(entries.map((entry) => this.set(entry.key, entry.value, entry.ttl)))
   }
 
+  /**
+   * Stores a value in memory using the provided TTL or layer default TTL.
+   */
   async set(key: string, value: unknown, ttl = this.defaultTtl): Promise<void> {
     this.entries.delete(key)
     this.entries.set(key, {
@@ -111,6 +141,9 @@ export class MemoryLayer implements CacheLayer {
     }
   }
 
+  /**
+   * Returns true when the key exists and has not expired.
+   */
   async has(key: string): Promise<boolean> {
     const entry = this.entries.get(key)
     if (!entry) {
@@ -123,6 +156,9 @@ export class MemoryLayer implements CacheLayer {
     return true
   }
 
+  /**
+   * Returns remaining TTL in milliseconds, or null when absent or non-expiring.
+   */
   async ttl(key: string): Promise<number | null> {
     const entry = this.entries.get(key)
     if (!entry) {
@@ -138,29 +174,47 @@ export class MemoryLayer implements CacheLayer {
     return Math.max(0, Math.ceil(entry.expiresAt - Date.now()))
   }
 
+  /**
+   * Returns the number of currently retained, non-expired entries.
+   */
   async size(): Promise<number> {
     this.pruneExpired()
     return this.entries.size
   }
 
+  /**
+   * Deletes a key from memory.
+   */
   async delete(key: string): Promise<void> {
     this.entries.delete(key)
   }
 
+  /**
+   * Deletes multiple keys from memory.
+   */
   async deleteMany(keys: string[]): Promise<void> {
     for (const key of keys) {
       this.entries.delete(key)
     }
   }
 
+  /**
+   * Removes all entries from memory.
+   */
   async clear(): Promise<void> {
     this.entries.clear()
   }
 
+  /**
+   * Health check hook that always succeeds for the in-process layer.
+   */
   async ping(): Promise<boolean> {
     return true
   }
 
+  /**
+   * Stops the cleanup timer, when one is active.
+   */
   async dispose(): Promise<void> {
     if (this.cleanupTimer) {
       clearInterval(this.cleanupTimer)
@@ -168,11 +222,17 @@ export class MemoryLayer implements CacheLayer {
     }
   }
 
+  /**
+   * Returns all currently retained, non-expired keys.
+   */
   async keys(): Promise<string[]> {
     this.pruneExpired()
     return [...this.entries.keys()]
   }
 
+  /**
+   * Visits all currently retained, non-expired keys.
+   */
   async forEachKey(visitor: (key: string) => void | Promise<void>): Promise<void> {
     this.pruneExpired()
     for (const key of this.entries.keys()) {
@@ -180,6 +240,9 @@ export class MemoryLayer implements CacheLayer {
     }
   }
 
+  /**
+   * Exports memory entries for process-local snapshots.
+   */
   exportState(): MemoryLayerSnapshotEntry[] {
     this.pruneExpired()
     return [...this.entries.entries()].map(([key, entry]) => ({
@@ -189,6 +252,9 @@ export class MemoryLayer implements CacheLayer {
     }))
   }
 
+  /**
+   * Imports entries previously produced by `exportState()`.
+   */
   importState(entries: MemoryLayerSnapshotEntry[]): void {
     for (const entry of entries) {
       if (entry.expiresAt !== null && entry.expiresAt <= Date.now()) {

--- a/src/layers/RedisLayer.ts
+++ b/src/layers/RedisLayer.ts
@@ -14,14 +14,23 @@ const gzipAsync = promisify(gzip)
 const brotliCompressAsync = promisify(brotliCompress)
 
 interface RedisLayerOptions {
+  /** ioredis client used for all Redis commands. */
   client: Redis
+  /** Default TTL in milliseconds for writes that do not provide an explicit TTL. */
   ttl?: number
+  /** Layer name used for metrics and per-layer TTL maps. Defaults to `redis`. */
   name?: string
+  /** Serializer or serializer chain used to encode values before storage. */
   serializer?: CacheSerializer | CacheSerializer[]
+  /** Prefix prepended to every Redis key. */
   prefix?: string
+  /** Allow `clear()` without a key prefix. Disabled by default to avoid deleting unrelated Redis keys. */
   allowUnprefixedClear?: boolean
+  /** Redis SCAN count hint used when discovering keys. Defaults to 100. */
   scanCount?: number
+  /** Optional compression algorithm applied to large serialized payloads. */
   compression?: CompressionAlgorithm
+  /** Minimum serialized payload size in bytes before compression is attempted. Defaults to 1 KiB. */
   compressionThreshold?: number
   /**
    * Maximum number of bytes allowed after decompression.
@@ -33,9 +42,13 @@ interface RedisLayerOptions {
    * Slow commands reject so CacheStack can treat the layer as degraded.
    */
   commandTimeoutMs?: number
+  /** Disconnect the Redis client when this layer is disposed. Disabled by default. */
   disconnectOnDispose?: boolean
 }
 
+/**
+ * Redis-backed cache layer for shared cross-process cache state.
+ */
 export class RedisLayer implements CacheLayer {
   readonly name: string
   readonly defaultTtl?: number
@@ -52,6 +65,9 @@ export class RedisLayer implements CacheLayer {
   private readonly commandTimeoutMs: number | undefined
   private readonly disconnectOnDispose: boolean
 
+  /**
+   * Creates a Redis cache layer using an existing ioredis client.
+   */
   constructor(options: RedisLayerOptions) {
     this.client = options.client
     this.defaultTtl = options.ttl
@@ -69,11 +85,17 @@ export class RedisLayer implements CacheLayer {
     this.disconnectOnDispose = options.disconnectOnDispose ?? false
   }
 
+  /**
+   * Reads and unwraps a fresh value from Redis.
+   */
   async get<T>(key: string): Promise<T | null> {
     const payload = await this.getEntry(key)
     return unwrapStoredValue<T>(payload)
   }
 
+  /**
+   * Reads the raw stored value or envelope from Redis.
+   */
   async getEntry<T = unknown>(key: string): Promise<T | null> {
     this.validateKey(key)
     const payload = await this.runCommand(`get(${this.displayKey(key)})`, () =>
@@ -86,6 +108,9 @@ export class RedisLayer implements CacheLayer {
     return this.deserializeOrDelete(key, payload)
   }
 
+  /**
+   * Reads many raw entries from Redis using a pipeline.
+   */
   async getMany<T>(keys: string[]): Promise<Array<T | null>> {
     if (keys.length === 0) {
       return []
@@ -117,6 +142,9 @@ export class RedisLayer implements CacheLayer {
     )
   }
 
+  /**
+   * Writes many entries to Redis using a pipeline.
+   */
   async setMany(entries: CacheLayerSetManyEntry[]): Promise<void> {
     if (entries.length === 0) {
       return
@@ -141,6 +169,9 @@ export class RedisLayer implements CacheLayer {
     await this.runCommand(`mset(${entries.length})`, () => pipeline.exec())
   }
 
+  /**
+   * Stores a value in Redis using the provided TTL or layer default TTL.
+   */
   async set(key: string, value: unknown, ttl = this.defaultTtl): Promise<void> {
     this.validateKey(key)
     const serialized = this.primarySerializer().serialize(value)
@@ -157,11 +188,17 @@ export class RedisLayer implements CacheLayer {
     await this.runCommand(`set(${this.displayKey(key)})`, () => this.client.set(normalizedKey, payload as never))
   }
 
+  /**
+   * Deletes a key from Redis.
+   */
   async delete(key: string): Promise<void> {
     this.validateKey(key)
     await this.runCommand(`delete(${this.displayKey(key)})`, () => this.client.del(this.withPrefix(key)))
   }
 
+  /**
+   * Deletes multiple keys from Redis in batches.
+   */
   async deleteMany(keys: string[]): Promise<void> {
     if (keys.length === 0) {
       return
@@ -174,12 +211,18 @@ export class RedisLayer implements CacheLayer {
     )
   }
 
+  /**
+   * Returns true when the key exists in Redis.
+   */
   async has(key: string): Promise<boolean> {
     this.validateKey(key)
     const exists = await this.runCommand(`has(${this.displayKey(key)})`, () => this.client.exists(this.withPrefix(key)))
     return exists > 0
   }
 
+  /**
+   * Returns remaining Redis TTL in milliseconds, or null when absent or non-expiring.
+   */
   async ttl(key: string): Promise<number | null> {
     this.validateKey(key)
     const remaining = await this.runCommand(`ttl(${this.displayKey(key)})`, () =>
@@ -192,6 +235,9 @@ export class RedisLayer implements CacheLayer {
     return remaining
   }
 
+  /**
+   * Returns the number of keys under this layer's prefix.
+   */
   async size(): Promise<number> {
     if (!this.prefix) {
       return this.runCommand('dbsize()', () => this.client.dbsize())
@@ -212,6 +258,9 @@ export class RedisLayer implements CacheLayer {
     return count
   }
 
+  /**
+   * Runs a Redis ping command.
+   */
   async ping(): Promise<boolean> {
     try {
       return (await this.runCommand('ping()', () => this.client.ping())) === 'PONG'
@@ -220,6 +269,9 @@ export class RedisLayer implements CacheLayer {
     }
   }
 
+  /**
+   * Disconnects the Redis client when `disconnectOnDispose` is enabled.
+   */
   async dispose(): Promise<void> {
     if (this.disconnectOnDispose) {
       this.client.disconnect()
@@ -258,6 +310,9 @@ export class RedisLayer implements CacheLayer {
     } while (cursor !== '0')
   }
 
+  /**
+   * Returns keys under this layer's prefix without the prefix included.
+   */
   async keys(): Promise<string[]> {
     const pattern = `${this.prefix}*`
     const keys = await this.scanKeys(pattern)
@@ -267,6 +322,9 @@ export class RedisLayer implements CacheLayer {
     return keys.map((key) => key.slice(this.prefix.length))
   }
 
+  /**
+   * Visits keys under this layer's prefix without materializing all results.
+   */
   async forEachKey(visitor: (key: string) => void | Promise<void>): Promise<void> {
     const pattern = `${this.prefix}*`
     let cursor = '0'

--- a/src/serialization/JsonSerializer.ts
+++ b/src/serialization/JsonSerializer.ts
@@ -2,10 +2,16 @@ import { sanitizeStructuredData } from '../internal/StructuredDataSanitizer'
 import type { CacheSerializer } from '../types'
 
 export class JsonSerializer implements CacheSerializer {
+  /**
+   * Serializes a value to JSON.
+   */
   serialize(value: unknown): string {
     return JSON.stringify(value)
   }
 
+  /**
+   * Parses JSON and sanitizes the result before returning it.
+   */
   deserialize<T>(payload: string | Buffer): T {
     const normalized = Buffer.isBuffer(payload) ? payload.toString('utf8') : payload
     let parsed: unknown

--- a/src/serialization/MsgpackSerializer.ts
+++ b/src/serialization/MsgpackSerializer.ts
@@ -3,10 +3,16 @@ import { sanitizeStructuredData } from '../internal/StructuredDataSanitizer'
 import type { CacheSerializer } from '../types'
 
 export class MsgpackSerializer implements CacheSerializer {
+  /**
+   * Serializes a value to MessagePack bytes.
+   */
   serialize(value: unknown): Buffer {
     return Buffer.from(encode(value))
   }
 
+  /**
+   * Decodes MessagePack bytes and sanitizes the result before returning it.
+   */
   deserialize<T>(payload: string | Buffer): T {
     // latin1 preserves byte values 1:1 for binary msgpack payloads stored as strings
     const normalized = Buffer.isBuffer(payload) ? payload : Buffer.from(payload, 'latin1')

--- a/src/singleflight/RedisSingleFlightCoordinator.ts
+++ b/src/singleflight/RedisSingleFlightCoordinator.ts
@@ -3,8 +3,11 @@ import type Redis from 'ioredis'
 import type { CacheSingleFlightCoordinator, CacheSingleFlightExecutionOptions } from '../types'
 
 interface RedisSingleFlightCoordinatorOptions {
+  /** Redis client used for lock acquisition, renewal, and release. */
   client: Redis
+  /** Redis key prefix for single-flight locks. Defaults to `layercache:singleflight`. */
   prefix?: string
+  /** Per-command timeout in milliseconds for Redis operations. */
   commandTimeoutMs?: number
 }
 
@@ -33,6 +36,10 @@ export class RedisSingleFlightCoordinator implements CacheSingleFlightCoordinato
     this.commandTimeoutMs = this.normalizeCommandTimeoutMs(options.commandTimeoutMs)
   }
 
+  /**
+   * Executes `worker` when this process acquires the Redis lock; otherwise runs
+   * `waiter` while another process owns the work.
+   */
   async execute<T>(
     key: string,
     options: CacheSingleFlightExecutionOptions,

--- a/src/stampede/StampedeGuard.ts
+++ b/src/stampede/StampedeGuard.ts
@@ -28,6 +28,9 @@ export class StampedeGuard {
     this.entryTimeoutMs = options.entryTimeoutMs
   }
 
+  /**
+   * Deduplicates concurrent work for the same key in this process.
+   */
   async execute<T>(key: string, task: () => Promise<T>): Promise<T> {
     const existing = this.inFlight.get(key) as InFlightEntry<T> | undefined
     if (existing) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,34 +22,56 @@ export class CacheMissError extends Error {
   }
 }
 
+/** Per-layer millisecond values keyed by each layer's `name`. */
 export interface LayerTtlMap {
+  /** Millisecond value for the named layer, or `undefined` to fall back. */
   [layerName: string]: number | undefined
 }
 
+/** Internal write classification used when resolving TTLs and entry options. */
 export type CacheEntryWriteKind = 'value' | 'empty'
 
+/** Options that describe how a cache entry should be stored. */
 export interface CacheEntryWriteOptions {
+  /** Tags to associate with the key for tag-based invalidation or expiration. */
   tags?: string[]
+  /** Fresh TTL in milliseconds, either uniform or per layer. */
   ttl?: number | LayerTtlMap
+  /** Dynamic TTL policy used instead of, or before falling back to, `ttl`. */
   ttlPolicy?: CacheTtlPolicy
+  /** TTL in milliseconds for cached null/empty results when negative caching is enabled. */
   negativeTtl?: number | LayerTtlMap
+  /** Extra window in milliseconds where stale values are returned while refresh runs in the background. */
   staleWhileRevalidate?: number | LayerTtlMap
+  /** Extra window in milliseconds where stale values are returned if refresh fails. */
   staleIfError?: number | LayerTtlMap
+  /** Random +/- jitter in milliseconds applied to resolved TTLs to avoid synchronized expiry. */
   ttlJitter?: number | LayerTtlMap
+  /** Increase TTL for frequently accessed keys using the adaptive TTL policy. */
   adaptiveTtl?: boolean | CacheAdaptiveTtlOptions
 }
 
+/** Context passed to `contextOptions` before a value is written. */
 export interface CacheContextOptionsContext {
+  /** Fully qualified cache key being written. */
   key: string
+  /** Value returned by the fetcher or passed to `set()`. */
   value: unknown
+  /** Whether the write stores a normal value or an empty/negative-cache marker. */
   kind: CacheEntryWriteKind
 }
 
+/** Options accepted by write operations and read-through fetch writes. */
 export interface CacheWriteOptions extends CacheEntryWriteOptions {
+  /** Cache `null` fetcher results using `negativeTtl` instead of treating them as misses. */
   negativeCache?: boolean
+  /** Extend a key's TTL on fresh reads. */
   slidingTtl?: boolean
+  /** Refresh in the background when the remaining TTL is at or below this threshold in milliseconds. */
   refreshAhead?: number | LayerTtlMap
+  /** Circuit breaker controls for this operation's fetcher. */
   circuitBreaker?: CacheCircuitBreakerOptions
+  /** Rate limit concurrent fetcher execution for this operation. */
   fetcherRateLimit?: CacheRateLimitOptions
   /**
    * Optional predicate called with the fetcher's return value before caching.
@@ -80,35 +102,55 @@ export interface CacheWriteOptions extends CacheEntryWriteOptions {
   contextOptions?: (context: CacheContextOptionsContext) => CacheEntryWriteOptions | undefined
 }
 
+/** Options accepted by read-through `get()` operations. */
 export interface CacheGetOptions extends CacheWriteOptions {}
 
+/** Metadata passed to a read-through fetcher. */
 export interface CacheFetcherContext<T = unknown> {
+  /** Fully qualified cache key being fetched. */
   key: string
+  /** Existing stale value, when a refresh is triggered from stale state. */
   currentValue: T | undefined
+  /** Cache state that caused the fetcher to run. */
   state: 'miss' | 'fresh' | 'stale-while-revalidate' | 'stale-if-error'
+  /** Layer that supplied the existing value, when available. */
   layer?: string
 }
 
+/** Async function used by read-through cache operations to produce a value on miss or refresh. */
 export type CacheFetcher<T = unknown> = (context: CacheFetcherContext<T>) => Promise<T>
 
+/** Entry descriptor for `CacheStack.mget()`. */
 export interface CacheMGetEntry<T> {
+  /** Cache key to read. */
   key: string
+  /** Optional read-through fetcher for this key. */
   fetch?: CacheFetcher<T>
+  /** Per-entry get/write options. */
   options?: CacheGetOptions
 }
 
+/** Entry descriptor for `CacheStack.mset()`. */
 export interface CacheMSetEntry<T> {
+  /** Cache key to write. */
   key: string
+  /** Value to store. */
   value: T
+  /** Per-entry write options. */
   options?: CacheWriteOptions
 }
 
 /** Interface that all cache backend implementations must satisfy. */
 export interface CacheLayer {
+  /** Human-readable unique layer name used for metrics and per-layer options. */
   readonly name: string
+  /** Default TTL in milliseconds used when a write does not provide one. */
   readonly defaultTtl?: number
+  /** Whether the layer is local to this process, such as memory or disk. */
   readonly isLocal?: boolean
+  /** Read and unwrap a fresh value, returning `null` on miss or expiry. */
   get<T>(key: string): Promise<T | null>
+  /** Read the raw stored value or envelope so CacheStack can resolve stale state. */
   getEntry?<T = unknown>(key: string): Promise<T | null>
   /**
    * Bulk read fast-path. Implementations should return raw stored entries using
@@ -116,14 +158,23 @@ export interface CacheLayer {
    * stale windows, and negative-cache markers consistently.
    */
   getMany?<T>(keys: string[]): Promise<Array<T | null>>
+  /** Bulk write entries; implementations may use this as an optimized fast path. */
   setMany?(entries: CacheLayerSetManyEntry[]): Promise<void>
+  /** Store a raw value for `ttl` milliseconds, or without expiry when omitted. */
   set(key: string, value: unknown, ttl?: number): Promise<void>
+  /** Delete a key from this layer. */
   delete(key: string): Promise<void>
+  /** Remove all keys from this layer. */
   clear(): Promise<void>
+  /** Delete several keys from this layer; CacheStack falls back to `delete()` when absent. */
   deleteMany?(keys: string[]): Promise<void>
+  /** Return known keys in this layer for pattern or prefix invalidation. */
   keys?(): Promise<string[]>
+  /** Visit known keys without materializing the full key list. */
   forEachKey?(visitor: (key: string) => void | Promise<void>): Promise<void>
+  /** Health check hook used by `CacheStack.healthCheck()`. */
   ping?(): Promise<boolean>
+  /** Release sockets, timers, or other resources held by the layer. */
   dispose?(): Promise<void>
   /**
    * Returns true if the key exists and has not expired.
@@ -143,8 +194,11 @@ export interface CacheLayer {
   size?(): Promise<number>
 }
 
+/** Serializer used by layers that convert values to bytes or strings. */
 export interface CacheSerializer {
+  /** Convert a value to a storable payload. */
   serialize(value: unknown): string | Buffer
+  /** Restore a value from a payload. */
   deserialize<T>(payload: string | Buffer): T
 }
 
@@ -160,22 +214,39 @@ export interface CacheLayerLatency {
 
 /** Snapshot of cumulative cache counters. */
 export interface CacheMetricsSnapshot {
+  /** Number of successful cache reads. */
   hits: number
+  /** Number of reads that did not find a usable value. */
   misses: number
+  /** Number of fetcher executions. */
   fetches: number
+  /** Number of cache write operations. */
   sets: number
+  /** Number of delete operations. */
   deletes: number
+  /** Number of values backfilled from slower layers into faster layers. */
   backfills: number
+  /** Number of invalidation operations. */
   invalidations: number
+  /** Number of stale values returned to callers. */
   staleHits: number
+  /** Number of background refresh attempts. */
   refreshes: number
+  /** Number of failed refresh attempts. */
   refreshErrors: number
+  /** Number of layer write failures. */
   writeFailures: number
+  /** Number of requests that waited for a single-flight result. */
   singleFlightWaits: number
+  /** Number of cached negative/empty results served. */
   negativeCacheHits: number
+  /** Number of times circuit breakers blocked a fetcher. */
   circuitBreakerTrips: number
+  /** Number of operations skipped or retried due to degraded layers. */
   degradedOperations: number
+  /** Hit counts grouped by layer name. */
   hitsByLayer: Record<string, number>
+  /** Miss counts grouped by layer name. */
   missesByLayer: Record<string, number>
   /** Per-layer read latency statistics (sampled from successful reads). */
   latencyByLayer: Record<string, CacheLayerLatency>
@@ -192,53 +263,87 @@ export interface CacheHitRateSnapshot {
 }
 
 export interface CacheLogger {
+  /** Low-volume diagnostic events. */
   debug?(message: string, context?: Record<string, unknown>): void
+  /** Informational operational messages. */
   info?(message: string, context?: Record<string, unknown>): void
+  /** Recoverable problems or risky configuration warnings. */
   warn?(message: string, context?: Record<string, unknown>): void
+  /** Errors surfaced by cache operations or layer integrations. */
   error?(message: string, context?: Record<string, unknown>): void
 }
 
+/** Index used to map cache keys to tags and discover keys for invalidation. */
 export interface CacheTagIndex {
+  /** Record that a key exists, even when it has no tags. */
   touch(key: string): Promise<void>
+  /** Associate a key with the provided tags, replacing any previous tag set. */
   track(key: string, tags: string[]): Promise<void>
+  /** Remove all tag/index metadata for a key. */
   remove(key: string): Promise<void>
+  /** Return keys currently associated with a tag. */
   keysForTag(tag: string): Promise<string[]>
+  /** Visit keys for a tag without materializing all results. */
   forEachKeyForTag?(tag: string, visitor: (key: string) => void | Promise<void>): Promise<void>
+  /** Return known keys with the given prefix. */
   keysForPrefix?(prefix: string): Promise<string[]>
+  /** Visit known keys with the given prefix without materializing all results. */
   forEachKeyForPrefix?(prefix: string, visitor: (key: string) => void | Promise<void>): Promise<void>
   /** Returns the tags associated with a specific key, or an empty array. */
   tagsForKey?(key: string): Promise<string[]>
+  /** Return known keys matching a wildcard pattern. */
   matchPattern(pattern: string): Promise<string[]>
+  /** Visit known keys matching a wildcard pattern without materializing all results. */
   forEachKeyMatchingPattern?(pattern: string, visitor: (key: string) => void | Promise<void>): Promise<void>
+  /** Remove all index state. */
   clear(): Promise<void>
 }
 
+/** Raw layer bulk-write entry. */
 export interface CacheLayerSetManyEntry {
+  /** Cache key to write. */
   key: string
+  /** Raw value or envelope to store. */
   value: unknown
+  /** TTL in milliseconds for this layer entry. */
   ttl?: number
 }
 
+/** Cross-process invalidation message sent through an `InvalidationBus`. */
 export interface InvalidationMessage {
+  /** Message target scope. */
   scope: 'key' | 'keys' | 'clear'
+  /** Sender instance id; receivers ignore messages from themselves. */
   sourceId: string
+  /** Keys affected by key- or keys-scoped messages. */
   keys?: string[]
+  /** Operation that produced this invalidation. */
   operation?: 'write' | 'delete' | 'invalidate' | 'expire' | 'clear'
 }
 
+/** Pub/sub abstraction used to broadcast invalidation across CacheStack instances. */
 export interface InvalidationBus {
+  /** Register a message handler and return an unsubscribe function. */
   subscribe(handler: (message: InvalidationMessage) => Promise<void> | void): Promise<() => Promise<void> | void>
+  /** Publish an invalidation message to other subscribers. */
   publish(message: InvalidationMessage): Promise<void>
 }
 
+/** Timing controls for a distributed single-flight execution. */
 export interface CacheSingleFlightExecutionOptions {
+  /** Lease duration in milliseconds for the worker lock. */
   leaseMs: number
+  /** Maximum time in milliseconds a waiter should poll for the worker result. */
   waitTimeoutMs: number
+  /** Poll interval in milliseconds for waiters. */
   pollIntervalMs: number
+  /** Optional interval in milliseconds for renewing a worker lock lease. */
   renewIntervalMs?: number
 }
 
+/** Coordinator that deduplicates fetchers across processes. */
 export interface CacheSingleFlightCoordinator {
+  /** Run `worker` when this process wins the lock, otherwise run `waiter`. */
   execute<T>(
     key: string,
     options: CacheSingleFlightExecutionOptions,
@@ -247,43 +352,77 @@ export interface CacheSingleFlightCoordinator {
   ): Promise<T>
 }
 
+/** Global options for a `CacheStack` instance. */
 export interface CacheStackOptions {
+  /** Logger instance, `true` for console debug logging, or `false`/omitted for quiet mode. */
   logger?: CacheLogger | boolean
+  /** Enable metrics collection. Currently metrics are always collected; this is kept for API compatibility. */
   metrics?: boolean
+  /** Deduplicate concurrent local fetches for the same key. */
   stampedePrevention?: boolean
+  /** Maximum number of distinct keys allowed in the local stampede guard. */
   stampedeMaxInFlight?: number
+  /** Timeout in milliseconds for a local stampede-guarded fetch. */
   stampedeEntryTimeoutMs?: number
+  /** Bus used to receive and publish cross-process invalidation messages. */
   invalidationBus?: InvalidationBus
+  /** Tag index implementation used for tag, prefix, and pattern discovery. */
   tagIndex?: CacheTagIndex
+  /** Generation number prefixed onto all keys for instant bulk invalidation. */
   generation?: number
+  /** Enable cleanup for keys from previous generations. */
   generationCleanup?: boolean | CacheGenerationCleanupOptions
+  /** Broadcast writes to other instances so their L1/local layers drop stale values. */
   broadcastL1Invalidation?: boolean
   /**
    * @deprecated Use `broadcastL1Invalidation` instead.
    */
   publishSetInvalidation?: boolean
+  /** Cache null fetcher results as negative entries. */
   negativeCaching?: boolean
+  /** Default negative-cache TTL in milliseconds. */
   negativeTtl?: number | LayerTtlMap
+  /** Default stale-while-revalidate window in milliseconds. */
   staleWhileRevalidate?: number | LayerTtlMap
+  /** Default stale-if-error window in milliseconds. */
   staleIfError?: number | LayerTtlMap
+  /** Default TTL jitter in milliseconds. */
   ttlJitter?: number | LayerTtlMap
+  /** Default refresh-ahead threshold in milliseconds. */
   refreshAhead?: number | LayerTtlMap
+  /** Default adaptive TTL policy. */
   adaptiveTtl?: boolean | CacheAdaptiveTtlOptions
+  /** Default circuit breaker settings for fetchers. */
   circuitBreaker?: CacheCircuitBreakerOptions
+  /** Keep using healthy layers when another layer fails temporarily. */
   gracefulDegradation?: boolean | CacheDegradationOptions
+  /** Write behavior: fail on any layer error (`strict`) or only if all layers fail (`best-effort`). */
   writePolicy?: 'strict' | 'best-effort'
+  /** Write immediately to all layers or queue writes behind the response path. */
   writeStrategy?: 'write-through' | 'write-behind'
+  /** Queue controls used when `writeStrategy` is `write-behind`. */
   writeBehind?: CacheWriteBehindOptions
+  /** Default fetcher rate limit settings. */
   fetcherRateLimit?: CacheRateLimitOptions
+  /** Max milliseconds allowed for background refresh before it is aborted. */
   backgroundRefreshTimeoutMs?: number
+  /** Coordinator used for distributed single-flight fetcher deduplication. */
   singleFlightCoordinator?: CacheSingleFlightCoordinator
+  /** Distributed single-flight lock lease in milliseconds. */
   singleFlightLeaseMs?: number
+  /** Maximum milliseconds waiters poll for distributed single-flight completion. */
   singleFlightTimeoutMs?: number
+  /** Poll interval in milliseconds for distributed single-flight waiters. */
   singleFlightPollMs?: number
+  /** Interval in milliseconds for renewing distributed single-flight leases. */
   singleFlightRenewIntervalMs?: number
+  /** Base directory that constrains snapshot persistence paths, or `false` to disable path sandboxing. */
   snapshotBaseDir?: string | false
+  /** Maximum snapshot file size in bytes accepted during restore, or `false` to disable. */
   snapshotMaxBytes?: number | false
+  /** Maximum number of entries exported or imported in one snapshot, or `false` to disable. */
   snapshotMaxEntries?: number | false
+  /** Maximum keys one invalidation scan may affect, or `false` to disable the guard. */
   invalidationMaxKeys?: number | false
   /**
    * Maximum number of entries in `accessProfiles` and `circuitBreakers` maps
@@ -293,60 +432,92 @@ export interface CacheStackOptions {
   maxProfileEntries?: number
 }
 
+/** Adaptive TTL policy settings for hot keys. */
 export interface CacheAdaptiveTtlOptions {
+  /** Number of accesses after which a key is considered hot. */
   hotAfter?: number
+  /** TTL increment in milliseconds, uniform or per layer. */
   step?: number | LayerTtlMap
+  /** Maximum TTL in milliseconds after adaptive increases. */
   maxTtl?: number | LayerTtlMap
 }
 
+/** Options for pruning keys from older generations. */
 export interface CacheGenerationCleanupOptions {
+  /** Number of old-generation keys to remove per cleanup batch. */
   batchSize?: number
 }
 
+/** Built-in TTL policies or a function that returns a TTL in milliseconds. */
 export type CacheTtlPolicy =
   | 'until-midnight'
   | 'next-hour'
   | { alignTo: number }
   | ((context: CacheTtlPolicyContext) => number | undefined)
 
+/** Context passed to a custom TTL policy. */
 export interface CacheTtlPolicyContext {
+  /** Fully qualified cache key being written. */
   key: string
+  /** Value being written. */
   value: unknown
 }
 
+/** Circuit breaker settings for protecting failing fetchers. */
 export interface CacheCircuitBreakerOptions {
+  /** Consecutive failures before the circuit opens. */
   failureThreshold?: number
+  /** Milliseconds before an open circuit allows another attempt. */
   cooldownMs?: number
 }
 
+/** Graceful degradation settings for temporarily unhealthy layers. */
 export interface CacheDegradationOptions {
+  /** Milliseconds to skip a failed layer before trying it again. */
   retryAfterMs?: number
 }
 
+/** Fetcher concurrency/rate limiting settings. */
 export interface CacheRateLimitOptions {
+  /** Maximum concurrent fetchers allowed in the selected scope. */
   maxConcurrent?: number
+  /** Window size in milliseconds for `maxPerInterval`. */
   intervalMs?: number
+  /** Maximum fetches allowed per interval window. */
   maxPerInterval?: number
+  /** Whether limits apply globally, per cache key, or per fetcher function. */
   scope?: 'global' | 'key' | 'fetcher'
+  /** Custom bucket id used to group otherwise unrelated fetches. */
   bucketKey?: string
 }
 
+/** Queue controls for write-behind mode. */
 export interface CacheWriteBehindOptions {
+  /** Milliseconds between automatic queue flushes. */
   flushIntervalMs?: number
+  /** Maximum entries flushed in one batch. */
   batchSize?: number
+  /** Maximum queued writes before new writes are rejected. */
   maxQueueSize?: number
 }
 
+/** Entry used by `CacheStack.warm()` to pre-populate a key. */
 export interface CacheWarmEntry<T = unknown> {
+  /** Cache key to warm. */
   key: string
+  /** Fetcher used to produce the value. */
   fetcher: CacheFetcher<T>
+  /** Cache options applied while warming this entry. */
   options?: CacheGetOptions
+  /** Higher priority entries are warmed first. */
   priority?: number
 }
 
 /** Options controlling the cache warm-up process. */
 export interface CacheWarmOptions {
+  /** Number of warm fetchers to run concurrently. Defaults to 4. */
   concurrency?: number
+  /** Continue warming remaining entries after an entry fails. */
   continueOnError?: boolean
   /** Called after each entry is processed (success or failure). */
   onProgress?: (progress: CacheWarmProgress) => void
@@ -354,41 +525,64 @@ export interface CacheWarmOptions {
 
 /** Progress information delivered to `CacheWarmOptions.onProgress`. */
 export interface CacheWarmProgress {
+  /** Number of entries processed so far. */
   completed: number
+  /** Total entries scheduled for warming. */
   total: number
+  /** Key that just finished processing. */
   key: string
+  /** Whether the key was warmed successfully. */
   success: boolean
 }
 
+/** Options for `CacheStack.wrap()` and `CacheNamespace.wrap()`. */
 export interface CacheWrapOptions<TArgs extends unknown[] = unknown[]> extends CacheGetOptions {
+  /** Converts wrapper function arguments into a cache key suffix. */
   keyResolver?: (...args: TArgs) => string
 }
 
+/** Entry exported by snapshot APIs. */
 export interface CacheSnapshotEntry {
+  /** Cache key. */
   key: string
+  /** Stored value or envelope. */
   value: unknown
+  /** Remaining TTL in milliseconds, when available. */
   ttl?: number
 }
 
+/** Snapshot of metrics, layer health state, and active background work. */
 export interface CacheStatsSnapshot {
+  /** Current cumulative metrics. */
   metrics: CacheMetricsSnapshot
+  /** Layer-level runtime state. */
   layers: Array<{
+    /** Layer name. */
     name: string
+    /** Whether the layer is local to this process. */
     isLocal: boolean
+    /** Timestamp in milliseconds until which the layer is degraded, or null. */
     degradedUntil: number | null
   }>
+  /** Number of background refreshes currently running. */
   backgroundRefreshes: number
 }
 
+/** Result returned by `CacheStack.healthCheck()`. */
 export interface CacheHealthCheckResult {
+  /** Layer name. */
   layer: string
+  /** Whether the layer responded successfully. */
   healthy: boolean
+  /** Time spent checking this layer in milliseconds. */
   latencyMs: number
+  /** Failure message when `healthy` is false. */
   error?: string
 }
 
 /** Detailed inspection result for a single cache key. */
 export interface CacheInspectResult {
+  /** User-facing cache key. */
   key: string
   /** Layers in which the key is currently stored (not expired). */
   foundInLayers: string[]


### PR DESCRIPTION
## Summary

- Add JSDoc descriptions to public type definitions so TypeScript language server hover/autocomplete can explain methods and options in editors.
- Cover core cache entry options, stack options, metrics/result types, layer interfaces, invalidation interfaces, and public helper/integration option surfaces.
- Add method-level documentation for CacheStack, CacheNamespace, concrete layers, tag indexes, serializers, stampede/single-flight helpers, and integration helpers.

Fixes #39

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [x] Documentation update
- [x] Type definition improvement

## Testing

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm test`
- [x] Verified generated declaration files preserve representative JSDoc comments in `dist/*.d.ts` and `dist/*.d.cts`

## Notes

- This is documentation-only at runtime: no implementation behavior was changed.
