### PR TITLE
Back off single-flight waiter polling

### DIFF
--- a/src/internal/CacheStackReader.ts
+++ b/src/internal/CacheStackReader.ts
@@ -27,6 +27,9 @@ const DEFAULT_SINGLE_FLIGHT_LEASE_MS = 30_000
 const DEFAULT_SINGLE_FLIGHT_TIMEOUT_MS = 5_000
 const DEFAULT_SINGLE_FLIGHT_POLL_MS = 50
 const DEFAULT_BACKGROUND_REFRESH_TIMEOUT_MS = 30_000
+const SINGLE_FLIGHT_BACKOFF_FACTOR = 2
+const SINGLE_FLIGHT_BACKOFF_JITTER = 0.2
+const SINGLE_FLIGHT_MAX_POLL_MS = 1_000
 
 type ReadMode = 'allow-stale' | 'fresh-only'
 
@@ -368,6 +371,7 @@ export class CacheStackReader {
     const timeoutMs = this.options.singleFlightTimeoutMs ?? DEFAULT_SINGLE_FLIGHT_TIMEOUT_MS
     const pollIntervalMs = this.options.singleFlightPollMs ?? DEFAULT_SINGLE_FLIGHT_POLL_MS
     const deadline = Date.now() + timeoutMs
+    let nextPollMs = pollIntervalMs
 
     this.options.metricsCollector.increment('singleFlightWaits')
     this.options.emit('stampede-dedupe', { key })
@@ -378,7 +382,13 @@ export class CacheStackReader {
         this.options.metricsCollector.increment('hits')
         return hit.value
       }
-      await this.options.sleep(pollIntervalMs)
+      const remainingMs = deadline - Date.now()
+      if (remainingMs <= 0) {
+        break
+      }
+      const delayMs = Math.min(this.jitterSingleFlightPoll(nextPollMs), remainingMs)
+      await this.options.sleep(delayMs)
+      nextPollMs = Math.min(nextPollMs * SINGLE_FLIGHT_BACKOFF_FACTOR, SINGLE_FLIGHT_MAX_POLL_MS, timeoutMs)
     }
 
     if (!this.options.singleFlightCoordinator) {
@@ -391,6 +401,11 @@ export class CacheStackReader {
       () => this.fetchAndPopulate(key, fetcher, options, expectedClearEpoch, expectedKeyEpoch, fetcherContext),
       () => this.waitForFreshValue(key, fetcher, options, expectedClearEpoch, expectedKeyEpoch, fetcherContext)
     )
+  }
+
+  private jitterSingleFlightPoll(delayMs: number): number {
+    const jitterRange = delayMs * SINGLE_FLIGHT_BACKOFF_JITTER
+    return Math.max(1, Math.round(delayMs - jitterRange + Math.random() * jitterRange * 2))
   }
 
   private async fetchAndPopulate<T>(

--- a/tests/internal/CacheStackReader.test.ts
+++ b/tests/internal/CacheStackReader.test.ts
@@ -713,6 +713,41 @@ describe('CacheStackReader', () => {
       expect(result).toBe('timeout-fetch')
       expect(execute).toHaveBeenCalledTimes(2)
     })
+
+    it('backs off single-flight waiter polling while respecting the timeout deadline', async () => {
+      vi.useFakeTimers()
+      const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5)
+      const { reader, options } = createReader()
+      options.layers = [createMockLayer('L0', { get: vi.fn(async () => null) })]
+      const execute = vi.fn(
+        async (
+          _key: string,
+          _opts: unknown,
+          worker: () => Promise<string | null>,
+          waiter: () => Promise<string | null>
+        ) => {
+          return execute.mock.calls.length === 1 ? waiter() : worker()
+        }
+      )
+      options.singleFlightCoordinator = { execute }
+      options.singleFlightTimeoutMs = 100
+      options.singleFlightPollMs = 10
+      options.sleep = vi.fn(async (ms: number) => {
+        vi.advanceTimersByTime(ms)
+      })
+      options.storeEntry = vi.fn(async () => {})
+
+      try {
+        await expect(reader.getPrepared('key:1', async () => 'timeout-fetch')).resolves.toBe('timeout-fetch')
+        expect(options.sleep).toHaveBeenNthCalledWith(1, 10)
+        expect(options.sleep).toHaveBeenNthCalledWith(2, 20)
+        expect(options.sleep).toHaveBeenNthCalledWith(3, 40)
+        expect(options.sleep).toHaveBeenLastCalledWith(30)
+      } finally {
+        randomSpy.mockRestore()
+        vi.useRealTimers()
+      }
+    })
   })
 
   // --- Background refresh management ---


### PR DESCRIPTION
## Summary
- replace fixed single-flight waiter polling with jittered exponential backoff
- cap sleeps by the remaining wait deadline
- add coverage for backoff progression and timeout behavior

## Verification
- npm run lint
- npm test
- npm run build

Closes #79