### PR TITLE
Limit CLI Redis scans

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ interface ParsedArgs {
   key?: string
   tagIndexPrefix?: string
   requireTls?: boolean
+  allowPlaintext?: boolean
   force?: boolean
 }
 
@@ -37,6 +38,14 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
       process.stderr.write(
         'Error: --require-tls is set but the URL uses redis:// (plaintext). ' +
           'Use rediss:// for TLS-encrypted connections.\n'
+      )
+      process.exitCode = 1
+      return
+    }
+    if (process.env.NODE_ENV === 'production' && !args.allowPlaintext) {
+      process.stderr.write(
+        'Error: refusing plaintext redis:// connection because NODE_ENV=production. ' +
+          'Use rediss:// for TLS-encrypted connections, or pass --allow-plaintext to explicitly override.\n'
       )
       process.exitCode = 1
       return
@@ -196,6 +205,8 @@ function parseArgs(argv: string[]): ParsedArgs {
       index += 1
     } else if (token === '--require-tls') {
       parsed.requireTls = true
+    } else if (token === '--allow-plaintext') {
+      parsed.allowPlaintext = true
     } else if (token === '--force') {
       parsed.force = true
     }
@@ -247,7 +258,8 @@ function printUsage(): void {
       '  --key <key>                 Exact cache key to inspect\n' +
       '  --tag <tag>                 Invalidate by tag name\n' +
       '  --tag-index-prefix <prefix> Redis key prefix for tag index (default: layercache:tag-index)\n' +
-      '  --require-tls               Reject non-TLS (redis://) connections\n'
+      '  --require-tls               Reject non-TLS (redis://) connections\n' +
+      '  --allow-plaintext          Explicitly allow redis:// when NODE_ENV=production\n'
   )
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,12 +13,16 @@ interface ParsedArgs {
   tag?: string
   key?: string
   tagIndexPrefix?: string
+  scanLimit?: number
   requireTls?: boolean
   force?: boolean
 }
 
 export async function main(argv = process.argv.slice(2)): Promise<void> {
   const args = parseArgs(argv)
+  if (process.exitCode === 1) {
+    return
+  }
   if (!args.command || !args.redisUrl) {
     printUsage()
     process.exitCode = 1
@@ -62,7 +66,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     if (args.command === 'stats') {
       const pattern = args.pattern ?? '*'
       if (args.pattern && !validateCliInput(args.pattern, validatePattern)) return
-      const keys = await scanKeys(redis, pattern)
+      const keys = await scanKeys(redis, pattern, args.scanLimit ?? DEFAULT_SCAN_MAX_KEYS)
       process.stdout.write(`${JSON.stringify({ totalKeys: keys.length, pattern }, null, 2)}\n`)
       return
     }
@@ -70,7 +74,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     if (args.command === 'keys') {
       const pattern = args.pattern ?? '*'
       if (args.pattern && !validateCliInput(args.pattern, validatePattern)) return
-      const keys = await scanKeys(redis, pattern)
+      const keys = await scanKeys(redis, pattern, args.scanLimit ?? DEFAULT_SCAN_MAX_KEYS)
       if (keys.length > 0) {
         process.stdout.write(`${keys.join('\n')}\n`)
       }
@@ -93,7 +97,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
       const effectivePattern = args.pattern ?? '*'
       if (args.pattern && !validateCliInput(args.pattern, validatePattern)) return
 
-      const keys = await scanKeys(redis, effectivePattern)
+      const keys = await scanKeys(redis, effectivePattern, args.scanLimit ?? DEFAULT_SCAN_MAX_KEYS)
 
       // Require --force for untargeted bulk invalidation (default * pattern with no --tag)
       if (!args.pattern && !args.force && keys.length > 0) {
@@ -194,6 +198,20 @@ function parseArgs(argv: string[]): ParsedArgs {
     } else if (token === '--tag-index-prefix') {
       parsed.tagIndexPrefix = value
       index += 1
+    } else if (token === '--limit') {
+      if (!value || value.startsWith('--')) {
+        process.stderr.write('Error: --limit requires a positive integer value.\n')
+        process.exitCode = 1
+        return parsed
+      }
+      const limit = Number(value)
+      if (!Number.isSafeInteger(limit) || limit <= 0) {
+        process.stderr.write('Error: --limit requires a positive integer value.\n')
+        process.exitCode = 1
+        return parsed
+      }
+      parsed.scanLimit = limit
+      index += 1
     } else if (token === '--require-tls') {
       parsed.requireTls = true
     } else if (token === '--force') {
@@ -205,7 +223,7 @@ function parseArgs(argv: string[]): ParsedArgs {
 }
 
 const BATCH_DELETE_SIZE = 500
-const SCAN_MAX_KEYS = 1_000_000
+const DEFAULT_SCAN_MAX_KEYS = 100_000
 
 async function batchDelete(redis: Redis, keys: string[]): Promise<void> {
   for (let i = 0; i < keys.length; i += BATCH_DELETE_SIZE) {
@@ -214,18 +232,17 @@ async function batchDelete(redis: Redis, keys: string[]): Promise<void> {
   }
 }
 
-async function scanKeys(redis: Redis, pattern: string): Promise<string[]> {
+async function scanKeys(redis: Redis, pattern: string, limit: number): Promise<string[]> {
   const keys: string[] = []
   let cursor = '0'
 
   do {
     const [nextCursor, batch] = await redis.scan(cursor, 'MATCH', pattern, 'COUNT', 100)
     cursor = nextCursor
-    keys.push(...batch)
-    if (keys.length >= SCAN_MAX_KEYS) {
-      process.stderr.write(
-        `Warning: stopped scanning after ${SCAN_MAX_KEYS} keys. Use a more specific --pattern to narrow results.\n`
-      )
+    const remaining = limit - keys.length
+    keys.push(...batch.slice(0, remaining))
+    if (keys.length >= limit) {
+      process.stderr.write(`Warning: stopped scanning after ${limit} keys. Use --limit to raise the scan cap.\n`)
       return keys
     }
   } while (cursor !== '0')
@@ -247,6 +264,7 @@ function printUsage(): void {
       '  --key <key>                 Exact cache key to inspect\n' +
       '  --tag <tag>                 Invalidate by tag name\n' +
       '  --tag-index-prefix <prefix> Redis key prefix for tag index (default: layercache:tag-index)\n' +
+      '  --limit <count>             Maximum Redis keys to scan (default: 100000)\n' +
       '  --require-tls               Reject non-TLS (redis://) connections\n'
   )
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,11 +16,13 @@ interface ParsedArgs {
   scanLimit?: number
   requireTls?: boolean
   force?: boolean
+  parseError?: boolean
 }
 
 export async function main(argv = process.argv.slice(2)): Promise<void> {
+  process.exitCode = undefined
   const args = parseArgs(argv)
-  if (process.exitCode === 1) {
+  if (args.parseError) {
     return
   }
   if (!args.command || !args.redisUrl) {
@@ -182,6 +184,7 @@ function parseArgs(argv: string[]): ParsedArgs {
       if (!value || value.startsWith('--')) {
         process.stderr.write('Error: --redis requires a value (e.g. redis://localhost:6379)\n')
         process.exitCode = 1
+        parsed.parseError = true
         return parsed
       }
       parsed.redisUrl = value
@@ -202,12 +205,14 @@ function parseArgs(argv: string[]): ParsedArgs {
       if (!value || value.startsWith('--')) {
         process.stderr.write('Error: --limit requires a positive integer value.\n')
         process.exitCode = 1
+        parsed.parseError = true
         return parsed
       }
       const limit = Number(value)
       if (!Number.isSafeInteger(limit) || limit <= 0) {
         process.stderr.write('Error: --limit requires a positive integer value.\n')
         process.exitCode = 1
+        parsed.parseError = true
         return parsed
       }
       parsed.scanLimit = limit

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -179,4 +179,19 @@ describe('CLI — main()', () => {
     expect(output).toContain('"totalKeys": 3')
     expect(stderrOutput.join('')).toContain('stopped scanning after 3 keys')
   })
+
+  it('does not let one parse error block a later exported main() call', async () => {
+    const { main } = await import('../src/cli')
+
+    await main(['stats', '--redis', 'redis://localhost:6379', '--limit', 'nope'])
+    expect(process.exitCode).toBe(1)
+
+    stdoutOutput = []
+    stderrOutput = []
+    await main(['stats', '--redis', 'redis://localhost:6379', '--limit', '2'])
+
+    expect(process.exitCode).toBeUndefined()
+    expect(stdoutOutput.join('')).toContain('"totalKeys": 2')
+    expect(stderrOutput.join('')).toContain('stopped scanning after 2 keys')
+  })
 })

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -2,11 +2,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // We test the exported `main` function with mocked ioredis
 let connectImpl = async () => undefined
+let connectCalls = 0
 
 vi.mock('ioredis', () => {
   function makeClient() {
     return {
-      connect: async () => connectImpl(),
+      connect: async () => {
+        connectCalls += 1
+        return connectImpl()
+      },
       scan: async () => ['0', ['key:1', 'key:2']],
       del: async () => 2,
       getBuffer: async () => Buffer.from(JSON.stringify({ ok: true })),
@@ -35,9 +39,12 @@ vi.mock('../src/invalidation/RedisTagIndex', () => ({
 describe('CLI — main()', () => {
   let stdoutOutput: string[]
   let stderrOutput: string[]
+  let originalNodeEnv: string | undefined
 
   beforeEach(() => {
     connectImpl = async () => undefined
+    connectCalls = 0
+    originalNodeEnv = process.env.NODE_ENV
     stdoutOutput = []
     stderrOutput = []
     vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
@@ -54,6 +61,7 @@ describe('CLI — main()', () => {
   afterEach(() => {
     vi.restoreAllMocks()
     process.exitCode = undefined
+    process.env.NODE_ENV = originalNodeEnv
   })
 
   it('prints usage and sets exitCode=1 when no arguments', async () => {
@@ -144,5 +152,29 @@ describe('CLI — main()', () => {
     await main(['stats', '--redis', 'redis://localhost:6379'])
     expect(stderrOutput.join('')).toContain('Warning')
     expect(stderrOutput.join('')).toContain('redis://')
+  })
+
+  it('rejects plaintext redis:// in production before connecting', async () => {
+    process.env.NODE_ENV = 'production'
+
+    const { main } = await import('../src/cli')
+    await main(['stats', '--redis', 'redis://localhost:6379'])
+
+    expect(process.exitCode).toBe(1)
+    expect(connectCalls).toBe(0)
+    expect(stderrOutput.join('')).toContain('NODE_ENV=production')
+    expect(stderrOutput.join('')).toContain('--allow-plaintext')
+  })
+
+  it('allows plaintext redis:// in production when explicitly overridden', async () => {
+    process.env.NODE_ENV = 'production'
+
+    const { main } = await import('../src/cli')
+    await main(['stats', '--redis', 'redis://localhost:6379', '--allow-plaintext'])
+
+    expect(process.exitCode).toBeUndefined()
+    expect(connectCalls).toBe(1)
+    expect(stderrOutput.join('')).toContain('Warning')
+    expect(stdoutOutput.join('')).toContain('totalKeys')
   })
 })

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -2,12 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // We test the exported `main` function with mocked ioredis
 let connectImpl = async () => undefined
+let scanImpl = async () => ['0', ['key:1', 'key:2']] as [string, string[]]
 
 vi.mock('ioredis', () => {
   function makeClient() {
     return {
       connect: async () => connectImpl(),
-      scan: async () => ['0', ['key:1', 'key:2']],
+      scan: async () => scanImpl(),
       del: async () => 2,
       getBuffer: async () => Buffer.from(JSON.stringify({ ok: true })),
       ttl: async () => 42,
@@ -38,6 +39,7 @@ describe('CLI — main()', () => {
 
   beforeEach(() => {
     connectImpl = async () => undefined
+    scanImpl = async () => ['0', ['key:1', 'key:2']]
     stdoutOutput = []
     stderrOutput = []
     vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
@@ -144,5 +146,37 @@ describe('CLI — main()', () => {
     await main(['stats', '--redis', 'redis://localhost:6379'])
     expect(stderrOutput.join('')).toContain('Warning')
     expect(stderrOutput.join('')).toContain('redis://')
+  })
+
+  it('limits Redis scans to 100000 keys by default and warns when truncated', async () => {
+    const firstBatch = Array.from({ length: 60_000 }, (_, index) => `key:${index}`)
+    const secondBatch = Array.from({ length: 60_000 }, (_, index) => `key:${index + firstBatch.length}`)
+    let scanCalls = 0
+    scanImpl = async () => {
+      scanCalls += 1
+      return scanCalls === 1 ? ['1', firstBatch] : ['0', secondBatch]
+    }
+
+    const { main } = await import('../src/cli')
+    await main(['stats', '--redis', 'redis://localhost:6379'])
+
+    const output = stdoutOutput.join('')
+    expect(output).toContain('"totalKeys": 100000')
+    expect(stderrOutput.join('')).toContain('stopped scanning after 100000 keys')
+  })
+
+  it('supports a custom Redis scan limit', async () => {
+    let scanCalls = 0
+    scanImpl = async () => {
+      scanCalls += 1
+      return scanCalls === 1 ? ['1', ['key:1', 'key:2']] : ['0', ['key:3', 'key:4']]
+    }
+
+    const { main } = await import('../src/cli')
+    await main(['stats', '--redis', 'redis://localhost:6379', '--limit', '3'])
+
+    const output = stdoutOutput.join('')
+    expect(output).toContain('"totalKeys": 3')
+    expect(stderrOutput.join('')).toContain('stopped scanning after 3 keys')
   })
 })


### PR DESCRIPTION
## Summary
- Lower the CLI Redis scan default cap from 1,000,000 keys to 100,000 keys.
- Add --limit so operators can explicitly choose a larger or smaller scan cap.
- Truncate oversized scan batches to the configured cap and warn when scanning stops early.
- Avoid using stale global `process.exitCode` as parse state across exported `main()` calls.

## Test Plan
- npx vitest run tests/cli.test.ts -t "parse error|Redis scan"
- npx vitest run tests/cli.test.ts
- npm run lint
- npm run build

Closes #46