### PR TITLE
Require Redis TLS in production CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ interface ParsedArgs {
   key?: string
   tagIndexPrefix?: string
   requireTls?: boolean
+  allowPlaintext?: boolean
   force?: boolean
 }
 
@@ -37,6 +38,14 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
       process.stderr.write(
         'Error: --require-tls is set but the URL uses redis:// (plaintext). ' +
           'Use rediss:// for TLS-encrypted connections.\n'
+      )
+      process.exitCode = 1
+      return
+    }
+    if (process.env.NODE_ENV === 'production' && !args.allowPlaintext) {
+      process.stderr.write(
+        'Error: refusing plaintext redis:// connection because NODE_ENV=production. ' +
+          'Use rediss:// for TLS-encrypted connections, or pass --allow-plaintext to explicitly override.\n'
       )
       process.exitCode = 1
       return
@@ -196,6 +205,8 @@ function parseArgs(argv: string[]): ParsedArgs {
       index += 1
     } else if (token === '--require-tls') {
       parsed.requireTls = true
+    } else if (token === '--allow-plaintext') {
+      parsed.allowPlaintext = true
     } else if (token === '--force') {
       parsed.force = true
     }
@@ -247,7 +258,8 @@ function printUsage(): void {
       '  --key <key>                 Exact cache key to inspect\n' +
       '  --tag <tag>                 Invalidate by tag name\n' +
       '  --tag-index-prefix <prefix> Redis key prefix for tag index (default: layercache:tag-index)\n' +
-      '  --require-tls               Reject non-TLS (redis://) connections\n'
+      '  --require-tls               Reject non-TLS (redis://) connections\n' +
+      '  --allow-plaintext          Explicitly allow redis:// when NODE_ENV=production\n'
   )
 }
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -2,11 +2,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // We test the exported `main` function with mocked ioredis
 let connectImpl = async () => undefined
+let connectCalls = 0
 
 vi.mock('ioredis', () => {
   function makeClient() {
     return {
-      connect: async () => connectImpl(),
+      connect: async () => {
+        connectCalls += 1
+        return connectImpl()
+      },
       scan: async () => ['0', ['key:1', 'key:2']],
       del: async () => 2,
       getBuffer: async () => Buffer.from(JSON.stringify({ ok: true })),
@@ -35,9 +39,12 @@ vi.mock('../src/invalidation/RedisTagIndex', () => ({
 describe('CLI — main()', () => {
   let stdoutOutput: string[]
   let stderrOutput: string[]
+  let originalNodeEnv: string | undefined
 
   beforeEach(() => {
     connectImpl = async () => undefined
+    connectCalls = 0
+    originalNodeEnv = process.env.NODE_ENV
     stdoutOutput = []
     stderrOutput = []
     vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
@@ -54,6 +61,7 @@ describe('CLI — main()', () => {
   afterEach(() => {
     vi.restoreAllMocks()
     process.exitCode = undefined
+    process.env.NODE_ENV = originalNodeEnv
   })
 
   it('prints usage and sets exitCode=1 when no arguments', async () => {
@@ -144,5 +152,29 @@ describe('CLI — main()', () => {
     await main(['stats', '--redis', 'redis://localhost:6379'])
     expect(stderrOutput.join('')).toContain('Warning')
     expect(stderrOutput.join('')).toContain('redis://')
+  })
+
+  it('rejects plaintext redis:// in production before connecting', async () => {
+    process.env.NODE_ENV = 'production'
+
+    const { main } = await import('../src/cli')
+    await main(['stats', '--redis', 'redis://localhost:6379'])
+
+    expect(process.exitCode).toBe(1)
+    expect(connectCalls).toBe(0)
+    expect(stderrOutput.join('')).toContain('NODE_ENV=production')
+    expect(stderrOutput.join('')).toContain('--allow-plaintext')
+  })
+
+  it('allows plaintext redis:// in production when explicitly overridden', async () => {
+    process.env.NODE_ENV = 'production'
+
+    const { main } = await import('../src/cli')
+    await main(['stats', '--redis', 'redis://localhost:6379', '--allow-plaintext'])
+
+    expect(process.exitCode).toBeUndefined()
+    expect(connectCalls).toBe(1)
+    expect(stderrOutput.join('')).toContain('Warning')
+    expect(stdoutOutput.join('')).toContain('totalKeys')
   })
 })


### PR DESCRIPTION
## Summary
- Block plaintext redis:// CLI connections by default when NODE_ENV=production.
- Add --allow-plaintext as an explicit production override.
- Add CLI regression tests proving production blocks before connecting unless overridden.

## Test Plan
- npx vitest run tests/cli.test.ts -t "plaintext redis:// in production"
- npx vitest run tests/cli.test.ts
- npm test
- npm run lint
- npm run build

Closes #45