### PR TITLE
Make Redis-backed assertions timing and order independent

### DIFF
--- a/tests/invalidation/RedisInvalidationBus.test.ts
+++ b/tests/invalidation/RedisInvalidationBus.test.ts
@@ -27,10 +27,10 @@ describe('RedisInvalidationBus', () => {
       })
     )
 
-    await new Promise((resolve) => setTimeout(resolve, 10))
-
-    expect(handler).toHaveBeenCalledTimes(1)
-    expect(errorSpy).toHaveBeenCalled()
+    await vi.waitFor(() => {
+      expect(handler).toHaveBeenCalledTimes(1)
+      expect(errorSpy).toHaveBeenCalled()
+    })
 
     await unsubscribe()
     publisher.disconnect()
@@ -68,10 +68,10 @@ describe('RedisInvalidationBus', () => {
       })
     )
 
-    await new Promise((resolve) => setTimeout(resolve, 10))
-
-    expect(handler).toHaveBeenCalledTimes(2)
-    expect(errorSpy).toHaveBeenCalled()
+    await vi.waitFor(() => {
+      expect(handler).toHaveBeenCalledTimes(2)
+      expect(errorSpy).toHaveBeenCalled()
+    })
 
     await unsubscribe()
     publisher.disconnect()
@@ -94,10 +94,10 @@ describe('RedisInvalidationBus', () => {
       JSON.stringify({ scope: 'key', sourceId: 'inst', keys: ['k'], operation: 'delete' })
     )
 
-    await new Promise((resolve) => setTimeout(resolve, 10))
-
-    expect(handler1).toHaveBeenCalledTimes(1)
-    expect(handler2).toHaveBeenCalledTimes(1)
+    await vi.waitFor(() => {
+      expect(handler1).toHaveBeenCalledTimes(1)
+      expect(handler2).toHaveBeenCalledTimes(1)
+    })
 
     // Unsubscribing one handler should not affect the other
     await unsub1()
@@ -107,10 +107,10 @@ describe('RedisInvalidationBus', () => {
       JSON.stringify({ scope: 'clear', sourceId: 'inst', operation: 'clear' })
     )
 
-    await new Promise((resolve) => setTimeout(resolve, 10))
-
-    expect(handler1).toHaveBeenCalledTimes(1) // no more calls
-    expect(handler2).toHaveBeenCalledTimes(2)
+    await vi.waitFor(() => {
+      expect(handler1).toHaveBeenCalledTimes(1) // no more calls
+      expect(handler2).toHaveBeenCalledTimes(2)
+    })
 
     await unsub2()
     publisher.disconnect()
@@ -138,10 +138,10 @@ describe('RedisInvalidationBus', () => {
       JSON.stringify({ scope: 'key', sourceId: 'inst', keys: ['k'], operation: 'delete' })
     )
 
-    await new Promise((resolve) => setTimeout(resolve, 10))
-
-    expect(logger.error).toHaveBeenCalled()
-    expect(consoleSpy).not.toHaveBeenCalled()
+    await vi.waitFor(() => {
+      expect(logger.error).toHaveBeenCalled()
+      expect(consoleSpy).not.toHaveBeenCalled()
+    })
 
     await unsubscribe()
     publisher.disconnect()
@@ -178,10 +178,10 @@ describe('RedisInvalidationBus', () => {
       })
     )
 
-    await new Promise((resolve) => setTimeout(resolve, 10))
-
-    expect(handler).not.toHaveBeenCalled()
-    expect(logger.error).toHaveBeenCalled()
+    await vi.waitFor(() => {
+      expect(handler).not.toHaveBeenCalled()
+      expect(logger.error).toHaveBeenCalled()
+    })
 
     await unsubscribe()
     publisher.disconnect()
@@ -213,10 +213,10 @@ describe('RedisInvalidationBus', () => {
       })
     )
 
-    await new Promise((resolve) => setTimeout(resolve, 10))
-
-    expect(handler).not.toHaveBeenCalled()
-    expect(logger.error).toHaveBeenCalled()
+    await vi.waitFor(() => {
+      expect(handler).not.toHaveBeenCalled()
+      expect(logger.error).toHaveBeenCalled()
+    })
 
     await unsubscribe()
     publisher.disconnect()
@@ -235,10 +235,10 @@ describe('RedisInvalidationBus', () => {
     await bus.publish({ scope: 'key', sourceId: 'inst', keys: ['user:1'], operation: 'delete' })
     await publisher.publish('layercache:test:shape', JSON.stringify(42))
 
-    await new Promise((resolve) => setTimeout(resolve, 10))
-
-    expect(handler).toHaveBeenCalledTimes(1)
-    expect(errorSpy).toHaveBeenCalled()
+    await vi.waitFor(() => {
+      expect(handler).toHaveBeenCalledTimes(1)
+      expect(errorSpy).toHaveBeenCalled()
+    })
 
     await unsubscribe()
     publisher.disconnect()
@@ -263,16 +263,16 @@ describe('RedisInvalidationBus', () => {
       JSON.stringify({ scope: 'keys', sourceId: 'inst', keys: ['user:2'], operation: 'unknown' })
     )
 
-    await new Promise((resolve) => setTimeout(resolve, 10))
-
-    expect(handler).toHaveBeenCalledTimes(1)
-    expect(handler).toHaveBeenCalledWith(
-      expect.objectContaining({
-        operation: 'expire',
-        keys: ['user:1']
-      })
-    )
-    expect(errorSpy).toHaveBeenCalled()
+    await vi.waitFor(() => {
+      expect(handler).toHaveBeenCalledTimes(1)
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: 'expire',
+          keys: ['user:1']
+        })
+      )
+      expect(errorSpy).toHaveBeenCalled()
+    })
 
     await unsubscribe()
     publisher.disconnect()
@@ -295,15 +295,17 @@ describe('RedisInvalidationBus', () => {
     const unsubscribe = await busB.subscribe(handler)
 
     await busA.publish({ scope: 'key', sourceId: 'inst', keys: ['user:1'], operation: 'delete' })
-    await new Promise((resolve) => setTimeout(resolve, 10))
 
-    expect(handler).toHaveBeenCalledWith(
-      expect.objectContaining({
-        scope: 'key',
-        keys: ['user:1'],
-        operation: 'delete'
-      })
-    )
+    await vi.waitFor(() => {
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scope: 'key',
+          keys: ['user:1'],
+          operation: 'delete'
+        })
+      )
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
 
     await unsubscribe()
     publisher.disconnect()
@@ -324,10 +326,10 @@ describe('RedisInvalidationBus', () => {
       channel,
       JSON.stringify({ scope: 'key', sourceId: 'inst', keys: ['user:1'], operation: 'delete' })
     )
-    await new Promise((resolve) => setTimeout(resolve, 10))
-
-    expect(handler).not.toHaveBeenCalled()
-    expect(logger.error).toHaveBeenCalled()
+    await vi.waitFor(() => {
+      expect(handler).not.toHaveBeenCalled()
+      expect(logger.error).toHaveBeenCalled()
+    })
 
     await unsubscribe()
     publisher.disconnect()
@@ -346,8 +348,9 @@ describe('RedisInvalidationBus', () => {
     const unsubscribe = await bus.subscribe(handler)
 
     await bus.publish({ scope: 'key', sourceId: 'inst', keys: ['user:1'], operation: 'delete' })
-    await new Promise((resolve) => setTimeout(resolve, 10))
-    expect(handler).toHaveBeenCalledTimes(1)
+    await vi.waitFor(() => {
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
 
     const signedPayload = String(publishSpy.mock.calls[0]?.[1])
     const parsedPayload = JSON.parse(signedPayload) as {
@@ -362,10 +365,10 @@ describe('RedisInvalidationBus', () => {
     logger.error.mockClear()
 
     await publisher.publish(channel, JSON.stringify(tampered))
-    await new Promise((resolve) => setTimeout(resolve, 10))
-
-    expect(handler).not.toHaveBeenCalled()
-    expect(logger.error).toHaveBeenCalled()
+    await vi.waitFor(() => {
+      expect(handler).not.toHaveBeenCalled()
+      expect(logger.error).toHaveBeenCalled()
+    })
 
     await unsubscribe()
     publisher.disconnect()

--- a/tests/invalidation/RedisTagIndex.test.ts
+++ b/tests/invalidation/RedisTagIndex.test.ts
@@ -10,7 +10,7 @@ describe('RedisTagIndex', () => {
     await index.track('user:1', ['team:a', 'role:admin'])
     await index.track('user:2', ['team:a'])
 
-    await expect(index.keysForTag('team:a')).resolves.toEqual(['user:1', 'user:2'])
+    expect((await index.keysForTag('team:a')).sort()).toEqual(['user:1', 'user:2'])
     await expect(index.tagsForKey('user:1')).resolves.toEqual(expect.arrayContaining(['role:admin', 'team:a']))
 
     await index.remove('user:1')
@@ -44,7 +44,7 @@ describe('RedisTagIndex', () => {
     await index.touch('user:2')
     await index.touch('post:1')
 
-    await expect(index.keysForPrefix('user:')).resolves.toEqual(['user:1', 'user:2'])
+    expect((await index.keysForPrefix('user:')).sort()).toEqual(['user:1', 'user:2'])
   })
 
   it('filters prefix scan results with startsWith for literal safety', async () => {
@@ -65,7 +65,7 @@ describe('RedisTagIndex', () => {
     await index.touch('user:2')
     await index.touch('post:1')
 
-    await expect(index.keysForPrefix('user:')).resolves.toEqual(['user:1', 'user:2'])
+    expect((await index.keysForPrefix('user:')).sort()).toEqual(['user:1', 'user:2'])
   })
 
   it('defaults known-key tracking to 16 shards', async () => {
@@ -80,7 +80,7 @@ describe('RedisTagIndex', () => {
 
     expect(indexKeys).toEqual(expect.arrayContaining([expect.stringMatching(/^tags:default-shards:keys:\d+$/)]))
     expect(indexKeys).not.toContain('tags:default-shards:keys')
-    await expect(index.keysForPrefix('user:')).resolves.toEqual(['user:1', 'user:2'])
+    expect((await index.keysForPrefix('user:')).sort()).toEqual(['user:1', 'user:2'])
   })
 
   it('reads and warns about legacy unsharded known-key sets after the default shard upgrade', async () => {
@@ -106,7 +106,7 @@ describe('RedisTagIndex', () => {
 
     await expect(index.migrateLegacyKnownKeys()).resolves.toEqual({ migratedKeys: 3 })
     await expect(redis.smembers('tags:migrate:keys')).resolves.toEqual([])
-    await expect(index.keysForPrefix('user:')).resolves.toEqual(['user:1', 'user:2'])
+    expect((await index.keysForPrefix('user:')).sort()).toEqual(['user:1', 'user:2'])
   })
 
   it('supports pattern scans and async visitor helpers', async () => {
@@ -117,19 +117,19 @@ describe('RedisTagIndex', () => {
     await index.track('user:2', ['people'])
     await index.track('post:1', ['posts'])
 
-    await expect(index.matchPattern('user:*')).resolves.toEqual(['user:1', 'user:2'])
+    expect((await index.matchPattern('user:*')).sort()).toEqual(['user:1', 'user:2'])
 
     const byTag: string[] = []
     await index.forEachKeyForTag('people', async (key) => {
       byTag.push(key)
     })
-    expect(byTag).toEqual(['user:1', 'user:2'])
+    expect(byTag.sort()).toEqual(['user:1', 'user:2'])
 
     const byPrefix: string[] = []
     await index.forEachKeyForPrefix('user:', async (key) => {
       byPrefix.push(key)
     })
-    expect(byPrefix).toEqual(['user:1', 'user:2'])
+    expect(byPrefix.sort()).toEqual(['user:1', 'user:2'])
 
     const byPattern: string[] = []
     await index.forEachKeyMatchingPattern('post:*', async (key) => {


### PR DESCRIPTION
## Description

Makes the Redis-backed test suites independent of timing and set-ordering assumptions. Uses `vi.waitFor` which resolves as soon as the assertion passes, so the suite should be both faster and deterministic.

This also prepares these suites to run unchanged against a real Redis server (pending different PR).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Refactor (no functional change, code improvement)
- [ ] Documentation update
- [x] Test coverage improvement

## Testing

- [x] All existing tests pass (`npm test`)
- [ ] New tests added for the changes
- [ ] Lint passes (`npm run lint`)
- [ ] Build succeeds (`npm run build:all`)

## Checklist

- [x] My changes follow the existing code style (single quotes, no semicolons, 2-space indent)
- [ ] I have updated documentation where applicable
- [ ] I have updated `CHANGELOG.md` and package versions when the PR changes release scope
- [ ] I have added tests that prove my fix/feature works
- [x] No type errors suppressed (`as any`, `@ts-ignore`, `@ts-expect-error`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Improved asynchronous test synchronization by replacing fixed delays with proper waiting until expected handler invocations and logging occur.
  * Strengthened invalidation and message validation scenarios, including signed message acceptance/rejection and tampering behavior.
  * Made tag/prefix index assertions deterministic by sorting returned key collections before comparing.
  * Updated async assertions to use direct awaits while preserving existing behavioral coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->