### PR TITLE
Reacquire distributed single-flight lock after waiter timeout

### DIFF
--- a/src/internal/CacheStackReader.ts
+++ b/src/internal/CacheStackReader.ts
@@ -373,7 +373,16 @@ export class CacheStackReader {
       await this.options.sleep(pollIntervalMs)
     }
 
-    return this.fetchAndPopulate(key, fetcher, options, expectedClearEpoch, expectedKeyEpoch, fetcherContext)
+    if (!this.options.singleFlightCoordinator) {
+      return this.fetchAndPopulate(key, fetcher, options, expectedClearEpoch, expectedKeyEpoch, fetcherContext)
+    }
+
+    return this.options.singleFlightCoordinator.execute(
+      key,
+      this.resolveSingleFlightOptions(),
+      () => this.fetchAndPopulate(key, fetcher, options, expectedClearEpoch, expectedKeyEpoch, fetcherContext),
+      () => this.waitForFreshValue(key, fetcher, options, expectedClearEpoch, expectedKeyEpoch, fetcherContext)
+    )
   }
 
   private async fetchAndPopulate<T>(

--- a/tests/features/OperationalFeatures.test.ts
+++ b/tests/features/OperationalFeatures.test.ts
@@ -91,14 +91,17 @@ class SharedCoordinator implements CacheSingleFlightCoordinator {
   }
 }
 
-class AlwaysWaitCoordinator implements CacheSingleFlightCoordinator {
+class WaitThenWorkerCoordinator implements CacheSingleFlightCoordinator {
+  calls = 0
+
   async execute<T>(
     _key: string,
     _options: CacheSingleFlightExecutionOptions,
-    _worker: () => Promise<T>,
+    worker: () => Promise<T>,
     waiter: () => Promise<T>
   ): Promise<T> {
-    return waiter()
+    this.calls += 1
+    return this.calls === 1 ? waiter() : worker()
   }
 }
 
@@ -878,14 +881,16 @@ describe('operational features', () => {
 
   it('falls back to fetching after single-flight waiting times out', async () => {
     const fetcher = vi.fn(async () => 'fresh')
+    const coordinator = new WaitThenWorkerCoordinator()
     const cache = new CacheStack([new MemoryLayer({ ttl: 60_000 })], {
-      singleFlightCoordinator: new AlwaysWaitCoordinator(),
+      singleFlightCoordinator: coordinator,
       singleFlightTimeoutMs: 20,
       singleFlightPollMs: 5
     })
 
     await expect(cache.get('user:1', fetcher)).resolves.toBe('fresh')
 
+    expect(coordinator.calls).toBe(2)
     expect(fetcher).toHaveBeenCalledTimes(1)
     expect(cache.getMetrics().singleFlightWaits).toBe(1)
   })

--- a/tests/internal/CacheStackReader.test.ts
+++ b/tests/internal/CacheStackReader.test.ts
@@ -664,17 +664,18 @@ describe('CacheStackReader', () => {
         get: vi.fn(async () => null)
       })
       options.layers = [layer]
+      const execute = vi.fn(
+        async (
+          _key: string,
+          _opts: unknown,
+          worker: () => Promise<string | null>,
+          waiter: () => Promise<string | null>
+        ) => {
+          return execute.mock.calls.length === 1 ? waiter() : worker()
+        }
+      )
       options.singleFlightCoordinator = {
-        execute: vi.fn(
-          async (
-            _key: string,
-            _opts: unknown,
-            worker: () => Promise<string | null>,
-            waiter: () => Promise<string | null>
-          ) => {
-            return waiter()
-          }
-        )
+        execute
       }
       options.singleFlightTimeoutMs = 100
       options.singleFlightPollMs = 50
@@ -686,6 +687,7 @@ describe('CacheStackReader', () => {
 
       const result = await reader.getPrepared('key:1', fetcher)
       expect(result).toBe('timeout-fetch')
+      expect(execute).toHaveBeenCalledTimes(2)
     })
   })
 


### PR DESCRIPTION
Fixes #59. Waiters that time out now re-enter the distributed coordinator so only a lock winner fetches after leader failure instead of every waiter fetching at once. Verification: npx vitest run tests/internal/CacheStackReader.test.ts; npm run lint; npm run build.