### PR TITLE
Avoid serializing namespace operations for metrics

### DIFF
--- a/src/CacheNamespace.ts
+++ b/src/CacheNamespace.ts
@@ -4,8 +4,7 @@ import {
   addNamespaceMetrics,
   cloneNamespaceMetrics,
   computeNamespaceHitRate,
-  createEmptyNamespaceMetrics,
-  diffNamespaceMetrics
+  createEmptyNamespaceMetrics
 } from './internal/CacheNamespaceMetrics'
 import type {
   CacheFetcher,
@@ -332,13 +331,13 @@ export class CacheNamespace {
   }
 
   private async trackMetrics<T>(operation: () => Promise<T>): Promise<T> {
-    return this.getMetricsMutex().runExclusive(async () => {
-      const before = this.cache.getMetrics()
-      const result = await operation()
-      const after = this.cache.getMetrics()
-      this.metrics = addNamespaceMetrics(this.metrics, diffNamespaceMetrics(before, after))
-      return result
+    const { result, metrics } = await this.cache.captureMetrics(operation)
+
+    await this.getMetricsMutex().runExclusive(() => {
+      this.metrics = addNamespaceMetrics(this.metrics, metrics)
     })
+
+    return result
   }
 
   private getMetricsMutex(): Mutex {

--- a/src/CacheStack.ts
+++ b/src/CacheStack.ts
@@ -868,6 +868,14 @@ export class CacheStack extends EventEmitter {
   }
 
   /**
+   * Runs an operation while collecting only the metrics emitted by its async context.
+   * Used by namespaces so metrics tracking does not serialize the operation itself.
+   */
+  async captureMetrics<T>(operation: () => Promise<T>): Promise<{ result: T; metrics: CacheMetricsSnapshot }> {
+    return this.metricsCollector.capture(operation)
+  }
+
+  /**
    * Returns metrics plus layer degradation state and active background refresh count.
    */
   getStats(): CacheStatsSnapshot {

--- a/src/internal/MetricsCollector.ts
+++ b/src/internal/MetricsCollector.ts
@@ -1,6 +1,8 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
 import type { CacheHitRateSnapshot, CacheLayerLatency, CacheMetricsSnapshot } from '../types'
 
 export class MetricsCollector {
+  private readonly captures = new AsyncLocalStorage<CacheMetricsSnapshot[]>()
   private data: CacheMetricsSnapshot = this.empty()
 
   get snapshot(): CacheMetricsSnapshot {
@@ -17,10 +19,16 @@ export class MetricsCollector {
     amount = 1
   ): void {
     ;(this.data[field] as number) += amount
+    for (const capture of this.captures.getStore() ?? []) {
+      ;(capture[field] as number) += amount
+    }
   }
 
   incrementLayer(map: 'hitsByLayer' | 'missesByLayer', layerName: string): void {
     this.data[map][layerName] = (this.data[map][layerName] ?? 0) + 1
+    for (const capture of this.captures.getStore() ?? []) {
+      capture[map][layerName] = (capture[map][layerName] ?? 0) + 1
+    }
   }
 
   /**
@@ -28,9 +36,24 @@ export class MetricsCollector {
    * Maintains a rolling average and max using Welford's online algorithm.
    */
   recordLatency(layerName: string, durationMs: number): void {
-    const existing = this.data.latencyByLayer[layerName]
+    this.recordLatencySample(this.data, layerName, durationMs)
+    for (const capture of this.captures.getStore() ?? []) {
+      this.recordLatencySample(capture, layerName, durationMs)
+    }
+  }
+
+  async capture<T>(operation: () => Promise<T>): Promise<{ result: T; metrics: CacheMetricsSnapshot }> {
+    const metrics = this.empty()
+    const activeCaptures = this.captures.getStore()
+    const captures = activeCaptures ? [...activeCaptures, metrics] : [metrics]
+    const result = await this.captures.run(captures, operation)
+    return { result, metrics }
+  }
+
+  private recordLatencySample(metrics: CacheMetricsSnapshot, layerName: string, durationMs: number): void {
+    const existing = metrics.latencyByLayer[layerName]
     if (!existing) {
-      this.data.latencyByLayer[layerName] = { avgMs: durationMs, maxMs: durationMs, count: 1 }
+      metrics.latencyByLayer[layerName] = { avgMs: durationMs, maxMs: durationMs, count: 1 }
       return
     }
 

--- a/tests/CacheNamespace.test.ts
+++ b/tests/CacheNamespace.test.ts
@@ -231,6 +231,36 @@ describe('CacheNamespace', () => {
     await second
   })
 
+  it('does not serialize namespace operations on the same cache stack', async () => {
+    const cache = makeCache()
+    const nsA = cache.namespace('a')
+    const nsB = cache.namespace('b')
+
+    let releaseFetch!: () => void
+    const fetchBlocked = new Promise<void>((resolve) => {
+      releaseFetch = resolve
+    })
+
+    const first = nsA.getOrSet('key', async () => {
+      await fetchBlocked
+      return 1
+    })
+
+    await Promise.resolve()
+
+    let secondCompleted = false
+    const second = nsB.set('key', 2).then(() => {
+      secondCompleted = true
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(secondCompleted).toBe(true)
+
+    releaseFetch()
+    await first
+    await second
+  })
+
   it('getMetrics proxies to the underlying stack', () => {
     const ns = makeCache().namespace('x')
     expect(ns.getMetrics()).toHaveProperty('hits')


### PR DESCRIPTION
## Summary
- collect namespace metrics from the operation async context instead of global before/after snapshots
- keep only the namespace metric merge behind the mutex
- add same-stack concurrency coverage for namespace operations

## Verification
- npm run lint
- npm test
- npm run build

Closes #75