### PR TITLE
Make rate limit queue overflow explicit

### DIFF
--- a/src/internal/CacheStackValidation.ts
+++ b/src/internal/CacheStackValidation.ts
@@ -59,6 +59,10 @@ export function validateRateLimitOptions(name: string, options: CacheRateLimitOp
     throw new Error(`${name}.scope must be one of "global", "key", or "fetcher".`)
   }
 
+  if (options.queueOverflow && !['reject', 'bypass'].includes(options.queueOverflow)) {
+    throw new Error(`${name}.queueOverflow must be one of "reject" or "bypass".`)
+  }
+
   if (options.bucketKey !== undefined && options.bucketKey.length === 0) {
     throw new Error(`${name}.bucketKey must not be empty.`)
   }

--- a/src/internal/FetchRateLimiter.ts
+++ b/src/internal/FetchRateLimiter.ts
@@ -25,6 +25,7 @@ interface NormalizedRateLimitOptions extends CacheRateLimitOptions {
 
 const MAX_BUCKETS = 10_000
 const MAX_QUEUE_PER_BUCKET = 10_000
+const DEFAULT_QUEUE_OVERFLOW_POLICY: NonNullable<CacheRateLimitOptions['queueOverflow']> = 'reject'
 
 export class FetchRateLimiter {
   private readonly buckets = new Map<string, BucketState>()
@@ -58,8 +59,12 @@ export class FetchRateLimiter {
       const bucketKey = this.resolveBucketKey(normalized, context)
       const queue = this.queuesByBucket.get(bucketKey) ?? []
       if (queue.length >= MAX_QUEUE_PER_BUCKET) {
-        this.rateLimitBypasses += 1
-        task().then(resolve, reject)
+        if ((normalized.queueOverflow ?? DEFAULT_QUEUE_OVERFLOW_POLICY) === 'bypass') {
+          this.rateLimitBypasses += 1
+          task().then(resolve, reject)
+          return
+        }
+        reject(new Error(`FetchRateLimiter queue overflow for bucket "${bucketKey}".`))
         return
       }
       queue.push({
@@ -114,7 +119,8 @@ export class FetchRateLimiter {
       intervalMs,
       maxPerInterval,
       scope: options.scope ?? 'global',
-      bucketKey: options.bucketKey
+      bucketKey: options.bucketKey,
+      queueOverflow: options.queueOverflow
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -489,6 +489,11 @@ export interface CacheRateLimitOptions {
   scope?: 'global' | 'key' | 'fetcher'
   /** Custom bucket id used to group otherwise unrelated fetches. */
   bucketKey?: string
+  /**
+   * Behavior when a bucket queue reaches its internal safety limit.
+   * Defaults to `reject` so overflow is explicit instead of bypassing limits.
+   */
+  queueOverflow?: 'reject' | 'bypass'
 }
 
 /** Queue controls for write-behind mode. */

--- a/tests/internal/CacheStackValidation.test.ts
+++ b/tests/internal/CacheStackValidation.test.ts
@@ -76,6 +76,7 @@ describe('CacheStackValidation', () => {
       validateRateLimitOptions('rate', { maxConcurrent: 1, intervalMs: 10, maxPerInterval: 2, scope: 'fetcher' })
     ).not.toThrow()
     expect(() => validateRateLimitOptions('rate', { scope: 'tenant' as never })).toThrow(/must be one of/i)
+    expect(() => validateRateLimitOptions('rate', { queueOverflow: 'drop' as never })).toThrow(/must be one of/i)
     expect(() => validateRateLimitOptions('rate', { bucketKey: '' })).toThrow(/must not be empty/i)
     expect(() => validateRateLimitOptions('rate', { maxConcurrent: 0 })).toThrow(/positive finite number/i)
   })

--- a/tests/internal/FetchRateLimiter.test.ts
+++ b/tests/internal/FetchRateLimiter.test.ts
@@ -286,7 +286,7 @@ describe('FetchRateLimiter', () => {
     }
   })
 
-  it('bypasses rate limiting when a bucket queue exceeds MAX_QUEUE_PER_BUCKET', async () => {
+  it('rejects by default when a bucket queue exceeds MAX_QUEUE_PER_BUCKET', async () => {
     const limiter = new FetchRateLimiter()
     const queuesByBucket = (limiter as unknown as { queuesByBucket: Map<string, Array<unknown>> }).queuesByBucket
 
@@ -297,8 +297,27 @@ describe('FetchRateLimiter', () => {
 
     expect(limiter.rateLimitBypasses).toBe(0)
 
+    await expect(
+      limiter.schedule(
+        { maxConcurrent: 1, scope: 'key' },
+        { key: 'user:1', fetcher: async () => 'x' },
+        async () => 'rejected'
+      )
+    ).rejects.toThrow(/queue overflow/i)
+    expect(limiter.rateLimitBypasses).toBe(0)
+  })
+
+  it('bypasses rate limiting on queue overflow when explicitly configured', async () => {
+    const limiter = new FetchRateLimiter()
+    const queuesByBucket = (limiter as unknown as { queuesByBucket: Map<string, Array<unknown>> }).queuesByBucket
+
+    queuesByBucket.set(
+      'key:user:1',
+      Array.from({ length: 10_000 }, () => ({}))
+    )
+
     const result = await limiter.schedule(
-      { maxConcurrent: 1, scope: 'key' },
+      { maxConcurrent: 1, scope: 'key', queueOverflow: 'bypass' },
       { key: 'user:1', fetcher: async () => 'x' },
       async () => 'bypassed'
     )


### PR DESCRIPTION
## Summary
- add a queueOverflow policy for fetcher rate limiting
- reject queue overflow by default instead of silently bypassing limits
- keep explicit bypass behavior available for callers that opt in

## Verification
- npm run lint
- npm test
- npm run build

Closes #77