### PR TITLE
Add entry reads that distinguish stored nulls

### DIFF
--- a/src/CacheNamespace.ts
+++ b/src/CacheNamespace.ts
@@ -8,6 +8,7 @@ import {
   diffNamespaceMetrics
 } from './internal/CacheNamespaceMetrics'
 import type {
+  CacheEntryResult,
   CacheFetcher,
   CacheGetOptions,
   CacheHitRateSnapshot,
@@ -54,6 +55,22 @@ export class CacheNamespace {
    */
   async getOrSet<T>(key: string, fetcher: CacheFetcher<T>, options?: CacheGetOptions): Promise<T | null> {
     return this.trackMetrics(() => this.cache.getOrSet(this.qualify(key), fetcher, this.qualifyGetOptions(options)))
+  }
+
+  /**
+   * Returns a namespaced cache entry, or `null` on miss.
+   * Unlike `get()`, this distinguishes a stored `null` value from an absent key.
+   */
+  async getEntry<T>(key: string): Promise<CacheEntryResult<T> | null> {
+    const entry = await this.trackMetrics(() => this.cache.getEntry<T>(this.qualify(key)))
+    if (entry === null) {
+      return null
+    }
+
+    return {
+      ...entry,
+      key
+    }
   }
 
   /**

--- a/src/CacheStack.ts
+++ b/src/CacheStack.ts
@@ -50,6 +50,7 @@ import {
   type CacheAdaptiveTtlOptions,
   type CacheCircuitBreakerOptions,
   type CacheContextOptionsContext,
+  type CacheEntryResult,
   type CacheEntryWriteKind,
   type CacheEntryWriteOptions,
   type CacheFetcher,
@@ -335,6 +336,42 @@ export class CacheStack extends EventEmitter {
    */
   async getOrSet<T>(key: string, fetcher: CacheFetcher<T>, options?: CacheGetOptions): Promise<T | null> {
     return this.get(key, fetcher, options)
+  }
+
+  /**
+   * Returns a discriminated cache entry, or `null` on miss.
+   * Unlike `get()`, this distinguishes a stored `null` value from an absent key.
+   */
+  async getEntry<T>(key: string): Promise<CacheEntryResult<T> | null> {
+    const userKey = validateCacheKey(key)
+    const normalizedKey = this.qualifyKey(userKey)
+    await this.awaitStartup('getEntry')
+
+    for (const layer of this.layers) {
+      if (this.shouldSkipLayer(layer)) {
+        continue
+      }
+
+      const stored = await this.readLayerEntry(layer, normalizedKey)
+      if (stored === null) {
+        continue
+      }
+
+      const resolved = resolveStoredValue<T>(stored)
+      if (resolved.state === 'expired') {
+        continue
+      }
+
+      return {
+        key: userKey,
+        value: resolved.value,
+        kind: resolved.envelope?.kind ?? 'value',
+        state: resolved.state,
+        layer: layer.name
+      }
+    }
+
+    return null
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ export {
   type CacheContextOptionsContext,
   type CacheEntryWriteKind,
   type CacheEntryWriteOptions,
+  type CacheEntryResult,
   type CacheDegradationOptions,
   type CacheFetcher,
   type CacheFetcherContext,

--- a/src/types.ts
+++ b/src/types.ts
@@ -598,6 +598,20 @@ export interface CacheInspectResult {
   tags: string[]
 }
 
+/** Cached entry result that can distinguish a stored `null` from a miss. */
+export interface CacheEntryResult<T = unknown> {
+  /** User-facing cache key. */
+  key: string
+  /** Unwrapped cached value. May be `null` when `kind` is `value` or `empty`. */
+  value: T | null
+  /** Whether this entry stores a normal value or a negative-cache empty marker. */
+  kind: 'value' | 'empty'
+  /** Fresh/stale state currently available for this entry. */
+  state: 'fresh' | 'stale-while-revalidate' | 'stale-if-error'
+  /** First layer that supplied the entry. */
+  layer: string
+}
+
 // ---------------------------------------------------------------------------
 // Typed EventEmitter events
 // ---------------------------------------------------------------------------

--- a/tests/CacheNamespace.test.ts
+++ b/tests/CacheNamespace.test.ts
@@ -146,6 +146,22 @@ describe('CacheNamespace', () => {
     expect(ns.getMetrics().sets).toBeGreaterThanOrEqual(1)
   })
 
+  it('getEntry returns unqualified keys and distinguishes stored null values', async () => {
+    const ns = makeCache().namespace('cache')
+
+    await ns.set('null-key', null)
+
+    await expect(ns.getEntry('null-key')).resolves.toEqual(
+      expect.objectContaining({
+        key: 'null-key',
+        value: null,
+        kind: 'value',
+        state: 'fresh'
+      })
+    )
+    await expect(ns.getEntry('missing')).resolves.toBeNull()
+  })
+
   it('getOrThrow participates in namespace metrics', async () => {
     const ns = makeCache().namespace('strict')
     await ns.set('key', 1)

--- a/tests/CacheStack.test.ts
+++ b/tests/CacheStack.test.ts
@@ -353,6 +353,33 @@ describe('CacheStack', () => {
     await expect(cache.getOrThrow('missing')).rejects.toMatchObject({ key: 'missing' })
   })
 
+  it('getEntry distinguishes stored null values and negative-cache entries from misses', async () => {
+    const cache = new CacheStack([new MemoryLayer({ ttl: 60_000 })])
+
+    await cache.set('stored-null', null)
+    await expect(cache.get('stored-null')).resolves.toBeNull()
+    await expect(cache.getEntry('stored-null')).resolves.toEqual(
+      expect.objectContaining({
+        key: 'stored-null',
+        value: null,
+        kind: 'value',
+        state: 'fresh',
+        layer: 'memory'
+      })
+    )
+
+    await cache.get('negative-null', async () => null, { negativeCache: true })
+    await expect(cache.getEntry('negative-null')).resolves.toEqual(
+      expect.objectContaining({
+        key: 'negative-null',
+        value: null,
+        kind: 'empty',
+        state: 'fresh'
+      })
+    )
+    await expect(cache.getEntry('missing')).resolves.toBeNull()
+  })
+
   it('continues has() checks when layer.has() fails or returns false', async () => {
     const warn = vi.fn()
     const flakyHasLayer: CacheLayer = {


### PR DESCRIPTION
## Summary
- add CacheStack.getEntry() and CacheNamespace.getEntry()
- return entry metadata so stored null values and negative-cache empty entries are distinguishable from misses
- export the new CacheEntryResult type

## Verification
- npm run lint
- npm test
- npm run build

Closes #76