### PR TITLE
Export public layer option types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,9 +15,11 @@ export { createTrpcCacheMiddleware } from './integrations/trpc'
 export { MemoryLayer } from './layers/MemoryLayer'
 export type { EvictionPolicy, MemoryLayerOptions, MemoryLayerSnapshotEntry } from './layers/MemoryLayer'
 export { RedisLayer } from './layers/RedisLayer'
+export type { CompressionAlgorithm, RedisLayerOptions } from './layers/RedisLayer'
 export { DiskLayer } from './layers/DiskLayer'
+export type { DiskLayerOptions } from './layers/DiskLayer'
 export { MemcachedLayer } from './layers/MemcachedLayer'
-export type { MemcachedClient } from './layers/MemcachedLayer'
+export type { MemcachedClient, MemcachedLayerOptions } from './layers/MemcachedLayer'
 export { JsonSerializer } from './serialization/JsonSerializer'
 export { MsgpackSerializer } from './serialization/MsgpackSerializer'
 export { RedisSingleFlightCoordinator } from './singleflight/RedisSingleFlightCoordinator'
@@ -32,6 +34,7 @@ export {
   type CacheContextOptionsContext,
   type CacheEntryWriteKind,
   type CacheEntryWriteOptions,
+  type CacheGenerationCleanupOptions,
   type CacheDegradationOptions,
   type CacheFetcher,
   type CacheFetcherContext,

--- a/src/layers/DiskLayer.ts
+++ b/src/layers/DiskLayer.ts
@@ -6,7 +6,7 @@ import { unwrapStoredValue } from '../internal/StoredValue'
 import { JsonSerializer } from '../serialization/JsonSerializer'
 import type { CacheLayer, CacheLayerSetManyEntry, CacheSerializer } from '../types'
 
-interface DiskLayerOptions {
+export interface DiskLayerOptions {
   /** Directory where cache entry files are stored. */
   directory: string
   /** Default TTL in milliseconds for writes that do not provide an explicit TTL. */

--- a/src/layers/MemcachedLayer.ts
+++ b/src/layers/MemcachedLayer.ts
@@ -19,7 +19,7 @@ export interface MemcachedClient {
   delete(key: string): Promise<boolean | undefined>
 }
 
-interface MemcachedLayerOptions {
+export interface MemcachedLayerOptions {
   /** Memcached-compatible client implementation. */
   client: MemcachedClient
   /** Default TTL in milliseconds for writes that do not provide an explicit TTL. */

--- a/src/layers/RedisLayer.ts
+++ b/src/layers/RedisLayer.ts
@@ -6,14 +6,14 @@ import { unwrapStoredValue } from '../internal/StoredValue'
 import { JsonSerializer } from '../serialization/JsonSerializer'
 import type { CacheLayer, CacheLayerSetManyEntry, CacheSerializer } from '../types'
 
-type CompressionAlgorithm = 'gzip' | 'brotli'
+export type CompressionAlgorithm = 'gzip' | 'brotli'
 
 const BATCH_DELETE_SIZE = 500
 
 const gzipAsync = promisify(gzip)
 const brotliCompressAsync = promisify(brotliCompress)
 
-interface RedisLayerOptions {
+export interface RedisLayerOptions {
   /** ioredis client used for all Redis commands. */
   client: Redis
   /** Default TTL in milliseconds for writes that do not provide an explicit TTL. */

--- a/tests/publicTypes.test.ts
+++ b/tests/publicTypes.test.ts
@@ -1,0 +1,18 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import type {
+  CacheGenerationCleanupOptions,
+  CompressionAlgorithm,
+  DiskLayerOptions,
+  MemcachedLayerOptions,
+  RedisLayerOptions
+} from '../src'
+
+describe('public type exports', () => {
+  it('exports option types referenced by public constructors and stack options', () => {
+    expectTypeOf<CacheGenerationCleanupOptions>().toMatchTypeOf<{ batchSize?: number }>()
+    expectTypeOf<CompressionAlgorithm>().toEqualTypeOf<'gzip' | 'brotli'>()
+    expectTypeOf<DiskLayerOptions>().toMatchTypeOf<{ directory: string; ttl?: number }>()
+    expectTypeOf<MemcachedLayerOptions>().toHaveProperty('client')
+    expectTypeOf<RedisLayerOptions>().toHaveProperty('client')
+  })
+})


### PR DESCRIPTION
## Summary
- Export public layer constructor option types from their modules and package entrypoint.
- Export CacheGenerationCleanupOptions, which is referenced by CacheStackOptions.generationCleanup.
- Add a public type export regression test for the affected option types.

## Test Plan
- npx vitest run tests/publicTypes.test.ts
- npm run build
- rg -n "CacheGenerationCleanupOptions|DiskLayerOptions|MemcachedLayerOptions|RedisLayerOptions|CompressionAlgorithm" dist/index.d.ts dist/index.d.cts
- npm test
- npm run lint

Follow-up to #41