### PR TITLE
Fix caching of non-success HTTP responses

### DIFF
--- a/src/integrations/express.ts
+++ b/src/integrations/express.ts
@@ -85,13 +85,15 @@ export function createExpressCacheMiddleware(cache: CacheStack, options: Express
       if (originalJson) {
         res.json = (body: unknown) => {
           res.setHeader?.('x-cache', 'MISS')
-          // Fire and forget — don't delay the response
-          cache.set(key, body, options).catch((err: unknown) => {
-            cache.emit('error', {
-              operation: 'set',
-              error: err instanceof Error ? err.message : String(err)
+          if (isSuccessfulStatus(res.statusCode)) {
+            // Fire and forget — don't delay the response
+            cache.set(key, body, options).catch((err: unknown) => {
+              cache.emit('error', {
+                operation: 'set',
+                error: err instanceof Error ? err.message : String(err)
+              })
             })
-          })
+          }
           return originalJson(body)
         }
       }
@@ -101,6 +103,10 @@ export function createExpressCacheMiddleware(cache: CacheStack, options: Express
       next(error)
     }
   }
+}
+
+function isSuccessfulStatus(statusCode: number | undefined): boolean {
+  return statusCode === undefined || (statusCode >= 200 && statusCode < 300)
 }
 
 function normalizeUrl(url: string): string {

--- a/src/integrations/hono.ts
+++ b/src/integrations/hono.ts
@@ -59,17 +59,23 @@ export function createHonoCacheMiddleware(cache: CacheStack, options: HonoCacheM
     const originalJson = context.json.bind(context)
     context.json = (body: unknown, status?: number) => {
       context.header?.('x-cache', 'MISS')
-      cache.set(key, body, options).catch((err: unknown) => {
-        cache.emit('error', {
-          operation: 'set',
-          error: err instanceof Error ? err.message : String(err)
+      if (isSuccessfulStatus(status)) {
+        cache.set(key, body, options).catch((err: unknown) => {
+          cache.emit('error', {
+            operation: 'set',
+            error: err instanceof Error ? err.message : String(err)
+          })
         })
-      })
+      }
       return originalJson(body, status)
     }
 
     await next()
   }
+}
+
+function isSuccessfulStatus(statusCode: number | undefined): boolean {
+  return statusCode === undefined || (statusCode >= 200 && statusCode < 300)
 }
 
 function normalizeUrl(url: string): string {

--- a/src/integrations/hono.ts
+++ b/src/integrations/hono.ts
@@ -13,6 +13,7 @@ interface HonoLikeRequest {
 interface HonoLikeContext {
   req: HonoLikeRequest
   header?: (name: string, value: string) => void
+  status?: (status: number) => unknown
   json: (body: unknown, status?: number) => Response | Promise<Response> | unknown
 }
 
@@ -56,10 +57,19 @@ export function createHonoCacheMiddleware(cache: CacheStack, options: HonoCacheM
       return context.json(cached)
     }
 
+    let currentStatus: number | undefined
+    const originalStatus = context.status?.bind(context)
+    if (originalStatus) {
+      context.status = (status: number) => {
+        currentStatus = status
+        return originalStatus(status)
+      }
+    }
+
     const originalJson = context.json.bind(context)
     context.json = (body: unknown, status?: number) => {
       context.header?.('x-cache', 'MISS')
-      if (isSuccessfulStatus(status)) {
+      if (isSuccessfulStatus(status ?? currentStatus)) {
         cache.set(key, body, options).catch((err: unknown) => {
           cache.emit('error', {
             operation: 'set',

--- a/tests/integrations/Integrations.test.ts
+++ b/tests/integrations/Integrations.test.ts
@@ -533,6 +533,38 @@ describe('createExpressCacheMiddleware', () => {
     expect(calls).toBe(1)
   })
 
+  it('does not serve a cached express error response after a later successful response', async () => {
+    const cache = makeCache()
+    const middleware = createExpressCacheMiddleware(cache, { allowPrivateCaching: true })
+    let calls = 0
+
+    const run = async (statusCode: number, body: unknown) => {
+      const json = vi.fn((payload: unknown) => payload)
+      const response = {
+        statusCode,
+        setHeader: vi.fn(),
+        json
+      }
+
+      await middleware({ method: 'GET', url: '/users' }, response, () => {
+        calls += 1
+        response.json(body)
+      })
+      await Promise.resolve()
+
+      return { response, json }
+    }
+
+    const errorResponse = await run(500, { error: 'temporary' })
+    const successResponse = await run(200, { ok: true })
+    const hitResponse = await run(200, { ok: 'cached' })
+
+    expect(errorResponse.json).toHaveBeenCalledWith({ error: 'temporary' })
+    expect(successResponse.json).toHaveBeenCalledWith({ ok: true })
+    expect(hitResponse.json).toHaveBeenCalledWith({ ok: true })
+    expect(calls).toBe(2)
+  })
+
   it('falls back to res.end on cached hits when res.json is unavailable', async () => {
     const cache = makeCache()
     const middleware = createExpressCacheMiddleware(cache, {
@@ -787,6 +819,38 @@ describe('createHonoCacheMiddleware', () => {
     await run()
 
     expect(calls).toBe(1)
+  })
+
+  it('does not serve a cached hono error response after a later successful response', async () => {
+    const cache = makeCache()
+    const middleware = createHonoCacheMiddleware(cache, { allowPrivateCaching: true })
+    let calls = 0
+
+    const run = async (status: number, body: unknown) => {
+      const json = vi.fn((payload: unknown, responseStatus?: number) => ({ body: payload, status: responseStatus }))
+      const context = {
+        req: { method: 'GET', path: '/users' },
+        header: vi.fn(),
+        json
+      }
+
+      const result = await middleware(context, async () => {
+        calls += 1
+        context.json(body, status)
+      })
+      await Promise.resolve()
+
+      return { context, json, result }
+    }
+
+    const errorResponse = await run(500, { error: 'temporary' })
+    const successResponse = await run(200, { ok: true })
+    const hitResponse = await run(200, { ok: 'cached' })
+
+    expect(errorResponse.json).toHaveBeenCalledWith({ error: 'temporary' }, 500)
+    expect(successResponse.json).toHaveBeenCalledWith({ ok: true }, 200)
+    expect(hitResponse.result).toEqual({ body: { ok: true }, status: undefined })
+    expect(calls).toBe(2)
   })
 
   it('defaults hono requests without a method to GET and falls back to req.url when path is missing', async () => {

--- a/tests/integrations/Integrations.test.ts
+++ b/tests/integrations/Integrations.test.ts
@@ -853,6 +853,47 @@ describe('createHonoCacheMiddleware', () => {
     expect(calls).toBe(2)
   })
 
+  it('does not cache a hono error response set through context.status()', async () => {
+    const cache = makeCache()
+    const middleware = createHonoCacheMiddleware(cache, { allowPrivateCaching: true })
+    let calls = 0
+
+    const run = async (status: number, body: unknown) => {
+      let currentStatus: number | undefined
+      const json = vi.fn((payload: unknown, responseStatus?: number) => ({
+        body: payload,
+        status: responseStatus ?? currentStatus
+      }))
+      const context = {
+        req: { method: 'GET', path: '/users' },
+        header: vi.fn(),
+        status: vi.fn((responseStatus: number) => {
+          currentStatus = responseStatus
+          return context
+        }),
+        json
+      }
+
+      const result = await middleware(context, async () => {
+        calls += 1
+        context.status(status)
+        context.json(body)
+      })
+      await Promise.resolve()
+
+      return { context, json, result }
+    }
+
+    const errorResponse = await run(500, { error: 'temporary' })
+    const successResponse = await run(200, { ok: true })
+    const hitResponse = await run(200, { ok: 'cached' })
+
+    expect(errorResponse.json).toHaveBeenCalledWith({ error: 'temporary' }, undefined)
+    expect(successResponse.json).toHaveBeenCalledWith({ ok: true }, undefined)
+    expect(hitResponse.result).toEqual({ body: { ok: true }, status: undefined })
+    expect(calls).toBe(2)
+  })
+
   it('defaults hono requests without a method to GET and falls back to req.url when path is missing', async () => {
     const cache = makeCache()
     await cache.set('GET:/fallback', { ok: true })


### PR DESCRIPTION
## Summary
- Avoid caching Express JSON responses unless the response status is 2xx.
- Avoid caching Hono JSON responses unless the explicit JSON status or `context.status()` value is 2xx.
- Add regression tests proving a 500 response does not poison later successful cache entries, including the Hono `context.status(500); context.json(body)` pattern.

## Test Plan
- npx vitest run tests/integrations/Integrations.test.ts -t "context.status|cached .* error response"
- npx vitest run tests/integrations/Integrations.test.ts
- npm run lint
- npm run build

Closes #44