### PR TITLE
Align RedisTagIndex shard default

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ interface ParsedArgs {
   tag?: string
   key?: string
   tagIndexPrefix?: string
+  knownKeysShards?: number
   requireTls?: boolean
   force?: boolean
 }
@@ -108,6 +109,17 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
       return
     }
 
+    if (args.command === 'migrate-tag-index') {
+      const tagIndex = new RedisTagIndex({
+        client: redis,
+        prefix: args.tagIndexPrefix ?? 'layercache:tag-index',
+        knownKeysShards: args.knownKeysShards
+      })
+      const result = await tagIndex.migrateLegacyKnownKeys()
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`)
+      return
+    }
+
     if (args.command === 'inspect') {
       if (!args.key) {
         throw new Error('inspect requires --key <key>.')
@@ -194,6 +206,20 @@ function parseArgs(argv: string[]): ParsedArgs {
     } else if (token === '--tag-index-prefix') {
       parsed.tagIndexPrefix = value
       index += 1
+    } else if (token === '--known-key-shards') {
+      if (!value || value.startsWith('--')) {
+        process.stderr.write('Error: --known-key-shards requires a positive integer value.\n')
+        process.exitCode = 1
+        return parsed
+      }
+      const knownKeysShards = Number(value)
+      if (!Number.isSafeInteger(knownKeysShards) || knownKeysShards <= 0) {
+        process.stderr.write('Error: --known-key-shards requires a positive integer value.\n')
+        process.exitCode = 1
+        return parsed
+      }
+      parsed.knownKeysShards = knownKeysShards
+      index += 1
     } else if (token === '--require-tls') {
       parsed.requireTls = true
     } else if (token === '--force') {
@@ -240,6 +266,7 @@ function printUsage(): void {
       '  layercache keys --redis <url> [--pattern <glob>]\n' +
       '  layercache inspect --redis <url> --key <key>\n' +
       '  layercache invalidate --redis <url> [--pattern <glob> | --tag <tag>] [--tag-index-prefix <prefix>]\n' +
+      '  layercache migrate-tag-index --redis <url> [--tag-index-prefix <prefix>] [--known-key-shards <count>]\n' +
       '\n' +
       'Options:\n' +
       '  --redis <url>               Redis connection URL (e.g. redis://localhost:6379)\n' +
@@ -247,6 +274,7 @@ function printUsage(): void {
       '  --key <key>                 Exact cache key to inspect\n' +
       '  --tag <tag>                 Invalidate by tag name\n' +
       '  --tag-index-prefix <prefix> Redis key prefix for tag index (default: layercache:tag-index)\n' +
+      '  --known-key-shards <count>  Shard count for RedisTagIndex migration (default: 16)\n' +
       '  --require-tls               Reject non-TLS (redis://) connections\n'
   )
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ interface ParsedArgs {
   key?: string
   tagIndexPrefix?: string
   requireTls?: boolean
+  allowPlaintext?: boolean
   force?: boolean
 }
 
@@ -37,6 +38,14 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
       process.stderr.write(
         'Error: --require-tls is set but the URL uses redis:// (plaintext). ' +
           'Use rediss:// for TLS-encrypted connections.\n'
+      )
+      process.exitCode = 1
+      return
+    }
+    if (process.env.NODE_ENV === 'production' && !args.allowPlaintext) {
+      process.stderr.write(
+        'Error: refusing plaintext redis:// connection because NODE_ENV=production. ' +
+          'Use rediss:// for TLS-encrypted connections, or pass --allow-plaintext to explicitly override.\n'
       )
       process.exitCode = 1
       return
@@ -196,6 +205,8 @@ function parseArgs(argv: string[]): ParsedArgs {
       index += 1
     } else if (token === '--require-tls') {
       parsed.requireTls = true
+    } else if (token === '--allow-plaintext') {
+      parsed.allowPlaintext = true
     } else if (token === '--force') {
       parsed.force = true
     }
@@ -247,7 +258,8 @@ function printUsage(): void {
       '  --key <key>                 Exact cache key to inspect\n' +
       '  --tag <tag>                 Invalidate by tag name\n' +
       '  --tag-index-prefix <prefix> Redis key prefix for tag index (default: layercache:tag-index)\n' +
-      '  --require-tls               Reject non-TLS (redis://) connections\n'
+      '  --require-tls               Reject non-TLS (redis://) connections\n' +
+      '  --allow-plaintext          Explicitly allow redis:// when NODE_ENV=production\n'
   )
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,12 +13,16 @@ interface ParsedArgs {
   tag?: string
   key?: string
   tagIndexPrefix?: string
+  scanLimit?: number
   requireTls?: boolean
   force?: boolean
 }
 
 export async function main(argv = process.argv.slice(2)): Promise<void> {
   const args = parseArgs(argv)
+  if (process.exitCode === 1) {
+    return
+  }
   if (!args.command || !args.redisUrl) {
     printUsage()
     process.exitCode = 1
@@ -62,7 +66,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     if (args.command === 'stats') {
       const pattern = args.pattern ?? '*'
       if (args.pattern && !validateCliInput(args.pattern, validatePattern)) return
-      const keys = await scanKeys(redis, pattern)
+      const keys = await scanKeys(redis, pattern, args.scanLimit ?? DEFAULT_SCAN_MAX_KEYS)
       process.stdout.write(`${JSON.stringify({ totalKeys: keys.length, pattern }, null, 2)}\n`)
       return
     }
@@ -70,7 +74,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     if (args.command === 'keys') {
       const pattern = args.pattern ?? '*'
       if (args.pattern && !validateCliInput(args.pattern, validatePattern)) return
-      const keys = await scanKeys(redis, pattern)
+      const keys = await scanKeys(redis, pattern, args.scanLimit ?? DEFAULT_SCAN_MAX_KEYS)
       if (keys.length > 0) {
         process.stdout.write(`${keys.join('\n')}\n`)
       }
@@ -93,7 +97,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
       const effectivePattern = args.pattern ?? '*'
       if (args.pattern && !validateCliInput(args.pattern, validatePattern)) return
 
-      const keys = await scanKeys(redis, effectivePattern)
+      const keys = await scanKeys(redis, effectivePattern, args.scanLimit ?? DEFAULT_SCAN_MAX_KEYS)
 
       // Require --force for untargeted bulk invalidation (default * pattern with no --tag)
       if (!args.pattern && !args.force && keys.length > 0) {
@@ -194,6 +198,20 @@ function parseArgs(argv: string[]): ParsedArgs {
     } else if (token === '--tag-index-prefix') {
       parsed.tagIndexPrefix = value
       index += 1
+    } else if (token === '--limit') {
+      if (!value || value.startsWith('--')) {
+        process.stderr.write('Error: --limit requires a positive integer value.\n')
+        process.exitCode = 1
+        return parsed
+      }
+      const limit = Number(value)
+      if (!Number.isSafeInteger(limit) || limit <= 0) {
+        process.stderr.write('Error: --limit requires a positive integer value.\n')
+        process.exitCode = 1
+        return parsed
+      }
+      parsed.scanLimit = limit
+      index += 1
     } else if (token === '--require-tls') {
       parsed.requireTls = true
     } else if (token === '--force') {
@@ -205,7 +223,7 @@ function parseArgs(argv: string[]): ParsedArgs {
 }
 
 const BATCH_DELETE_SIZE = 500
-const SCAN_MAX_KEYS = 1_000_000
+const DEFAULT_SCAN_MAX_KEYS = 100_000
 
 async function batchDelete(redis: Redis, keys: string[]): Promise<void> {
   for (let i = 0; i < keys.length; i += BATCH_DELETE_SIZE) {
@@ -214,18 +232,17 @@ async function batchDelete(redis: Redis, keys: string[]): Promise<void> {
   }
 }
 
-async function scanKeys(redis: Redis, pattern: string): Promise<string[]> {
+async function scanKeys(redis: Redis, pattern: string, limit: number): Promise<string[]> {
   const keys: string[] = []
   let cursor = '0'
 
   do {
     const [nextCursor, batch] = await redis.scan(cursor, 'MATCH', pattern, 'COUNT', 100)
     cursor = nextCursor
-    keys.push(...batch)
-    if (keys.length >= SCAN_MAX_KEYS) {
-      process.stderr.write(
-        `Warning: stopped scanning after ${SCAN_MAX_KEYS} keys. Use a more specific --pattern to narrow results.\n`
-      )
+    const remaining = limit - keys.length
+    keys.push(...batch.slice(0, remaining))
+    if (keys.length >= limit) {
+      process.stderr.write(`Warning: stopped scanning after ${limit} keys. Use --limit to raise the scan cap.\n`)
       return keys
     }
   } while (cursor !== '0')
@@ -247,6 +264,7 @@ function printUsage(): void {
       '  --key <key>                 Exact cache key to inspect\n' +
       '  --tag <tag>                 Invalidate by tag name\n' +
       '  --tag-index-prefix <prefix> Redis key prefix for tag index (default: layercache:tag-index)\n' +
+      '  --limit <count>             Maximum Redis keys to scan (default: 100000)\n' +
       '  --require-tls               Reject non-TLS (redis://) connections\n'
   )
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,11 +16,13 @@ interface ParsedArgs {
   scanLimit?: number
   requireTls?: boolean
   force?: boolean
+  parseError?: boolean
 }
 
 export async function main(argv = process.argv.slice(2)): Promise<void> {
+  process.exitCode = undefined
   const args = parseArgs(argv)
-  if (process.exitCode === 1) {
+  if (args.parseError) {
     return
   }
   if (!args.command || !args.redisUrl) {
@@ -182,6 +184,7 @@ function parseArgs(argv: string[]): ParsedArgs {
       if (!value || value.startsWith('--')) {
         process.stderr.write('Error: --redis requires a value (e.g. redis://localhost:6379)\n')
         process.exitCode = 1
+        parsed.parseError = true
         return parsed
       }
       parsed.redisUrl = value
@@ -202,12 +205,14 @@ function parseArgs(argv: string[]): ParsedArgs {
       if (!value || value.startsWith('--')) {
         process.stderr.write('Error: --limit requires a positive integer value.\n')
         process.exitCode = 1
+        parsed.parseError = true
         return parsed
       }
       const limit = Number(value)
       if (!Number.isSafeInteger(limit) || limit <= 0) {
         process.stderr.write('Error: --limit requires a positive integer value.\n')
         process.exitCode = 1
+        parsed.parseError = true
         return parsed
       }
       parsed.scanLimit = limit

--- a/src/invalidation/RedisTagIndex.ts
+++ b/src/invalidation/RedisTagIndex.ts
@@ -1,5 +1,5 @@
 import type Redis from 'ioredis'
-import type { CacheTagIndex } from '../types'
+import type { CacheLogger, CacheTagIndex } from '../types'
 import { PatternMatcher } from './PatternMatcher'
 
 const DEFAULT_KNOWN_KEYS_SHARDS = 16
@@ -13,6 +13,12 @@ interface RedisTagIndexOptions {
   scanCount?: number
   /** Number of shards for known-key sets. Defaults to 16. */
   knownKeysShards?: number
+  /** Optional logger for legacy index warnings. */
+  logger?: CacheLogger
+}
+
+interface RedisTagIndexMigrationResult {
+  migratedKeys: number
 }
 
 export class RedisTagIndex implements CacheTagIndex {
@@ -20,12 +26,15 @@ export class RedisTagIndex implements CacheTagIndex {
   private readonly prefix: string
   private readonly scanCount: number
   private readonly knownKeysShards: number
+  private readonly logger?: CacheLogger
+  private warnedLegacyKnownKeys = false
 
   constructor(options: RedisTagIndexOptions) {
     this.client = options.client
     this.prefix = options.prefix ?? 'layercache:tag-index'
     this.scanCount = options.scanCount ?? 100
     this.knownKeysShards = normalizeKnownKeysShards(options.knownKeysShards)
+    this.logger = options.logger
   }
 
   /**
@@ -70,6 +79,9 @@ export class RedisTagIndex implements CacheTagIndex {
     const pipeline = this.client.pipeline()
 
     pipeline.srem(this.knownKeysKeyFor(key), key)
+    if (this.knownKeysShards > 1) {
+      pipeline.srem(this.legacyKnownKeysKey(), key)
+    }
     pipeline.del(keyTagsKey)
 
     for (const tag of existingTags) {
@@ -106,25 +118,8 @@ export class RedisTagIndex implements CacheTagIndex {
    * Returns known keys that start with a prefix.
    */
   async keysForPrefix(prefix: string): Promise<string[]> {
-    const matches: string[] = []
-    for (const knownKeysKey of this.knownKeysKeys()) {
-      let cursor = '0'
-
-      do {
-        const [nextCursor, keys] = await this.client.sscan(knownKeysKey, cursor, 'COUNT', this.scanCount)
-        cursor = nextCursor
-        matches.push(...keys.filter((key) => key.startsWith(prefix)))
-      } while (cursor !== '0')
-    }
-
-    return matches
-  }
-
-  /**
-   * Visits known keys that start with a prefix.
-   */
-  async forEachKeyForPrefix(prefix: string, visitor: (key: string) => void | Promise<void>): Promise<void> {
-    for (const knownKeysKey of this.knownKeysKeys()) {
+    const matches = new Set<string>()
+    for (const knownKeysKey of await this.knownKeysKeysForRead()) {
       let cursor = '0'
 
       do {
@@ -132,6 +127,29 @@ export class RedisTagIndex implements CacheTagIndex {
         cursor = nextCursor
         for (const key of keys) {
           if (key.startsWith(prefix)) {
+            matches.add(key)
+          }
+        }
+      } while (cursor !== '0')
+    }
+
+    return [...matches]
+  }
+
+  /**
+   * Visits known keys that start with a prefix.
+   */
+  async forEachKeyForPrefix(prefix: string, visitor: (key: string) => void | Promise<void>): Promise<void> {
+    const visited = new Set<string>()
+    for (const knownKeysKey of await this.knownKeysKeysForRead()) {
+      let cursor = '0'
+
+      do {
+        const [nextCursor, keys] = await this.client.sscan(knownKeysKey, cursor, 'COUNT', this.scanCount)
+        cursor = nextCursor
+        for (const key of keys) {
+          if (key.startsWith(prefix) && !visited.has(key)) {
+            visited.add(key)
             await visitor(key)
           }
         }
@@ -150,32 +168,8 @@ export class RedisTagIndex implements CacheTagIndex {
    * Returns known keys matching a wildcard pattern.
    */
   async matchPattern(pattern: string): Promise<string[]> {
-    const matches: string[] = []
-    for (const knownKeysKey of this.knownKeysKeys()) {
-      let cursor = '0'
-
-      do {
-        const [nextCursor, keys] = await this.client.sscan(
-          knownKeysKey,
-          cursor,
-          'MATCH',
-          pattern,
-          'COUNT',
-          this.scanCount
-        )
-        cursor = nextCursor
-        matches.push(...keys.filter((key) => PatternMatcher.matches(pattern, key)))
-      } while (cursor !== '0')
-    }
-
-    return matches
-  }
-
-  /**
-   * Visits known keys matching a wildcard pattern.
-   */
-  async forEachKeyMatchingPattern(pattern: string, visitor: (key: string) => void | Promise<void>): Promise<void> {
-    for (const knownKeysKey of this.knownKeysKeys()) {
+    const matches = new Set<string>()
+    for (const knownKeysKey of await this.knownKeysKeysForRead()) {
       let cursor = '0'
 
       do {
@@ -190,6 +184,36 @@ export class RedisTagIndex implements CacheTagIndex {
         cursor = nextCursor
         for (const key of keys) {
           if (PatternMatcher.matches(pattern, key)) {
+            matches.add(key)
+          }
+        }
+      } while (cursor !== '0')
+    }
+
+    return [...matches]
+  }
+
+  /**
+   * Visits known keys matching a wildcard pattern.
+   */
+  async forEachKeyMatchingPattern(pattern: string, visitor: (key: string) => void | Promise<void>): Promise<void> {
+    const visited = new Set<string>()
+    for (const knownKeysKey of await this.knownKeysKeysForRead()) {
+      let cursor = '0'
+
+      do {
+        const [nextCursor, keys] = await this.client.sscan(
+          knownKeysKey,
+          cursor,
+          'MATCH',
+          pattern,
+          'COUNT',
+          this.scanCount
+        )
+        cursor = nextCursor
+        for (const key of keys) {
+          if (PatternMatcher.matches(pattern, key) && !visited.has(key)) {
+            visited.add(key)
             await visitor(key)
           }
         }
@@ -207,6 +231,37 @@ export class RedisTagIndex implements CacheTagIndex {
     }
 
     await this.client.del(...indexKeys)
+  }
+
+  async migrateLegacyKnownKeys(): Promise<RedisTagIndexMigrationResult> {
+    if (this.knownKeysShards === 1) {
+      return { migratedKeys: 0 }
+    }
+
+    const legacyKey = this.legacyKnownKeysKey()
+    let cursor = '0'
+    let migratedKeys = 0
+
+    do {
+      const [nextCursor, keys] = await this.client.sscan(legacyKey, cursor, 'COUNT', this.scanCount)
+      cursor = nextCursor
+      if (keys.length === 0) {
+        continue
+      }
+
+      const pipeline = this.client.pipeline()
+      for (const key of keys) {
+        pipeline.sadd(this.knownKeysKeyFor(key), key)
+      }
+      await pipeline.exec()
+      migratedKeys += keys.length
+    } while (cursor !== '0')
+
+    if (migratedKeys > 0) {
+      await this.client.del(legacyKey)
+    }
+
+    return { migratedKeys }
   }
 
   private async scanIndexKeys(): Promise<string[]> {
@@ -231,12 +286,47 @@ export class RedisTagIndex implements CacheTagIndex {
     return `${this.prefix}:keys:${simpleHash(key) % this.knownKeysShards}`
   }
 
+  private async knownKeysKeysForRead(): Promise<string[]> {
+    if (this.knownKeysShards === 1) {
+      return [this.legacyKnownKeysKey()]
+    }
+
+    const shardedKeys = this.knownKeysKeys()
+    const legacyKey = this.legacyKnownKeysKey()
+    const legacyExists = (await this.client.exists(legacyKey)) > 0
+    if (!legacyExists) {
+      return shardedKeys
+    }
+
+    this.warnLegacyKnownKeys(legacyKey)
+    return [legacyKey, ...shardedKeys]
+  }
+
   private knownKeysKeys(): string[] {
     if (this.knownKeysShards === 1) {
       return [`${this.prefix}:keys`]
     }
 
     return Array.from({ length: this.knownKeysShards }, (_, index) => `${this.prefix}:keys:${index}`)
+  }
+
+  private legacyKnownKeysKey(): string {
+    return `${this.prefix}:keys`
+  }
+
+  private warnLegacyKnownKeys(legacyKey: string): void {
+    if (this.warnedLegacyKnownKeys) {
+      return
+    }
+
+    this.warnedLegacyKnownKeys = true
+    const message =
+      'RedisTagIndex detected a legacy RedisTagIndex known-key set. Run `layercache migrate-tag-index` to migrate keys into the sharded layout.'
+    if (this.logger?.warn) {
+      this.logger.warn(message, { legacyKey, knownKeysShards: this.knownKeysShards })
+      return
+    }
+    console.warn(`[layercache] ${message}`, { legacyKey, knownKeysShards: this.knownKeysShards })
   }
 
   private keyTagsKey(key: string): string {

--- a/src/invalidation/RedisTagIndex.ts
+++ b/src/invalidation/RedisTagIndex.ts
@@ -2,6 +2,8 @@ import type Redis from 'ioredis'
 import type { CacheTagIndex } from '../types'
 import { PatternMatcher } from './PatternMatcher'
 
+const DEFAULT_KNOWN_KEYS_SHARDS = 16
+
 interface RedisTagIndexOptions {
   /** Redis client used for tag and known-key sets. */
   client: Redis
@@ -248,7 +250,7 @@ export class RedisTagIndex implements CacheTagIndex {
 
 function normalizeKnownKeysShards(value: number | undefined): number {
   if (value === undefined) {
-    return 1
+    return DEFAULT_KNOWN_KEYS_SHARDS
   }
 
   if (!Number.isInteger(value) || value <= 0) {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // We test the exported `main` function with mocked ioredis
 let connectImpl = async () => undefined
+let migrateCalls = 0
 
 vi.mock('ioredis', () => {
   function makeClient() {
@@ -27,7 +28,11 @@ vi.mock('ioredis', () => {
 vi.mock('../src/invalidation/RedisTagIndex', () => ({
   RedisTagIndex: function RedisTagIndex() {
     return {
-      keysForTag: async () => ['tag:key:1', 'tag:key:2']
+      keysForTag: async () => ['tag:key:1', 'tag:key:2'],
+      migrateLegacyKnownKeys: async () => {
+        migrateCalls += 1
+        return { migratedKeys: 2 }
+      }
     }
   }
 }))
@@ -38,6 +43,7 @@ describe('CLI — main()', () => {
 
   beforeEach(() => {
     connectImpl = async () => undefined
+    migrateCalls = 0
     stdoutOutput = []
     stderrOutput = []
     vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
@@ -144,5 +150,13 @@ describe('CLI — main()', () => {
     await main(['stats', '--redis', 'redis://localhost:6379'])
     expect(stderrOutput.join('')).toContain('Warning')
     expect(stderrOutput.join('')).toContain('redis://')
+  })
+
+  it('runs RedisTagIndex legacy known-key migrations', async () => {
+    const { main } = await import('../src/cli')
+    await main(['migrate-tag-index', '--redis', 'redis://localhost:6379', '--tag-index-prefix', 'tags:migrate'])
+
+    expect(migrateCalls).toBe(1)
+    expect(stdoutOutput.join('')).toContain('"migratedKeys": 2')
   })
 })

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -179,4 +179,19 @@ describe('CLI — main()', () => {
     expect(output).toContain('"totalKeys": 3')
     expect(stderrOutput.join('')).toContain('stopped scanning after 3 keys')
   })
+
+  it('does not let one parse error block a later exported main() call', async () => {
+    const { main } = await import('../src/cli')
+
+    await main(['stats', '--redis', 'redis://localhost:6379', '--limit', 'nope'])
+    expect(process.exitCode).toBe(1)
+
+    stdoutOutput = []
+    stderrOutput = []
+    await main(['stats', '--redis', 'redis://localhost:6379', '--limit', '2'])
+
+    expect(process.exitCode).toBeUndefined()
+    expect(stdoutOutput.join('')).toContain('"totalKeys": 2')
+    expect(stderrOutput.join('')).toContain('stopped scanning after 2 keys')
+  })
 })

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -2,11 +2,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // We test the exported `main` function with mocked ioredis
 let connectImpl = async () => undefined
+let connectCalls = 0
 
 vi.mock('ioredis', () => {
   function makeClient() {
     return {
-      connect: async () => connectImpl(),
+      connect: async () => {
+        connectCalls += 1
+        return connectImpl()
+      },
       scan: async () => ['0', ['key:1', 'key:2']],
       del: async () => 2,
       getBuffer: async () => Buffer.from(JSON.stringify({ ok: true })),
@@ -35,9 +39,12 @@ vi.mock('../src/invalidation/RedisTagIndex', () => ({
 describe('CLI — main()', () => {
   let stdoutOutput: string[]
   let stderrOutput: string[]
+  let originalNodeEnv: string | undefined
 
   beforeEach(() => {
     connectImpl = async () => undefined
+    connectCalls = 0
+    originalNodeEnv = process.env.NODE_ENV
     stdoutOutput = []
     stderrOutput = []
     vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
@@ -54,6 +61,7 @@ describe('CLI — main()', () => {
   afterEach(() => {
     vi.restoreAllMocks()
     process.exitCode = undefined
+    process.env.NODE_ENV = originalNodeEnv
   })
 
   it('prints usage and sets exitCode=1 when no arguments', async () => {
@@ -144,5 +152,29 @@ describe('CLI — main()', () => {
     await main(['stats', '--redis', 'redis://localhost:6379'])
     expect(stderrOutput.join('')).toContain('Warning')
     expect(stderrOutput.join('')).toContain('redis://')
+  })
+
+  it('rejects plaintext redis:// in production before connecting', async () => {
+    process.env.NODE_ENV = 'production'
+
+    const { main } = await import('../src/cli')
+    await main(['stats', '--redis', 'redis://localhost:6379'])
+
+    expect(process.exitCode).toBe(1)
+    expect(connectCalls).toBe(0)
+    expect(stderrOutput.join('')).toContain('NODE_ENV=production')
+    expect(stderrOutput.join('')).toContain('--allow-plaintext')
+  })
+
+  it('allows plaintext redis:// in production when explicitly overridden', async () => {
+    process.env.NODE_ENV = 'production'
+
+    const { main } = await import('../src/cli')
+    await main(['stats', '--redis', 'redis://localhost:6379', '--allow-plaintext'])
+
+    expect(process.exitCode).toBeUndefined()
+    expect(connectCalls).toBe(1)
+    expect(stderrOutput.join('')).toContain('Warning')
+    expect(stdoutOutput.join('')).toContain('totalKeys')
   })
 })

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -2,12 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // We test the exported `main` function with mocked ioredis
 let connectImpl = async () => undefined
+let scanImpl = async () => ['0', ['key:1', 'key:2']] as [string, string[]]
 
 vi.mock('ioredis', () => {
   function makeClient() {
     return {
       connect: async () => connectImpl(),
-      scan: async () => ['0', ['key:1', 'key:2']],
+      scan: async () => scanImpl(),
       del: async () => 2,
       getBuffer: async () => Buffer.from(JSON.stringify({ ok: true })),
       ttl: async () => 42,
@@ -38,6 +39,7 @@ describe('CLI — main()', () => {
 
   beforeEach(() => {
     connectImpl = async () => undefined
+    scanImpl = async () => ['0', ['key:1', 'key:2']]
     stdoutOutput = []
     stderrOutput = []
     vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
@@ -144,5 +146,37 @@ describe('CLI — main()', () => {
     await main(['stats', '--redis', 'redis://localhost:6379'])
     expect(stderrOutput.join('')).toContain('Warning')
     expect(stderrOutput.join('')).toContain('redis://')
+  })
+
+  it('limits Redis scans to 100000 keys by default and warns when truncated', async () => {
+    const firstBatch = Array.from({ length: 60_000 }, (_, index) => `key:${index}`)
+    const secondBatch = Array.from({ length: 60_000 }, (_, index) => `key:${index + firstBatch.length}`)
+    let scanCalls = 0
+    scanImpl = async () => {
+      scanCalls += 1
+      return scanCalls === 1 ? ['1', firstBatch] : ['0', secondBatch]
+    }
+
+    const { main } = await import('../src/cli')
+    await main(['stats', '--redis', 'redis://localhost:6379'])
+
+    const output = stdoutOutput.join('')
+    expect(output).toContain('"totalKeys": 100000')
+    expect(stderrOutput.join('')).toContain('stopped scanning after 100000 keys')
+  })
+
+  it('supports a custom Redis scan limit', async () => {
+    let scanCalls = 0
+    scanImpl = async () => {
+      scanCalls += 1
+      return scanCalls === 1 ? ['1', ['key:1', 'key:2']] : ['0', ['key:3', 'key:4']]
+    }
+
+    const { main } = await import('../src/cli')
+    await main(['stats', '--redis', 'redis://localhost:6379', '--limit', '3'])
+
+    const output = stdoutOutput.join('')
+    expect(output).toContain('"totalKeys": 3')
+    expect(stderrOutput.join('')).toContain('stopped scanning after 3 keys')
   })
 })

--- a/tests/invalidation/RedisTagIndex.test.ts
+++ b/tests/invalidation/RedisTagIndex.test.ts
@@ -68,6 +68,21 @@ describe('RedisTagIndex', () => {
     await expect(index.keysForPrefix('user:')).resolves.toEqual(['user:1', 'user:2'])
   })
 
+  it('defaults known-key tracking to 16 shards', async () => {
+    const redis = new Redis()
+    const index = new RedisTagIndex({ client: redis, prefix: 'tags:default-shards' })
+
+    await index.touch('user:1')
+    await index.touch('user:2')
+    await index.touch('post:1')
+
+    const indexKeys = await redis.keys('tags:default-shards:keys*')
+
+    expect(indexKeys).toEqual(expect.arrayContaining([expect.stringMatching(/^tags:default-shards:keys:\d+$/)]))
+    expect(indexKeys).not.toContain('tags:default-shards:keys')
+    await expect(index.keysForPrefix('user:')).resolves.toEqual(['user:1', 'user:2'])
+  })
+
   it('supports pattern scans and async visitor helpers', async () => {
     const redis = new Redis()
     const index = new RedisTagIndex({ client: redis, prefix: 'tags:visitors', scanCount: 1 })

--- a/tests/invalidation/RedisTagIndex.test.ts
+++ b/tests/invalidation/RedisTagIndex.test.ts
@@ -1,5 +1,5 @@
 import Redis from 'ioredis-mock'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { RedisTagIndex } from '../../src/invalidation/RedisTagIndex'
 
 describe('RedisTagIndex', () => {
@@ -80,6 +80,32 @@ describe('RedisTagIndex', () => {
 
     expect(indexKeys).toEqual(expect.arrayContaining([expect.stringMatching(/^tags:default-shards:keys:\d+$/)]))
     expect(indexKeys).not.toContain('tags:default-shards:keys')
+    await expect(index.keysForPrefix('user:')).resolves.toEqual(['user:1', 'user:2'])
+  })
+
+  it('reads and warns about legacy unsharded known-key sets after the default shard upgrade', async () => {
+    const redis = new Redis()
+    const logger = { warn: vi.fn() }
+    const index = new RedisTagIndex({ client: redis, prefix: 'tags:legacy', logger })
+
+    await redis.sadd('tags:legacy:keys', 'user:legacy', 'post:legacy')
+    await index.touch('user:sharded')
+
+    await expect(index.keysForPrefix('user:')).resolves.toEqual(expect.arrayContaining(['user:legacy', 'user:sharded']))
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('legacy RedisTagIndex known-key set'),
+      expect.objectContaining({ legacyKey: 'tags:legacy:keys' })
+    )
+  })
+
+  it('migrates legacy known keys into the configured shard layout', async () => {
+    const redis = new Redis()
+    const index = new RedisTagIndex({ client: redis, prefix: 'tags:migrate' })
+
+    await redis.sadd('tags:migrate:keys', 'user:1', 'user:2', 'post:1')
+
+    await expect(index.migrateLegacyKnownKeys()).resolves.toEqual({ migratedKeys: 3 })
+    await expect(redis.smembers('tags:migrate:keys')).resolves.toEqual([])
     await expect(index.keysForPrefix('user:')).resolves.toEqual(['user:1', 'user:2'])
   })
 


### PR DESCRIPTION
## Summary
- Align RedisTagIndex knownKeysShards implementation with the documented default of 16.
- Keep explicit knownKeysShards overrides unchanged.
- Preserve backward compatibility by reading legacy unsharded `:keys` sets and warning when they are detected.
- Add `RedisTagIndex.migrateLegacyKnownKeys()` and `layercache migrate-tag-index` to migrate legacy known keys into the sharded layout.

## Breaking change / migration note
Changing the default from one known-key set to 16 sharded sets changes where newly touched keys are stored. Existing deployments may already have keys in the legacy `<prefix>:keys` set. This PR keeps reading that legacy set to avoid invalidation misses, logs a warning when it is detected, and provides a migration command:

```sh
layercache migrate-tag-index --redis <url> --tag-index-prefix <prefix>
```

After migration, the legacy set is removed and keys are stored in the configured sharded layout.

## Test Plan
- npx vitest run tests/invalidation/RedisTagIndex.test.ts -t "legacy|migrates|defaults known-key"
- npx vitest run tests/cli.test.ts -t "legacy known-key"
- npx vitest run tests/invalidation/RedisTagIndex.test.ts tests/cli.test.ts
- npm run lint
- npm run build

Closes #49