### PR TITLE
Fix TagIndex pruning preserving tag mappings

### DIFF
--- a/src/invalidation/TagIndex.ts
+++ b/src/invalidation/TagIndex.ts
@@ -292,7 +292,7 @@ export class TagIndex implements CacheTagIndex {
     for (let i = 0; i < toRemove && i < sorted.length; i += 1) {
       const entry = sorted[i]
       if (entry) {
-        this.removeKey(entry[0])
+        this.removeKnownKey(entry[0])
       }
     }
   }

--- a/tests/invalidation/TagIndex.test.ts
+++ b/tests/invalidation/TagIndex.test.ts
@@ -2,14 +2,15 @@ import { describe, expect, it } from 'vitest'
 import { TagIndex } from '../../src/invalidation/TagIndex'
 
 describe('TagIndex', () => {
-  it('prunes tag reverse references when known keys are trimmed', async () => {
+  it('keeps tag mappings when known keys are trimmed', async () => {
     const index = new TagIndex({ maxKnownKeys: 2 })
 
     await index.track('user:1', ['users'])
     await index.track('user:2', ['users'])
     await index.track('user:3', ['users'])
 
-    expect(await index.keysForTag('users')).toEqual(['user:2', 'user:3'])
+    expect(await index.keysForTag('users')).toEqual(['user:1', 'user:2', 'user:3'])
+    expect(await index.keysForPrefix('user:')).toEqual(['user:2', 'user:3'])
   })
 
   it('returns prefix matches without scanning unrelated keys', async () => {


### PR DESCRIPTION
Fixes #58. Prunes only the known-key/trie index when maxKnownKeys is exceeded so tag mappings remain valid for tag invalidation. Verification: npx vitest run tests/invalidation/TagIndex.test.ts; npm run lint; npm run build.