### PR TITLE
Parallelize cache backfill writes

### DIFF
--- a/src/internal/CacheStackReader.ts
+++ b/src/internal/CacheStackReader.ts
@@ -191,6 +191,8 @@ export class CacheStackReader {
       return
     }
 
+    const operations: Array<Promise<void>> = []
+
     for (let index = 0; index <= upToIndex; index += 1) {
       const layer = this.options.layers[index]
       if (!layer || this.options.shouldSkipLayer(layer)) {
@@ -200,16 +202,22 @@ export class CacheStackReader {
       const ttl =
         remainingStoredTtlMs(stored) ??
         this.options.resolveLayerMs(layer.name, options?.ttl, undefined, layer.defaultTtl)
-      try {
-        await layer.set(key, stored, ttl)
-      } catch (error) {
-        await this.options.handleLayerFailure(layer, 'backfill', error)
-        continue
-      }
-      this.options.metricsCollector.increment('backfills')
-      this.options.logger.debug?.('backfill', { key, layer: layer.name })
-      this.options.emit('backfill', { key, layer: layer.name })
+      operations.push(
+        (async () => {
+          try {
+            await layer.set(key, stored, ttl)
+          } catch (error) {
+            await this.options.handleLayerFailure(layer, 'backfill', error)
+            return
+          }
+          this.options.metricsCollector.increment('backfills')
+          this.options.logger.debug?.('backfill', { key, layer: layer.name })
+          this.options.emit('backfill', { key, layer: layer.name })
+        })()
+      )
     }
+
+    await Promise.all(operations)
   }
 
   abortAllRefreshes(): void {

--- a/tests/internal/CacheStackReader.test.ts
+++ b/tests/internal/CacheStackReader.test.ts
@@ -196,6 +196,30 @@ describe('CacheStackReader', () => {
       expect(layer2.set).not.toHaveBeenCalled()
     })
 
+    it('starts eligible backfill writes in parallel', async () => {
+      const { reader, options } = createReader()
+      let releaseLayer0!: () => void
+      const layer0Pending = new Promise<void>((resolve) => {
+        releaseLayer0 = resolve
+      })
+      const layer0 = createMockLayer('L0', {
+        set: vi.fn(async () => {
+          await layer0Pending
+        })
+      })
+      const layer1 = createMockLayer('L1')
+      options.layers = [layer0, layer1]
+
+      const backfill = reader.backfill('key:1', 'stored', 1)
+      await Promise.resolve()
+
+      expect(layer0.set).toHaveBeenCalled()
+      expect(layer1.set).toHaveBeenCalled()
+
+      releaseLayer0()
+      await backfill
+    })
+
     it('handles layer.set error gracefully (calls handleLayerFailure)', async () => {
       const { reader, options } = createReader()
       const error = new Error('set fail')


### PR DESCRIPTION
Fixes #61. Starts eligible upper-layer backfill writes in parallel while preserving per-layer failure handling, metrics, and events. Verification: npx vitest run tests/internal/CacheStackReader.test.ts; npm run lint; npm run build.