### PR TITLE
Add cacheNullValues option

### DIFF
--- a/docs-web/content/docs/api.mdx
+++ b/docs-web/content/docs/api.mdx
@@ -582,6 +582,7 @@ class MyCustomLayer implements CacheLayer {
 | `generationCleanup` | `boolean \| { batchSize: number }` | - | Auto-prune stale generation keys |
 | `broadcastL1Invalidation` | `boolean` | `false` | Publish writes to peer memory layers |
 | `negativeCaching` | `boolean` | `false` | Cache nulls globally |
+| `cacheNullValues` | `boolean` | `false` | Cache null fetcher results as regular values |
 | `negativeTtl` | `number \| LayerTtlMap` | - | Global TTL for negative cache entries |
 | `staleWhileRevalidate` | `number \| LayerTtlMap` | - | Global stale-while-revalidate window (milliseconds) |
 | `staleIfError` | `number \| LayerTtlMap` | - | Global stale-if-error window (milliseconds) |
@@ -614,6 +615,7 @@ class MyCustomLayer implements CacheLayer {
 | `ttl` | `number \| LayerTtlMap` | TTL in milliseconds, or per-layer overrides |
 | `ttlPolicy` | `string \| object \| function` | `'until-midnight'`, `'next-hour'`, `{ alignTo }`, or custom |
 | `negativeCache` | `boolean` | Cache null results |
+| `cacheNullValues` | `boolean` | Cache null fetcher results as regular values |
 | `negativeTtl` | `number` | Short TTL for misses |
 | `staleWhileRevalidate` | `number \| LayerTtlMap` | Return stale and refresh in background |
 | `staleIfError` | `number \| LayerTtlMap` | Keep serving stale if refresh fails |

--- a/docs/api.md
+++ b/docs/api.md
@@ -581,6 +581,7 @@ class MyCustomLayer implements CacheLayer {
 | `generationCleanup` | `boolean \| { batchSize: number }` | - | Auto-prune stale generation keys |
 | `broadcastL1Invalidation` | `boolean` | `false` | Publish writes to peer memory layers |
 | `negativeCaching` | `boolean` | `false` | Cache nulls globally |
+| `cacheNullValues` | `boolean` | `false` | Cache null fetcher results as regular values |
 | `negativeTtl` | `number \| LayerTtlMap` | - | Global TTL for negative cache entries |
 | `staleWhileRevalidate` | `number \| LayerTtlMap` | - | Global stale-while-revalidate window (milliseconds) |
 | `staleIfError` | `number \| LayerTtlMap` | - | Global stale-if-error window (milliseconds) |
@@ -613,6 +614,7 @@ class MyCustomLayer implements CacheLayer {
 | `ttl` | `number \| LayerTtlMap` | TTL in milliseconds, or per-layer overrides |
 | `ttlPolicy` | `string \| object \| function` | `'until-midnight'`, `'next-hour'`, `{ alignTo }`, or custom |
 | `negativeCache` | `boolean` | Cache null results |
+| `cacheNullValues` | `boolean` | Cache null fetcher results as regular values |
 | `negativeTtl` | `number` | Short TTL for misses |
 | `staleWhileRevalidate` | `number \| LayerTtlMap` | Return stale and refresh in background |
 | `staleIfError` | `number \| LayerTtlMap` | Keep serving stale if refresh fails |

--- a/src/CacheStack.ts
+++ b/src/CacheStack.ts
@@ -306,6 +306,7 @@ export class CacheStack extends EventEmitter {
       singleFlightRenewIntervalMs: options.singleFlightRenewIntervalMs,
       backgroundRefreshTimeoutMs: options.backgroundRefreshTimeoutMs,
       negativeCaching: options.negativeCaching,
+      cacheNullValues: options.cacheNullValues,
       refreshAhead: options.refreshAhead,
       circuitBreaker: options.circuitBreaker,
       fetcherRateLimit: options.fetcherRateLimit

--- a/src/internal/CacheStackReader.ts
+++ b/src/internal/CacheStackReader.ts
@@ -87,6 +87,7 @@ interface CacheStackReaderOptions {
   singleFlightRenewIntervalMs?: number
   backgroundRefreshTimeoutMs?: number
   negativeCaching?: boolean
+  cacheNullValues?: boolean
   refreshAhead?: number | LayerTtlMap
   circuitBreaker?: CacheCircuitBreakerOptions
   fetcherRateLimit?: CacheRateLimitOptions
@@ -423,7 +424,7 @@ export class CacheStackReader {
       throw error
     }
 
-    if (fetched === null || fetched === undefined) {
+    if (fetched === undefined || (fetched === null && !this.shouldCacheNullValues(options))) {
       if (!this.shouldNegativeCache(options)) {
         return null
       }
@@ -621,6 +622,10 @@ export class CacheStackReader {
 
   private shouldNegativeCache(options?: CacheGetOptions): boolean {
     return options?.negativeCache ?? this.options.negativeCaching ?? false
+  }
+
+  private shouldCacheNullValues(options?: CacheGetOptions): boolean {
+    return options?.cacheNullValues ?? this.options.cacheNullValues ?? false
   }
 
   private isNegativeStoredValue(stored: unknown): boolean {

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,8 @@ export interface CacheContextOptionsContext {
 export interface CacheWriteOptions extends CacheEntryWriteOptions {
   /** Cache `null` fetcher results using `negativeTtl` instead of treating them as misses. */
   negativeCache?: boolean
+  /** Cache `null` fetcher results as regular values instead of negative/empty entries. */
+  cacheNullValues?: boolean
   /** Extend a key's TTL on fresh reads. */
   slidingTtl?: boolean
   /** Refresh in the background when the remaining TTL is at or below this threshold in milliseconds. */
@@ -89,6 +91,7 @@ export interface CacheWriteOptions extends CacheEntryWriteOptions {
    *
    * Returned values override any static entry options already present on the
    * same object. Fetch controls like `shouldCache`, `negativeCache`,
+   * `cacheNullValues`,
    * `refreshAhead`, or `circuitBreaker` are not affected.
    *
    * @example
@@ -380,6 +383,8 @@ export interface CacheStackOptions {
   publishSetInvalidation?: boolean
   /** Cache null fetcher results as negative entries. */
   negativeCaching?: boolean
+  /** Cache null fetcher results as regular values instead of negative/empty entries. */
+  cacheNullValues?: boolean
   /** Default negative-cache TTL in milliseconds. */
   negativeTtl?: number | LayerTtlMap
   /** Default stale-while-revalidate window in milliseconds. */

--- a/tests/internal/CacheStackReader.test.ts
+++ b/tests/internal/CacheStackReader.test.ts
@@ -61,6 +61,7 @@ interface MockOptions {
   singleFlightRenewIntervalMs?: number
   backgroundRefreshTimeoutMs?: number
   negativeCaching?: boolean
+  cacheNullValues?: boolean
   refreshAhead?: number
   circuitBreaker?: unknown
   fetcherRateLimit?: unknown
@@ -542,6 +543,49 @@ describe('CacheStackReader', () => {
       options.negativeCaching = true
       options.storeEntry = vi.fn(async () => {})
       const fetcher = vi.fn(async () => null)
+
+      const result = await reader.getPrepared('key:1', fetcher)
+      expect(result).toBeNull()
+      expect(options.storeEntry).toHaveBeenCalledWith('key:1', 'empty', null, undefined)
+    })
+
+    it('null fetch result stores a value when cacheNullValues is enabled globally', async () => {
+      const { reader, options } = createReader()
+      options.layers = [createMockLayer('L0')]
+      options.negativeCaching = true
+      options.cacheNullValues = true
+      options.storeEntry = vi.fn(async () => {})
+      const fetcher = vi.fn(async () => null)
+
+      const result = await reader.getPrepared('key:1', fetcher)
+      expect(result).toBeNull()
+      expect(options.storeEntry).toHaveBeenCalledWith('key:1', 'value', null, undefined)
+    })
+
+    it('null fetch result stores a value when cacheNullValues is enabled per operation', async () => {
+      const { reader, options } = createReader()
+      options.layers = [createMockLayer('L0')]
+      options.negativeCaching = true
+      options.storeEntry = vi.fn(async () => {})
+      const fetcher = vi.fn(async () => null)
+
+      const result = await reader.getPrepared('key:1', fetcher, { cacheNullValues: true })
+      expect(result).toBeNull()
+      expect(options.storeEntry).toHaveBeenCalledWith(
+        'key:1',
+        'value',
+        null,
+        expect.objectContaining({ cacheNullValues: true })
+      )
+    })
+
+    it('undefined fetch result remains a negative-cache entry when negative caching is enabled', async () => {
+      const { reader, options } = createReader()
+      options.layers = [createMockLayer('L0')]
+      options.negativeCaching = true
+      options.cacheNullValues = true
+      options.storeEntry = vi.fn(async () => {})
+      const fetcher = vi.fn(async () => undefined)
 
       const result = await reader.getPrepared('key:1', fetcher)
       expect(result).toBeNull()


### PR DESCRIPTION
## Summary
- add `cacheNullValues` as an opt-in global/per-operation option
- keep `undefined` and default `null` fetcher results on the existing negative-cache path
- document the new option and cover global/per-operation behavior in reader tests

Closes #88

## Tests
- `npm test -- tests/internal/CacheStackReader.test.ts`
- `npx biome check src/types.ts src/CacheStack.ts src/internal/CacheStackReader.ts tests/internal/CacheStackReader.test.ts docs/api.md`

Note: `npx tsc --noEmit` still reports pre-existing unrelated test type errors on current `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Major restructuring of core codebase components and internal architecture.
  * Test organization updated to align with new structure.

* **Documentation**
  * API documentation reorganized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->