### PR TITLE
Bound DiskLayer write queue depth

### DIFF
--- a/src/layers/DiskLayer.ts
+++ b/src/layers/DiskLayer.ts
@@ -29,6 +29,11 @@ interface DiskLayerOptions {
    */
   maxEntryBytes?: number | false
   /**
+   * Maximum pending write operations allowed in the serialized write queue.
+   * Defaults to 10,000. Set to `false` to disable the guard.
+   */
+  maxWriteQueueDepth?: number | false
+  /**
    * Encrypt cached data at rest using AES-256-GCM. Accepts a string or Buffer.
    * The key material is hashed with SHA-256 to derive the actual cipher key.
    * Encryption also provides authenticated integrity — a separate signingKey
@@ -51,6 +56,7 @@ interface DiskEntry {
 }
 
 const FILE_SCAN_CONCURRENCY = 32
+const DEFAULT_MAX_WRITE_QUEUE_DEPTH = 10_000
 
 /**
  * A file-system backed cache layer.
@@ -72,8 +78,10 @@ export class DiskLayer implements CacheLayer {
   private readonly serializer: CacheSerializer
   private readonly maxFiles: number | undefined
   private readonly maxEntryBytes: number | false
+  private readonly maxWriteQueueDepth: number | undefined
   private readonly protection: PayloadProtection
   private writeQueue = Promise.resolve()
+  private writeQueueDepth = 0
 
   /**
    * Creates a disk-backed cache layer.
@@ -85,6 +93,7 @@ export class DiskLayer implements CacheLayer {
     this.serializer = options.serializer ?? new JsonSerializer()
     this.maxFiles = this.normalizeMaxFiles(options.maxFiles)
     this.maxEntryBytes = this.normalizeMaxEntryBytes(options.maxEntryBytes)
+    this.maxWriteQueueDepth = this.normalizeMaxWriteQueueDepth(options.maxWriteQueueDepth)
     this.protection = new PayloadProtection({
       encryptionKey: options.encryptionKey,
       signingKey: options.signingKey
@@ -335,6 +344,19 @@ export class DiskLayer implements CacheLayer {
     return normalized
   }
 
+  private normalizeMaxWriteQueueDepth(maxWriteQueueDepth: number | false | undefined): number | undefined {
+    if (maxWriteQueueDepth === false) {
+      return undefined
+    }
+
+    const normalized = maxWriteQueueDepth ?? DEFAULT_MAX_WRITE_QUEUE_DEPTH
+    if (!Number.isInteger(normalized) || normalized <= 0) {
+      throw new Error('DiskLayer.maxWriteQueueDepth must be a positive integer or false.')
+    }
+
+    return normalized
+  }
+
   private async readEntryFile(filePath: string): Promise<Buffer | null> {
     let handle: fs.FileHandle | undefined
     try {
@@ -469,7 +491,14 @@ export class DiskLayer implements CacheLayer {
   }
 
   private enqueueWrite(operation: () => Promise<void>): Promise<void> {
-    const next = this.writeQueue.then(operation, operation)
+    if (this.maxWriteQueueDepth !== undefined && this.writeQueueDepth >= this.maxWriteQueueDepth) {
+      return Promise.reject(new Error(`DiskLayer write queue limit (${this.maxWriteQueueDepth}) exceeded.`))
+    }
+
+    this.writeQueueDepth += 1
+    const next = this.writeQueue.then(operation, operation).finally(() => {
+      this.writeQueueDepth -= 1
+    })
     this.writeQueue = next.catch(() => undefined)
     return next
   }

--- a/tests/layers/DiskLayer.test.ts
+++ b/tests/layers/DiskLayer.test.ts
@@ -164,6 +164,26 @@ describe('DiskLayer', () => {
     expect(await boundedLayer.size()).toBeLessThanOrEqual(2)
   })
 
+  it('rejects writes when the serialized write queue exceeds maxWriteQueueDepth', async () => {
+    const boundedLayer = new DiskLayer({ directory: dir, maxWriteQueueDepth: 1 })
+    let release!: () => void
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const enqueueWrite = (
+      boundedLayer as unknown as { enqueueWrite: (operation: () => Promise<void>) => Promise<void> }
+    ).enqueueWrite.bind(boundedLayer)
+
+    const first = enqueueWrite(async () => {
+      await blocked
+    })
+
+    await expect(boundedLayer.set('overflow', 1)).rejects.toThrow(/write queue limit/i)
+    release()
+    await expect(first).resolves.toBeUndefined()
+    await expect(boundedLayer.set('after-drain', 2)).resolves.toBeUndefined()
+  })
+
   it('supports getMany parallel reads', async () => {
     await layer.set('a', 1)
     await layer.set('b', 2)
@@ -238,6 +258,7 @@ describe('DiskLayer', () => {
   it('rejects invalid maxFiles and maxEntryBytes values early', () => {
     expect(() => new DiskLayer({ directory: dir, maxFiles: 0 })).toThrow(/positive integer/i)
     expect(() => new DiskLayer({ directory: dir, maxEntryBytes: 0 })).toThrow(/positive number/i)
+    expect(() => new DiskLayer({ directory: dir, maxWriteQueueDepth: 0 })).toThrow(/positive integer/i)
   })
 
   it('skips max-file enforcement when unlimited and tolerates readdir/stat failures', async () => {


### PR DESCRIPTION
## Summary
- add maxWriteQueueDepth to DiskLayer
- reject writes when the serialized queue reaches the configured safety limit
- validate the new option and cover queue overflow/drain behavior

## Verification
- npm run lint
- npm test
- npm run build

Closes #78