### PR TITLE
Support shared circuit breaker scope

### DIFF
--- a/src/CacheStack.ts
+++ b/src/CacheStack.ts
@@ -285,7 +285,8 @@ export class CacheStack extends EventEmitter {
       emitError: (operation, context) => this.emitError(operation, context),
       formatError: (error) => this.formatError(error),
       storeEntry: (key, kind, value, options) => this.storeEntry(key, kind, value, options),
-      recordCircuitFailure: (key, options, error) => this.recordCircuitFailure(key, options, error),
+      recordCircuitFailure: (key, breakerKey, options, error) =>
+        this.recordCircuitFailure(key, breakerKey, options, error),
       resolveLayerMs: (layerName, override, globalDefault, fallback) =>
         this.resolveLayerMs(layerName, override, globalDefault, fallback),
       sleep: (ms) => this.sleep(ms),
@@ -1622,16 +1623,21 @@ export class CacheStack extends EventEmitter {
     return Boolean(this.options.gracefulDegradation)
   }
 
-  private recordCircuitFailure(key: string, options: CacheCircuitBreakerOptions | undefined, error: unknown): void {
+  private recordCircuitFailure(
+    key: string,
+    breakerKey: string,
+    options: CacheCircuitBreakerOptions | undefined,
+    error: unknown
+  ): void {
     if (!options) {
       return
     }
 
-    this.circuitBreakerManager.recordFailure(key, options)
-    if (this.circuitBreakerManager.isOpen(key)) {
+    this.circuitBreakerManager.recordFailure(breakerKey, options)
+    if (this.circuitBreakerManager.isOpen(breakerKey)) {
       this.metricsCollector.increment('circuitBreakerTrips')
     }
-    this.emitError('fetch', { key, error: this.formatError(error) })
+    this.emitError('fetch', { key, breakerKey, error: this.formatError(error) })
   }
 
   private emitError(operation: string, context: Record<string, unknown>): void {

--- a/src/internal/CacheStackReader.ts
+++ b/src/internal/CacheStackReader.ts
@@ -60,7 +60,12 @@ interface CacheStackReaderOptions {
   emitError: (operation: string, context: Record<string, unknown>) => void
   formatError: (error: unknown) => string
   storeEntry: (key: string, kind: CacheWriteKind, value: unknown, options?: CacheWriteOptions) => Promise<void>
-  recordCircuitFailure: (key: string, options: CacheCircuitBreakerOptions | undefined, error: unknown) => void
+  recordCircuitFailure: (
+    key: string,
+    breakerKey: string,
+    options: CacheCircuitBreakerOptions | undefined,
+    error: unknown
+  ) => void
   resolveLayerMs: (
     layerName: string,
     override: number | LayerTtlMap | undefined,
@@ -405,7 +410,9 @@ export class CacheStackReader {
       state: 'miss'
     }
   ): Promise<T | null> {
-    this.options.circuitBreakerManager.assertClosed(key, options?.circuitBreaker ?? this.options.circuitBreaker)
+    const circuitBreakerOptions = options?.circuitBreaker ?? this.options.circuitBreaker
+    const breakerKey = this.resolveCircuitBreakerKey(key, circuitBreakerOptions)
+    this.options.circuitBreakerManager.assertClosed(breakerKey, circuitBreakerOptions)
     this.options.metricsCollector.increment('fetches')
     const fetchStart = Date.now()
     let fetched: T
@@ -416,10 +423,10 @@ export class CacheStackReader {
         { key, fetcher },
         () => fetcher(fetcherContext)
       )
-      this.options.circuitBreakerManager.recordSuccess(key)
+      this.options.circuitBreakerManager.recordSuccess(breakerKey)
       this.options.logger.debug?.('fetch', { key, durationMs: Date.now() - fetchStart })
     } catch (error) {
-      this.options.recordCircuitFailure(key, options?.circuitBreaker ?? this.options.circuitBreaker, error)
+      this.options.recordCircuitFailure(key, breakerKey, circuitBreakerOptions, error)
       throw error
     }
 
@@ -470,6 +477,22 @@ export class CacheStackReader {
 
     await this.options.storeEntry(key, 'value', fetched, options)
     return fetched
+  }
+
+  private resolveCircuitBreakerKey(key: string, options: CacheCircuitBreakerOptions | undefined): string {
+    if (!options) {
+      return key
+    }
+
+    if (options.breakerKey) {
+      return `custom:${options.breakerKey}`
+    }
+
+    if (options.scope === 'shared') {
+      return 'shared'
+    }
+
+    return key
   }
 
   runScheduleBackgroundRefresh<T>(

--- a/src/internal/CacheStackValidation.ts
+++ b/src/internal/CacheStackValidation.ts
@@ -162,6 +162,14 @@ export function validateCircuitBreakerOptions(options: CacheCircuitBreakerOption
 
   validatePositiveNumber('circuitBreaker.failureThreshold', options.failureThreshold)
   validatePositiveNumber('circuitBreaker.cooldownMs', options.cooldownMs)
+
+  if (options.scope && !['key', 'shared'].includes(options.scope)) {
+    throw new Error('circuitBreaker.scope must be one of "key" or "shared".')
+  }
+
+  if (options.breakerKey !== undefined && options.breakerKey.length === 0) {
+    throw new Error('circuitBreaker.breakerKey must not be empty.')
+  }
 }
 
 export function validateContextEntryOptions(name: string, options: CacheEntryWriteOptions | undefined): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -469,6 +469,13 @@ export interface CacheCircuitBreakerOptions {
   failureThreshold?: number
   /** Milliseconds before an open circuit allows another attempt. */
   cooldownMs?: number
+  /**
+   * Failure scope. `key` preserves the historical per-cache-key behavior.
+   * `shared` uses one breaker for all fetches using these options.
+   */
+  scope?: 'key' | 'shared'
+  /** Custom breaker id for grouping related fetches, such as one backend dependency. */
+  breakerKey?: string
 }
 
 /** Graceful degradation settings for temporarily unhealthy layers. */

--- a/tests/CacheStack.test.ts
+++ b/tests/CacheStack.test.ts
@@ -353,6 +353,20 @@ describe('CacheStack', () => {
     await expect(cache.getOrThrow('missing')).rejects.toMatchObject({ key: 'missing' })
   })
 
+  it('supports shared circuit breaker scope across different cache keys', async () => {
+    const cache = new CacheStack([new MemoryLayer({ ttl: 60_000 })], {
+      circuitBreaker: { failureThreshold: 1, cooldownMs: 60_000, scope: 'shared', breakerKey: 'api' }
+    })
+    const firstFetcher = vi.fn(async () => {
+      throw new Error('backend down')
+    })
+    const secondFetcher = vi.fn(async () => 'should-not-run')
+
+    await expect(cache.get('user:1', firstFetcher)).rejects.toThrow(/backend down/i)
+    await expect(cache.get('user:2', secondFetcher)).rejects.toThrow(/Circuit breaker is open/i)
+    expect(secondFetcher).not.toHaveBeenCalled()
+  })
+
   it('continues has() checks when layer.has() fails or returns false', async () => {
     const warn = vi.fn()
     const flakyHasLayer: CacheLayer = {

--- a/tests/internal/CacheStackInternals.test.ts
+++ b/tests/internal/CacheStackInternals.test.ts
@@ -786,21 +786,23 @@ describe('CacheStack internals', () => {
       cache as {
         recordCircuitFailure: (
           key: string,
+          breakerKey: string,
           options: { failureThreshold: number; cooldownMs: number } | undefined,
           error: unknown
         ) => void
       }
-    ).recordCircuitFailure('user:1', undefined, new Error('ignored'))
+    ).recordCircuitFailure('user:1', 'user:1', undefined, new Error('ignored'))
     expect(cache.getMetrics().circuitBreakerTrips).toBe(0)
     ;(
       cache as {
         recordCircuitFailure: (
           key: string,
+          breakerKey: string,
           options: { failureThreshold: number; cooldownMs: number } | undefined,
           error: unknown
         ) => void
       }
-    ).recordCircuitFailure('user:1', { failureThreshold: 1, cooldownMs: 50 }, new Error('boom'))
+    ).recordCircuitFailure('user:1', 'user:1', { failureThreshold: 1, cooldownMs: 50 }, new Error('boom'))
     expect(cache.getMetrics().circuitBreakerTrips).toBe(1)
 
     const emitted: unknown[] = []

--- a/tests/internal/CacheStackValidation.test.ts
+++ b/tests/internal/CacheStackValidation.test.ts
@@ -66,8 +66,12 @@ describe('CacheStackValidation', () => {
     expect(() => validateContextEntryOptions('contextOptions', { ttl: -1 })).toThrow(/non-negative finite number/i)
 
     expect(() => validateCircuitBreakerOptions(undefined)).not.toThrow()
-    expect(() => validateCircuitBreakerOptions({ failureThreshold: 1, cooldownMs: 100 })).not.toThrow()
+    expect(() =>
+      validateCircuitBreakerOptions({ failureThreshold: 1, cooldownMs: 100, scope: 'shared', breakerKey: 'redis' })
+    ).not.toThrow()
     expect(() => validateCircuitBreakerOptions({ failureThreshold: 0 })).toThrow(/positive finite number/i)
+    expect(() => validateCircuitBreakerOptions({ scope: 'backend' as never })).toThrow(/must be one of/i)
+    expect(() => validateCircuitBreakerOptions({ breakerKey: '' })).toThrow(/must not be empty/i)
   })
 
   it('validates rate limit options', () => {


### PR DESCRIPTION
## Summary
- add shared circuit breaker scope and custom breaker keys
- keep the existing per-key behavior as the default
- use the resolved breaker key for assert, failure, success, and telemetry paths

## Verification
- npm run lint
- npm test
- npm run build

Closes #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Circuit breaker now supports shared scope across multiple cache keys, enabling related fetches to share breaker state.
  * Added `breakerKey` configuration option to group related fetches under a custom circuit breaker identifier.
  * Added `scope` option ('key' | 'shared') to control whether circuit breaker applies per key or shared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->