### PR TITLE
Avoid sorting on pruning hot paths

### DIFF
--- a/src/internal/CacheStackMaintenance.ts
+++ b/src/internal/CacheStackMaintenance.ts
@@ -61,7 +61,9 @@ export class CacheStackMaintenance {
 
   bumpKeyEpochs(keys: string[]): void {
     for (const key of keys) {
-      this.keyEpochs.set(key, this.currentKeyEpoch(key) + 1)
+      const nextEpoch = this.currentKeyEpoch(key) + 1
+      this.keyEpochs.delete(key)
+      this.keyEpochs.set(key, nextEpoch)
     }
     this.pruneKeyEpochsIfNeeded()
   }
@@ -148,10 +150,13 @@ export class CacheStackMaintenance {
       return
     }
 
-    const sorted = [...this.keyEpochs.entries()].sort((a, b) => a[1] - b[1])
-    const toDelete = Math.ceil(sorted.length * 0.1)
+    const toDelete = Math.ceil(this.keyEpochs.size * 0.1)
     for (let i = 0; i < toDelete; i++) {
-      this.keyEpochs.delete(sorted[i][0])
+      const oldestKey = this.keyEpochs.keys().next().value
+      if (oldestKey === undefined) {
+        break
+      }
+      this.keyEpochs.delete(oldestKey)
     }
   }
 }

--- a/src/internal/TtlResolver.ts
+++ b/src/internal/TtlResolver.ts
@@ -32,6 +32,7 @@ export class TtlResolver {
     const profile = this.accessProfiles.get(key) ?? { hits: 0, lastAccessAt: Date.now() }
     profile.hits += 1
     profile.lastAccessAt = Date.now()
+    this.accessProfiles.delete(key)
     this.accessProfiles.set(key, profile)
     this.pruneIfNeeded()
   }
@@ -164,14 +165,13 @@ export class TtlResolver {
       return
     }
 
-    // Remove least recently accessed 10% of entries
     const toRemove = Math.ceil(this.maxProfileEntries * 0.1)
-    const sorted = [...this.accessProfiles.entries()].sort((a, b) => a[1].lastAccessAt - b[1].lastAccessAt)
-    for (let i = 0; i < toRemove && i < sorted.length; i++) {
-      const entry = sorted[i]
-      if (entry) {
-        this.accessProfiles.delete(entry[0])
+    for (let i = 0; i < toRemove; i++) {
+      const oldestKey = this.accessProfiles.keys().next().value
+      if (oldestKey === undefined) {
+        break
       }
+      this.accessProfiles.delete(oldestKey)
     }
   }
 }

--- a/src/invalidation/TagIndex.ts
+++ b/src/invalidation/TagIndex.ts
@@ -162,6 +162,9 @@ export class TagIndex implements CacheTagIndex {
 
   private insertKnownKey(key: string): void {
     const isNew = !this.knownKeys.has(key)
+    if (!isNew) {
+      this.knownKeys.delete(key)
+    }
     this.knownKeys.set(key, Date.now())
 
     if (!isNew) {
@@ -287,13 +290,13 @@ export class TagIndex implements CacheTagIndex {
       return
     }
 
-    const sorted = [...this.knownKeys.entries()].sort((a, b) => a[1] - b[1])
     const toRemove = Math.ceil(this.maxKnownKeys * 0.1)
-    for (let i = 0; i < toRemove && i < sorted.length; i += 1) {
-      const entry = sorted[i]
-      if (entry) {
-        this.removeKey(entry[0])
+    for (let i = 0; i < toRemove; i += 1) {
+      const oldestKey = this.knownKeys.keys().next().value
+      if (oldestKey === undefined) {
+        break
       }
+      this.removeKey(oldestKey)
     }
   }
 

--- a/tests/internal/CacheStackMaintenance.test.ts
+++ b/tests/internal/CacheStackMaintenance.test.ts
@@ -268,6 +268,21 @@ describe('CacheStackMaintenance', () => {
         expect(keyEpochs.has(`new:${i}`)).toBe(true)
       }
     })
+
+    it('prunes key epochs without sorting the full epoch map', () => {
+      const maintenance = new CacheStackMaintenance()
+      const keyEpochs = (maintenance as unknown as { keyEpochs: Map<string, number> }).keyEpochs
+      const sort = vi.spyOn(Array.prototype, 'sort')
+
+      for (let i = 0; i < 50_001; i++) {
+        keyEpochs.set(`key:${i}`, i)
+      }
+
+      maintenance.bumpKeyEpochs(['trigger'])
+
+      expect(sort).not.toHaveBeenCalled()
+      sort.mockRestore()
+    })
   })
 
   it('starts and stops the write-behind timer only for write-behind mode with a positive interval', async () => {

--- a/tests/internal/TtlResolver.test.ts
+++ b/tests/internal/TtlResolver.test.ts
@@ -187,6 +187,18 @@ describe('TtlResolver', () => {
     }
   })
 
+  it('prunes access profiles without sorting the full profile map', () => {
+    const resolver = new TtlResolver({ maxProfileEntries: 2 })
+    const sort = vi.spyOn(Array.prototype, 'sort')
+
+    resolver.recordAccess('a')
+    resolver.recordAccess('b')
+    resolver.recordAccess('c')
+
+    expect(sort).not.toHaveBeenCalled()
+    sort.mockRestore()
+  })
+
   it('falls back across defaults and exercises function policy branches', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-04-05T10:05:10Z'))

--- a/tests/invalidation/TagIndex.test.ts
+++ b/tests/invalidation/TagIndex.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { TagIndex } from '../../src/invalidation/TagIndex'
 
 describe('TagIndex', () => {
@@ -20,6 +20,18 @@ describe('TagIndex', () => {
     await index.touch('user:2:profile')
 
     expect(await index.keysForPrefix('user:1:')).toEqual(['user:1:profile', 'user:1:posts'])
+  })
+
+  it('prunes known keys without sorting the full index', async () => {
+    const index = new TagIndex({ maxKnownKeys: 2 })
+    const sort = vi.spyOn(Array.prototype, 'sort')
+
+    await index.touch('user:1')
+    await index.touch('user:2')
+    await index.touch('user:3')
+
+    expect(sort).not.toHaveBeenCalled()
+    sort.mockRestore()
   })
 
   it('matches wildcard patterns through the trie-backed known-key index', async () => {


### PR DESCRIPTION
Fixes #60. Converts TagIndex, TtlResolver, and CacheStackMaintenance pruning to Map-order LRU style removal instead of full Map sort-and-slice. Verification: npx vitest run tests/invalidation/TagIndex.test.ts tests/internal/TtlResolver.test.ts tests/internal/CacheStackMaintenance.test.ts; npm run lint; npm run build.