### PR TITLE
Filter sensitive HTTP cache key query params

### DIFF
--- a/docs-web/content/docs/integrations.mdx
+++ b/docs-web/content/docs/integrations.mdx
@@ -65,7 +65,7 @@ app.get('/api/users/:id',
 - `methods` - HTTP methods to cache (default: `['GET']`)
 - `ttl` - Time-to-live in milliseconds
 - `tags` - Tags for invalidation
-- `allowPrivateCaching` - Allow implicit URL-based keys (default: false)
+- `allowPrivateCaching` - Allow implicit URL-based keys (default: false). Implicit URL keys omit common sensitive query parameters such as `token`, `api_key`, `code`, `session`, and `private_key`; upgrading can therefore cause cache misses for older entries that included those parameters.
 
 ### Response Headers
 

--- a/src/integrations/express.ts
+++ b/src/integrations/express.ts
@@ -1,5 +1,6 @@
 import type { CacheStack } from '../CacheStack'
 import type { CacheGetOptions } from '../types'
+import { normalizeHttpCacheUrl } from './httpCacheKeys'
 
 interface ExpressLikeRequest {
   method?: string
@@ -19,22 +20,6 @@ interface ExpressLikeResponse {
 }
 
 type NextFunction = (error?: unknown) => void
-
-const SENSITIVE_QUERY_PARAMETERS = new Set([
-  'access_token',
-  'auth',
-  'authorization',
-  'code',
-  'id_token',
-  'jwt',
-  'password',
-  'refresh_token',
-  'secret',
-  'session',
-  'sessionid',
-  'session_id',
-  'token'
-])
 
 interface ExpressCacheMiddlewareOptions extends CacheGetOptions {
   /**
@@ -82,7 +67,7 @@ export function createExpressCacheMiddleware(cache: CacheStack, options: Express
       }
 
       const rawUrl = req.originalUrl ?? req.url ?? '/'
-      const key = options.keyResolver ? options.keyResolver(req) : `${method}:${normalizeUrl(rawUrl)}`
+      const key = options.keyResolver ? options.keyResolver(req) : `${method}:${normalizeHttpCacheUrl(rawUrl)}`
 
       const cached = await cache.get<unknown>(key, undefined, options)
       if (cached !== null) {
@@ -116,20 +101,5 @@ export function createExpressCacheMiddleware(cache: CacheStack, options: Express
     } catch (error) {
       next(error)
     }
-  }
-}
-
-function normalizeUrl(url: string): string {
-  try {
-    const parsed = new URL(url, 'http://localhost')
-    for (const name of [...parsed.searchParams.keys()]) {
-      if (SENSITIVE_QUERY_PARAMETERS.has(name.toLowerCase())) {
-        parsed.searchParams.delete(name)
-      }
-    }
-    parsed.searchParams.sort()
-    return parsed.pathname + parsed.search
-  } catch {
-    return url
   }
 }

--- a/src/integrations/express.ts
+++ b/src/integrations/express.ts
@@ -20,6 +20,22 @@ interface ExpressLikeResponse {
 
 type NextFunction = (error?: unknown) => void
 
+const SENSITIVE_QUERY_PARAMETERS = new Set([
+  'access_token',
+  'auth',
+  'authorization',
+  'code',
+  'id_token',
+  'jwt',
+  'password',
+  'refresh_token',
+  'secret',
+  'session',
+  'sessionid',
+  'session_id',
+  'token'
+])
+
 interface ExpressCacheMiddlewareOptions extends CacheGetOptions {
   /**
    * Resolves a cache key from the incoming request. Defaults to
@@ -106,6 +122,11 @@ export function createExpressCacheMiddleware(cache: CacheStack, options: Express
 function normalizeUrl(url: string): string {
   try {
     const parsed = new URL(url, 'http://localhost')
+    for (const name of [...parsed.searchParams.keys()]) {
+      if (SENSITIVE_QUERY_PARAMETERS.has(name.toLowerCase())) {
+        parsed.searchParams.delete(name)
+      }
+    }
     parsed.searchParams.sort()
     return parsed.pathname + parsed.search
   } catch {

--- a/src/integrations/express.ts
+++ b/src/integrations/express.ts
@@ -85,13 +85,15 @@ export function createExpressCacheMiddleware(cache: CacheStack, options: Express
       if (originalJson) {
         res.json = (body: unknown) => {
           res.setHeader?.('x-cache', 'MISS')
-          // Fire and forget — don't delay the response
-          cache.set(key, body, options).catch((err: unknown) => {
-            cache.emit('error', {
-              operation: 'set',
-              error: err instanceof Error ? err.message : String(err)
+          if (isSuccessfulStatus(res.statusCode)) {
+            // Fire and forget — don't delay the response
+            cache.set(key, body, options).catch((err: unknown) => {
+              cache.emit('error', {
+                operation: 'set',
+                error: err instanceof Error ? err.message : String(err)
+              })
             })
-          })
+          }
           return originalJson(body)
         }
       }
@@ -101,6 +103,10 @@ export function createExpressCacheMiddleware(cache: CacheStack, options: Express
       next(error)
     }
   }
+}
+
+function isSuccessfulStatus(statusCode: number | undefined): boolean {
+  return statusCode === undefined || (statusCode >= 200 && statusCode < 300)
 }
 
 function normalizeUrl(url: string): string {

--- a/src/integrations/hono.ts
+++ b/src/integrations/hono.ts
@@ -59,17 +59,23 @@ export function createHonoCacheMiddleware(cache: CacheStack, options: HonoCacheM
     const originalJson = context.json.bind(context)
     context.json = (body: unknown, status?: number) => {
       context.header?.('x-cache', 'MISS')
-      cache.set(key, body, options).catch((err: unknown) => {
-        cache.emit('error', {
-          operation: 'set',
-          error: err instanceof Error ? err.message : String(err)
+      if (isSuccessfulStatus(status)) {
+        cache.set(key, body, options).catch((err: unknown) => {
+          cache.emit('error', {
+            operation: 'set',
+            error: err instanceof Error ? err.message : String(err)
+          })
         })
-      })
+      }
       return originalJson(body, status)
     }
 
     await next()
   }
+}
+
+function isSuccessfulStatus(statusCode: number | undefined): boolean {
+  return statusCode === undefined || (statusCode >= 200 && statusCode < 300)
 }
 
 function normalizeUrl(url: string): string {

--- a/src/integrations/hono.ts
+++ b/src/integrations/hono.ts
@@ -1,6 +1,22 @@
 import type { CacheStack } from '../CacheStack'
 import type { CacheGetOptions } from '../types'
 
+const SENSITIVE_QUERY_PARAMETERS = new Set([
+  'access_token',
+  'auth',
+  'authorization',
+  'code',
+  'id_token',
+  'jwt',
+  'password',
+  'refresh_token',
+  'secret',
+  'session',
+  'sessionid',
+  'session_id',
+  'token'
+])
+
 interface HonoLikeRequest {
   method?: string
   url?: string
@@ -75,6 +91,11 @@ export function createHonoCacheMiddleware(cache: CacheStack, options: HonoCacheM
 function normalizeUrl(url: string): string {
   try {
     const parsed = new URL(url, 'http://localhost')
+    for (const name of [...parsed.searchParams.keys()]) {
+      if (SENSITIVE_QUERY_PARAMETERS.has(name.toLowerCase())) {
+        parsed.searchParams.delete(name)
+      }
+    }
     parsed.searchParams.sort()
     return parsed.pathname + parsed.search
   } catch {

--- a/src/integrations/hono.ts
+++ b/src/integrations/hono.ts
@@ -1,21 +1,6 @@
 import type { CacheStack } from '../CacheStack'
 import type { CacheGetOptions } from '../types'
-
-const SENSITIVE_QUERY_PARAMETERS = new Set([
-  'access_token',
-  'auth',
-  'authorization',
-  'code',
-  'id_token',
-  'jwt',
-  'password',
-  'refresh_token',
-  'secret',
-  'session',
-  'sessionid',
-  'session_id',
-  'token'
-])
+import { normalizeHttpCacheUrl } from './httpCacheKeys'
 
 interface HonoLikeRequest {
   method?: string
@@ -63,7 +48,7 @@ export function createHonoCacheMiddleware(cache: CacheStack, options: HonoCacheM
     }
 
     const rawPath = context.req.path ?? context.req.url ?? '/'
-    const key = options.keyResolver ? options.keyResolver(context.req) : `${method}:${normalizeUrl(rawPath)}`
+    const key = options.keyResolver ? options.keyResolver(context.req) : `${method}:${normalizeHttpCacheUrl(rawPath)}`
 
     const cached = await cache.get(key, undefined, options)
     if (cached !== null) {
@@ -85,20 +70,5 @@ export function createHonoCacheMiddleware(cache: CacheStack, options: HonoCacheM
     }
 
     await next()
-  }
-}
-
-function normalizeUrl(url: string): string {
-  try {
-    const parsed = new URL(url, 'http://localhost')
-    for (const name of [...parsed.searchParams.keys()]) {
-      if (SENSITIVE_QUERY_PARAMETERS.has(name.toLowerCase())) {
-        parsed.searchParams.delete(name)
-      }
-    }
-    parsed.searchParams.sort()
-    return parsed.pathname + parsed.search
-  } catch {
-    return url
   }
 }

--- a/src/integrations/hono.ts
+++ b/src/integrations/hono.ts
@@ -13,6 +13,7 @@ interface HonoLikeRequest {
 interface HonoLikeContext {
   req: HonoLikeRequest
   header?: (name: string, value: string) => void
+  status?: (status: number) => unknown
   json: (body: unknown, status?: number) => Response | Promise<Response> | unknown
 }
 
@@ -56,10 +57,19 @@ export function createHonoCacheMiddleware(cache: CacheStack, options: HonoCacheM
       return context.json(cached)
     }
 
+    let currentStatus: number | undefined
+    const originalStatus = context.status?.bind(context)
+    if (originalStatus) {
+      context.status = (status: number) => {
+        currentStatus = status
+        return originalStatus(status)
+      }
+    }
+
     const originalJson = context.json.bind(context)
     context.json = (body: unknown, status?: number) => {
       context.header?.('x-cache', 'MISS')
-      if (isSuccessfulStatus(status)) {
+      if (isSuccessfulStatus(status ?? currentStatus)) {
         cache.set(key, body, options).catch((err: unknown) => {
           cache.emit('error', {
             operation: 'set',

--- a/src/integrations/httpCacheKeys.ts
+++ b/src/integrations/httpCacheKeys.ts
@@ -1,0 +1,34 @@
+const SENSITIVE_QUERY_PARAMETERS = new Set([
+  'access_token',
+  'api_key',
+  'apikey',
+  'auth',
+  'authorization',
+  'code',
+  'credentials',
+  'id_token',
+  'jwt',
+  'password',
+  'private_key',
+  'refresh_token',
+  'secret',
+  'session',
+  'sessionid',
+  'session_id',
+  'token'
+])
+
+export function normalizeHttpCacheUrl(url: string): string {
+  try {
+    const parsed = new URL(url, 'http://localhost')
+    for (const name of [...parsed.searchParams.keys()]) {
+      if (SENSITIVE_QUERY_PARAMETERS.has(name.toLowerCase())) {
+        parsed.searchParams.delete(name)
+      }
+    }
+    parsed.searchParams.sort()
+    return parsed.pathname + parsed.search
+  } catch {
+    return url
+  }
+}

--- a/tests/integrations/Integrations.test.ts
+++ b/tests/integrations/Integrations.test.ts
@@ -533,6 +533,38 @@ describe('createExpressCacheMiddleware', () => {
     expect(calls).toBe(1)
   })
 
+  it('does not serve a cached express error response after a later successful response', async () => {
+    const cache = makeCache()
+    const middleware = createExpressCacheMiddleware(cache, { allowPrivateCaching: true })
+    let calls = 0
+
+    const run = async (statusCode: number, body: unknown) => {
+      const json = vi.fn((payload: unknown) => payload)
+      const response = {
+        statusCode,
+        setHeader: vi.fn(),
+        json
+      }
+
+      await middleware({ method: 'GET', url: '/users' }, response, () => {
+        calls += 1
+        response.json(body)
+      })
+      await Promise.resolve()
+
+      return { response, json }
+    }
+
+    const errorResponse = await run(500, { error: 'temporary' })
+    const successResponse = await run(200, { ok: true })
+    const hitResponse = await run(200, { ok: 'cached' })
+
+    expect(errorResponse.json).toHaveBeenCalledWith({ error: 'temporary' })
+    expect(successResponse.json).toHaveBeenCalledWith({ ok: true })
+    expect(hitResponse.json).toHaveBeenCalledWith({ ok: true })
+    expect(calls).toBe(2)
+  })
+
   it('falls back to res.end on cached hits when res.json is unavailable', async () => {
     const cache = makeCache()
     const middleware = createExpressCacheMiddleware(cache, {
@@ -787,6 +819,38 @@ describe('createHonoCacheMiddleware', () => {
     await run()
 
     expect(calls).toBe(1)
+  })
+
+  it('does not serve a cached hono error response after a later successful response', async () => {
+    const cache = makeCache()
+    const middleware = createHonoCacheMiddleware(cache, { allowPrivateCaching: true })
+    let calls = 0
+
+    const run = async (status: number, body: unknown) => {
+      const json = vi.fn((payload: unknown, responseStatus?: number) => ({ body: payload, status: responseStatus }))
+      const context = {
+        req: { method: 'GET', path: '/users' },
+        header: vi.fn(),
+        json
+      }
+
+      const result = await middleware(context, async () => {
+        calls += 1
+        context.json(body, status)
+      })
+      await Promise.resolve()
+
+      return { context, json, result }
+    }
+
+    const errorResponse = await run(500, { error: 'temporary' })
+    const successResponse = await run(200, { ok: true })
+    const hitResponse = await run(200, { ok: 'cached' })
+
+    expect(errorResponse.json).toHaveBeenCalledWith({ error: 'temporary' }, 500)
+    expect(successResponse.json).toHaveBeenCalledWith({ ok: true }, 200)
+    expect(hitResponse.result).toEqual({ body: { ok: true }, status: undefined })
+    expect(calls).toBe(2)
   })
 
   it('defaults hono requests without a method to GET and falls back to req.url when path is missing', async () => {

--- a/tests/integrations/Integrations.test.ts
+++ b/tests/integrations/Integrations.test.ts
@@ -542,9 +542,16 @@ describe('createExpressCacheMiddleware', () => {
       json: vi.fn((body: unknown) => body)
     }
 
-    await middleware({ method: 'GET', url: '/users?token=secret&b=2&code=oauth&a=1&session=abc' }, response, () => {
-      response.json({ ok: true })
-    })
+    await middleware(
+      {
+        method: 'GET',
+        url: '/users?token=secret&api_key=secret&apikey=secret&private_key=secret&credentials=secret&b=2&code=oauth&a=1&session=abc'
+      },
+      response,
+      () => {
+        response.json({ ok: true })
+      }
+    )
 
     expect(setSpy).toHaveBeenCalledWith('GET:/users?a=1&b=2', { ok: true }, expect.any(Object))
   })
@@ -810,7 +817,10 @@ describe('createHonoCacheMiddleware', () => {
     const setSpy = vi.spyOn(cache, 'set')
     const middleware = createHonoCacheMiddleware(cache, { allowPrivateCaching: true })
     const context = {
-      req: { method: 'GET', path: '/users?token=secret&b=2&code=oauth&a=1&session=abc' },
+      req: {
+        method: 'GET',
+        path: '/users?token=secret&api_key=secret&apikey=secret&private_key=secret&credentials=secret&b=2&code=oauth&a=1&session=abc'
+      },
       header: vi.fn(),
       json: vi.fn((body) => body)
     }

--- a/tests/integrations/Integrations.test.ts
+++ b/tests/integrations/Integrations.test.ts
@@ -533,6 +533,22 @@ describe('createExpressCacheMiddleware', () => {
     expect(calls).toBe(1)
   })
 
+  it('excludes sensitive query parameters from implicit express cache keys', async () => {
+    const cache = makeCache()
+    const setSpy = vi.spyOn(cache, 'set')
+    const middleware = createExpressCacheMiddleware(cache, { allowPrivateCaching: true })
+    const response = {
+      setHeader: vi.fn(),
+      json: vi.fn((body: unknown) => body)
+    }
+
+    await middleware({ method: 'GET', url: '/users?token=secret&b=2&code=oauth&a=1&session=abc' }, response, () => {
+      response.json({ ok: true })
+    })
+
+    expect(setSpy).toHaveBeenCalledWith('GET:/users?a=1&b=2', { ok: true }, expect.any(Object))
+  })
+
   it('falls back to res.end on cached hits when res.json is unavailable', async () => {
     const cache = makeCache()
     const middleware = createExpressCacheMiddleware(cache, {
@@ -787,6 +803,23 @@ describe('createHonoCacheMiddleware', () => {
     await run()
 
     expect(calls).toBe(1)
+  })
+
+  it('excludes sensitive query parameters from implicit hono cache keys', async () => {
+    const cache = makeCache()
+    const setSpy = vi.spyOn(cache, 'set')
+    const middleware = createHonoCacheMiddleware(cache, { allowPrivateCaching: true })
+    const context = {
+      req: { method: 'GET', path: '/users?token=secret&b=2&code=oauth&a=1&session=abc' },
+      header: vi.fn(),
+      json: vi.fn((body) => body)
+    }
+
+    await middleware(context, async () => {
+      context.json({ ok: true })
+    })
+
+    expect(setSpy).toHaveBeenCalledWith('GET:/users?a=1&b=2', { ok: true }, expect.any(Object))
   })
 
   it('defaults hono requests without a method to GET and falls back to req.url when path is missing', async () => {

--- a/tests/integrations/Integrations.test.ts
+++ b/tests/integrations/Integrations.test.ts
@@ -853,6 +853,47 @@ describe('createHonoCacheMiddleware', () => {
     expect(calls).toBe(2)
   })
 
+  it('does not cache a hono error response set through context.status()', async () => {
+    const cache = makeCache()
+    const middleware = createHonoCacheMiddleware(cache, { allowPrivateCaching: true })
+    let calls = 0
+
+    const run = async (status: number, body: unknown) => {
+      let currentStatus: number | undefined
+      const json = vi.fn((payload: unknown, responseStatus?: number) => ({
+        body: payload,
+        status: responseStatus ?? currentStatus
+      }))
+      const context = {
+        req: { method: 'GET', path: '/users' },
+        header: vi.fn(),
+        status: vi.fn((responseStatus: number) => {
+          currentStatus = responseStatus
+          return context
+        }),
+        json
+      }
+
+      const result = await middleware(context, async () => {
+        calls += 1
+        context.status(status)
+        context.json(body)
+      })
+      await Promise.resolve()
+
+      return { context, json, result }
+    }
+
+    const errorResponse = await run(500, { error: 'temporary' })
+    const successResponse = await run(200, { ok: true })
+    const hitResponse = await run(200, { ok: 'cached' })
+
+    expect(errorResponse.json).toHaveBeenCalledWith({ error: 'temporary' }, undefined)
+    expect(successResponse.json).toHaveBeenCalledWith({ ok: true }, undefined)
+    expect(hitResponse.result).toEqual({ body: { ok: true }, status: undefined })
+    expect(calls).toBe(2)
+  })
+
   it('defaults hono requests without a method to GET and falls back to req.url when path is missing', async () => {
     const cache = makeCache()
     await cache.set('GET:/fallback', { ok: true })


### PR DESCRIPTION
## Summary
- Filter sensitive query parameters from default Express implicit URL cache keys.
- Filter sensitive query parameters from default Hono implicit URL cache keys.
- Share the sensitive query filtering helper across Express and Hono.
- Expand the denylist to include `api_key`, `apikey`, `private_key`, and `credentials`.
- Document that this key normalization can cause cache misses for older implicit URL keys containing sensitive parameters.

## Test Plan
- npx vitest run tests/integrations/Integrations.test.ts -t "sensitive query"
- npx vitest run tests/integrations/Integrations.test.ts
- npm run lint
- npm run build

Closes #48