### PR TITLE
Optimize TagIndex wildcard candidate selection

### DIFF
--- a/src/invalidation/TagIndex.ts
+++ b/src/invalidation/TagIndex.ts
@@ -1,4 +1,5 @@
 import type { CacheTagIndex } from '../types'
+import { PatternMatcher } from './PatternMatcher'
 
 interface TagIndexOptions {
   /**
@@ -14,8 +15,6 @@ interface TrieNode {
   terminal: boolean
   children: Map<string, TrieNode>
 }
-
-const MAX_PATTERN_RECURSION_DEPTH = 500
 
 export class TagIndex implements CacheTagIndex {
   private readonly tagToKeys = new Map<string, Set<string>>()
@@ -125,9 +124,15 @@ export class TagIndex implements CacheTagIndex {
    * Returns known keys matching a wildcard pattern.
    */
   async matchPattern(pattern: string): Promise<string[]> {
-    const matches = new Set<string>()
-    this.collectPatternMatches(this.root, '', pattern, 0, matches, new Set<string>(), 0)
-    return [...matches]
+    const literalPrefix = this.literalPrefix(pattern)
+    const node = this.findNode(literalPrefix)
+    if (!node) {
+      return []
+    }
+
+    const candidates: string[] = []
+    this.collectFromNode(node, literalPrefix, candidates)
+    return candidates.filter((key) => PatternMatcher.matches(pattern, key))
   }
 
   /**
@@ -195,12 +200,20 @@ export class TagIndex implements CacheTagIndex {
   }
 
   private collectFromNode(node: TrieNode, prefix: string, matches: string[]): void {
-    if (node.terminal) {
-      matches.push(prefix)
-    }
+    const stack: Array<{ node: TrieNode; prefix: string }> = [{ node, prefix }]
+    while (stack.length > 0) {
+      const current = stack.pop()
+      if (!current) {
+        continue
+      }
+      if (current.node.terminal) {
+        matches.push(current.prefix)
+      }
 
-    for (const [character, child] of node.children) {
-      this.collectFromNode(child, `${prefix}${character}`, matches)
+      const children = [...current.node.children].reverse()
+      for (const [character, child] of children) {
+        stack.push({ node: child, prefix: `${current.prefix}${character}` })
+      }
     }
   }
 
@@ -209,80 +222,16 @@ export class TagIndex implements CacheTagIndex {
     prefix: string,
     visitor: (key: string) => void | Promise<void>
   ): Promise<void> {
-    if (node.terminal) {
-      await visitor(prefix)
-    }
-
-    for (const [character, child] of node.children) {
-      await this.visitFromNode(child, `${prefix}${character}`, visitor)
+    const matches: string[] = []
+    this.collectFromNode(node, prefix, matches)
+    for (const key of matches) {
+      await visitor(key)
     }
   }
 
-  private collectPatternMatches(
-    node: TrieNode,
-    prefix: string,
-    pattern: string,
-    patternIndex: number,
-    matches: Set<string>,
-    visited: Set<string>,
-    depth: number
-  ): void {
-    if (depth > MAX_PATTERN_RECURSION_DEPTH) {
-      return
-    }
-
-    const stateKey = `${node.id}:${patternIndex}`
-    if (visited.has(stateKey)) {
-      return
-    }
-    visited.add(stateKey)
-
-    if (patternIndex === pattern.length) {
-      if (node.terminal) {
-        matches.add(prefix)
-      }
-      return
-    }
-
-    const patternChar = pattern[patternIndex]
-    if (patternChar === undefined) {
-      return
-    }
-    if (patternChar === '*') {
-      this.collectPatternMatches(node, prefix, pattern, patternIndex + 1, matches, visited, depth + 1)
-      for (const [character, child] of node.children) {
-        this.collectPatternMatches(child, `${prefix}${character}`, pattern, patternIndex, matches, visited, depth + 1)
-      }
-      return
-    }
-
-    if (patternChar === '?') {
-      for (const [character, child] of node.children) {
-        this.collectPatternMatches(
-          child,
-          `${prefix}${character}`,
-          pattern,
-          patternIndex + 1,
-          matches,
-          visited,
-          depth + 1
-        )
-      }
-      return
-    }
-
-    const child = node.children.get(patternChar)
-    if (child) {
-      this.collectPatternMatches(
-        child,
-        `${prefix}${patternChar}`,
-        pattern,
-        patternIndex + 1,
-        matches,
-        visited,
-        depth + 1
-      )
-    }
+  private literalPrefix(pattern: string): string {
+    const wildcardIndex = pattern.search(/[*?]/)
+    return wildcardIndex === -1 ? pattern : pattern.slice(0, wildcardIndex)
   }
 
   private pruneKnownKeysIfNeeded(): void {

--- a/tests/invalidation/TagIndex.test.ts
+++ b/tests/invalidation/TagIndex.test.ts
@@ -45,6 +45,17 @@ describe('TagIndex', () => {
     expect((await index.matchPattern('user:*')).sort()).toEqual(['user:1', 'user:2'])
   })
 
+  it('matches long structured keys without recursive wildcard traversal limits', async () => {
+    const index = new TagIndex()
+    const longSegment = 'a'.repeat(600)
+    const key = `user:${longSegment}:profile`
+
+    await index.touch(key)
+    await index.touch(`post:${longSegment}:profile`)
+
+    expect(await index.matchPattern(`user:${longSegment}:*`)).toEqual([key])
+  })
+
   it('resets public key indexes when cleared', async () => {
     const index = new TagIndex()
 


### PR DESCRIPTION
## Summary
- use the literal prefix before the first wildcard to narrow TagIndex pattern candidates
- replace recursive wildcard trie traversal with the existing linear PatternMatcher
- make prefix collection iterative to avoid depth-sensitive traversal

## Verification
- npm run lint
- npm test
- npm run build

Closes #74