### PR TITLE
Map snapshot paths through realpath base dir

### DIFF
--- a/src/internal/CacheSnapshotFile.ts
+++ b/src/internal/CacheSnapshotFile.ts
@@ -35,6 +35,21 @@ async function findExistingAncestor(
   }
 }
 
+function mapUnderRealBase(
+  resolvedPath: string,
+  logicalBaseDir: string,
+  realBaseDir: string,
+  pathSeparator: string,
+  path: typeof import('node:path')
+): string {
+  if (!isWithinSnapshotBase(logicalBaseDir, resolvedPath, pathSeparator, path)) {
+    return resolvedPath
+  }
+
+  const relative = path.relative(logicalBaseDir, resolvedPath)
+  return relative.length === 0 ? realBaseDir : path.join(realBaseDir, relative)
+}
+
 export async function validateSnapshotFilePath(
   filePath: string,
   mode: 'read' | 'write',
@@ -60,7 +75,8 @@ export async function validateSnapshotFilePath(
 
   await fs.mkdir(baseDir, { recursive: true })
   const realBaseDir = await fs.realpath(baseDir)
-  if (!isWithinSnapshotBase(realBaseDir, resolved, path.sep, path)) {
+  const normalizedResolved = mapUnderRealBase(resolved, baseDir, realBaseDir, path.sep, path)
+  if (!isWithinSnapshotBase(realBaseDir, normalizedResolved, path.sep, path)) {
     throw new Error(`filePath is outside the allowed snapshot directory: ${realBaseDir}`)
   }
 

--- a/tests/internal/CacheSnapshotFile.test.ts
+++ b/tests/internal/CacheSnapshotFile.test.ts
@@ -1,5 +1,5 @@
 import * as fs from 'node:fs'
-import { mkdtemp, open, rm, symlink, writeFile } from 'node:fs/promises'
+import { mkdtemp, open, realpath, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
@@ -14,13 +14,14 @@ describe('CacheSnapshotFile', () => {
   it('validates read and write paths inside the configured snapshot base dir', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'layercache-snapshot-file-'))
     const filePath = join(dir, 'nested', 'deeper', 'snapshot.json')
+    const realFilePath = join(await realpath(dir), 'nested', 'deeper', 'snapshot.json')
 
     try {
-      await expect(validateSnapshotFilePath(filePath, 'write', dir)).resolves.toBe(filePath)
+      await expect(validateSnapshotFilePath(filePath, 'write', dir)).resolves.toBe(realFilePath)
       await expect(validateSnapshotFilePath(filePath, 'write', false)).resolves.toBe(resolve(filePath))
 
       await writeFile(filePath, '[]', 'utf8')
-      await expect(validateSnapshotFilePath(filePath, 'read', dir)).resolves.toBe(filePath)
+      await expect(validateSnapshotFilePath(filePath, 'read', dir)).resolves.toBe(realFilePath)
     } finally {
       await rm(dir, { recursive: true, force: true })
     }


### PR DESCRIPTION
## Description

macOS tmpdir is `/var/...` while `realpath` is `/private/var/...`, so snapshot path checks wrongly rejected valid paths.

## Type of Change

<!-- Mark the relevant option with an `x` -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Refactor (no functional change, code improvement)
- [ ] Documentation update
- [ ] Test coverage improvement

## Changes

Map paths under the logical `snapshotBaseDir` into its realpathed form without following user symlinks, so symlink escape checks still work.

## Testing

<!-- How did you verify the changes? -->

- [x] All existing tests pass (`npm test`)
- [ ] New tests added for the changes
- [ ] Lint passes (`npm run lint`)
- [ ] Build succeeds (`npm run build:all`)

## Checklist

- [x] My changes follow the existing code style (single quotes, no semicolons, 2-space indent)
- [x] I have updated documentation where applicable
- [x] I have updated `CHANGELOG.md` and package versions when the PR changes release scope
- [x] I have added tests that prove my fix/feature works
- [x] No type errors suppressed (`as any`, `@ts-ignore`, `@ts-expect-error`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapshot file path validation when configured directories include symbolic links.
  * Read and write operations now resolve to the corresponding real filesystem paths, helping ensure files remain within the permitted snapshot directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->