### PR TITLE
Document adaptive TTL process-local counters

### DIFF
--- a/docs-web/content/docs/api.mdx
+++ b/docs-web/content/docs/api.mdx
@@ -690,6 +690,10 @@ await cache.get('popular-post', fetchPost, {
 })
 ```
 
+Adaptive TTL counters are process-local. In multi-instance deployments, each
+Node.js process ramps TTLs from its own observed hits, so use explicit TTLs or a
+shared Redis counter when every instance must make the same TTL decision.
+
 ### Refresh-Ahead
 
 ```ts

--- a/docs-web/tests/current-docs-content.test.mjs
+++ b/docs-web/tests/current-docs-content.test.mjs
@@ -42,3 +42,11 @@ test("integration docs describe HTTP cache safety behavior", async () => {
   assert.match(source, /private_key/);
   assert.match(source, /credentials/);
 });
+
+test("API docs describe adaptive TTL process-local counters", async () => {
+  const source = await readDoc("content/docs/api.mdx");
+
+  assert.match(source, /Adaptive TTL counters are process-local/);
+  assert.match(source, /multi-instance deployments/);
+  assert.match(source, /shared Redis counter/);
+});

--- a/docs/api.md
+++ b/docs/api.md
@@ -669,6 +669,10 @@ await cache.get('popular-post', fetchPost, {
 })
 ```
 
+Adaptive TTL counters are process-local. In multi-instance deployments, each
+Node.js process ramps TTLs from its own observed hits, so use explicit TTLs or a
+shared Redis counter when every instance must make the same TTL decision.
+
 ### Refresh-Ahead
 
 ```ts


### PR DESCRIPTION
Fixes #62. Documents that adaptive TTL counters are process-local and calls out multi-instance guidance to use explicit TTLs or a shared Redis counter when deterministic TTL decisions are required. Verification: node docs-web/tests/current-docs-content.test.mjs; npm run lint; npm run build; docs-web npm run lint; docs-web npm run build.