### PR TITLE
Add Redis generation store helper

### DIFF
--- a/docs-web/content/docs/api.mdx
+++ b/docs-web/content/docs/api.mdx
@@ -411,6 +411,22 @@ const cache = new CacheStack([...], {
 })
 ```
 
+Persist the active generation outside the process when you deploy multiple
+instances or restart workers:
+
+```ts
+import { CacheStack, RedisGenerationStore } from 'layercache'
+
+const generations = new RedisGenerationStore({ client: redis })
+const generation = await generations.getOrInitialize(1)
+
+const cache = new CacheStack([...], { generation })
+
+// Later, rotate all future keys and persist that rotation.
+cache.bumpGeneration()
+await generations.set(cache.getGeneration())
+```
+
 #### `cache.bumpGeneration()`
 
 Rotate cache namespace by incrementing generation.

--- a/docs/api.md
+++ b/docs/api.md
@@ -410,6 +410,22 @@ const cache = new CacheStack([...], {
 })
 ```
 
+Persist the active generation outside the process when you deploy multiple
+instances or restart workers:
+
+```ts
+import { CacheStack, RedisGenerationStore } from 'layercache'
+
+const generations = new RedisGenerationStore({ client: redis })
+const generation = await generations.getOrInitialize(1)
+
+const cache = new CacheStack([...], { generation })
+
+// Later, rotate all future keys and persist that rotation.
+cache.bumpGeneration()
+await generations.set(cache.getGeneration())
+```
+
 #### `cache.bumpGeneration()`
 
 Rotate cache namespace by incrementing generation.

--- a/src/generation/RedisGenerationStore.ts
+++ b/src/generation/RedisGenerationStore.ts
@@ -1,0 +1,72 @@
+interface RedisGenerationClient {
+  get(key: string): Promise<string | null>
+  set(key: string, value: string, mode?: 'NX'): Promise<unknown>
+  incr(key: string): Promise<number>
+}
+
+interface RedisGenerationStoreOptions {
+  /** Redis client used to persist and atomically bump the generation. */
+  client: RedisGenerationClient
+  /** Redis key storing the active generation. Defaults to `layercache:generation`. */
+  key?: string
+}
+
+const DEFAULT_GENERATION_KEY = 'layercache:generation'
+
+export class RedisGenerationStore {
+  private readonly client: RedisGenerationClient
+  private readonly key: string
+
+  constructor(options: RedisGenerationStoreOptions) {
+    this.client = options.client
+    this.key = options.key ?? DEFAULT_GENERATION_KEY
+  }
+
+  async get(): Promise<number | undefined> {
+    const stored = await this.client.get(this.key)
+    if (stored === null) {
+      return undefined
+    }
+
+    return this.parseGeneration(stored)
+  }
+
+  async getOrInitialize(initialGeneration = 0): Promise<number> {
+    this.assertGeneration(initialGeneration)
+    await this.client.set(this.key, String(initialGeneration), 'NX')
+    const generation = await this.get()
+    if (generation === undefined) {
+      throw new Error(`RedisGenerationStore failed to initialize generation key "${this.key}".`)
+    }
+    return generation
+  }
+
+  async set(generation: number): Promise<void> {
+    this.assertGeneration(generation)
+    await this.client.set(this.key, String(generation))
+  }
+
+  async bump(): Promise<number> {
+    const generation = await this.client.incr(this.key)
+    this.assertGeneration(generation)
+    return generation
+  }
+
+  private parseGeneration(value: string): number {
+    const generation = Number.parseInt(value, 10)
+    if (String(generation) !== value || !this.isGeneration(generation)) {
+      throw new Error(`RedisGenerationStore found invalid persisted generation value for key "${this.key}".`)
+    }
+    return generation
+  }
+
+  private assertGeneration(value: number): void {
+    if (!this.isGeneration(value)) {
+      throw new Error('RedisGenerationStore generation must be a non-negative safe integer.')
+    }
+  }
+
+  private isGeneration(value: number): boolean {
+    return Number.isSafeInteger(value) && value >= 0
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { CacheStack } from './CacheStack'
 export { CacheNamespace } from './CacheNamespace'
+export { RedisGenerationStore } from './generation/RedisGenerationStore'
 export { PatternMatcher } from './invalidation/PatternMatcher'
 export { RedisInvalidationBus } from './invalidation/RedisInvalidationBus'
 export { RedisTagIndex } from './invalidation/RedisTagIndex'

--- a/tests/generation/RedisGenerationStore.test.ts
+++ b/tests/generation/RedisGenerationStore.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest'
+import { RedisGenerationStore } from '../../src'
+
+describe('RedisGenerationStore', () => {
+  it('initializes, reads, sets, and bumps a persisted generation value', async () => {
+    const values = new Map<string, string>()
+    const client = {
+      get: vi.fn(async (key: string) => values.get(key) ?? null),
+      set: vi.fn(async (key: string, value: string, mode?: string) => {
+        if (mode === 'NX' && values.has(key)) {
+          return null
+        }
+        values.set(key, value)
+        return 'OK'
+      }),
+      incr: vi.fn(async (key: string) => {
+        const next = Number.parseInt(values.get(key) ?? '0', 10) + 1
+        values.set(key, String(next))
+        return next
+      })
+    }
+
+    const store = new RedisGenerationStore({ client, key: 'cache:generation' })
+
+    await expect(store.get()).resolves.toBeUndefined()
+    await expect(store.getOrInitialize(7)).resolves.toBe(7)
+    await expect(store.getOrInitialize(3)).resolves.toBe(7)
+    await expect(store.bump()).resolves.toBe(8)
+    await store.set(12)
+    await expect(store.get()).resolves.toBe(12)
+  })
+
+  it('rejects invalid generation values and corrupt persisted data', async () => {
+    const client = {
+      get: vi.fn(async () => 'not-a-number'),
+      set: vi.fn(),
+      incr: vi.fn()
+    }
+    const store = new RedisGenerationStore({ client, key: 'cache:generation' })
+
+    await expect(store.get()).rejects.toThrow(/invalid persisted generation/i)
+    await expect(store.set(-1)).rejects.toThrow(/non-negative safe integer/i)
+    await expect(store.getOrInitialize(1.5)).rejects.toThrow(/non-negative safe integer/i)
+  })
+})


### PR DESCRIPTION
Fixes #63. Adds RedisGenerationStore to persist, initialize, set, and atomically bump generation values across restarts, with API docs showing how to wire it into CacheStack. Verification: npx vitest run tests/generation/RedisGenerationStore.test.ts; npm run lint; npm run build; docs-web npm run lint; docs-web npm run build.