### PR TITLE
fix: harden integration caching against cross-user data exposure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking
+
+- `createTrpcCacheMiddleware` and `cacheGraphqlResolver` now require a `keyResolver` and no longer accept `allowImplicitContextCaching`. Implicit path+input or argument-only keys could not distinguish authenticated callers and could leak one user's data to another; pass a `keyResolver` that includes every input and request-context attribute that affects the result.
+
 ### Security
 
-- Hardened implicit Express/Hono URL caching so requests carrying common authentication headers (`authorization`, `cookie`, `x-api-key`, `x-session-id`, `x-auth-token`, `x-forwarded-user`) bypass implicit URL-only caching unless a custom `keyResolver` is supplied, preventing one user's authenticated response from being served to another.
-- Hardened tRPC middleware implicit context caching so requests with an authenticated request context (`user`, `session`, `auth`, `identity`, `principal`, `claims`, `currentUser`, `tenant`, or `req` in `ctx`) bypass implicit caching, and emit a startup warning when `allowImplicitContextCaching` is enabled without a `keyResolver`.
-- Emit a startup warning when `cacheGraphqlResolver` runs with implicit context caching (`allowImplicitContextCaching: true`) and no `keyResolver`, since implicit keys do not include the GraphQL request context.
-- Added `RedisInvalidationBus.requireSignature` so deployments can fail fast at construction when `signingSecret` is missing, preventing an unsigned invalidation channel that any Redis publisher could forge messages on.
+- Hardened implicit Express/Hono URL caching so requests carrying common authentication headers (`authorization`, `cookie`, `set-cookie`, `x-api-key`, `x-session-id`, `x-auth-token`, `x-forwarded-user`) bypass implicit URL-only caching unless a custom `keyResolver` is supplied, preventing one user's authenticated response from being served to another. Header names are matched case-insensitively, and header accessors (`Headers#get`, `get()`/`header()`) are invoked with the correct receiver.
+- Added `RedisInvalidationBus.requireSignature` so deployments can fail fast at construction when `signingSecret` is missing, preventing an unsigned invalidation channel that any Redis publisher could forge messages on. Zero-length strings and buffers are treated as missing secrets, and the requirement is validated before a default subscriber is created.
 
 ## [4.0.0] — 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Hardened implicit Express/Hono URL caching so requests carrying common authentication headers (`authorization`, `cookie`, `x-api-key`, `x-session-id`, `x-auth-token`, `x-forwarded-user`) bypass implicit URL-only caching unless a custom `keyResolver` is supplied, preventing one user's authenticated response from being served to another.
+- Hardened tRPC middleware implicit context caching so requests with an authenticated request context (`user`, `session`, `auth`, `identity`, `principal`, `claims`, `currentUser`, `tenant`, or `req` in `ctx`) bypass implicit caching, and emit a startup warning when `allowImplicitContextCaching` is enabled without a `keyResolver`.
+- Emit a startup warning when `cacheGraphqlResolver` runs with implicit context caching (`allowImplicitContextCaching: true`) and no `keyResolver`, since implicit keys do not include the GraphQL request context.
+- Added `RedisInvalidationBus.requireSignature` so deployments can fail fast at construction when `signingSecret` is missing, preventing an unsigned invalidation channel that any Redis publisher could forge messages on.
+
 ## [4.0.0] — 2026-07-19
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ layercache is built for multi-instance production environments:
 ```
 
 - **Redis single-flight** - dedup misses across instances with distributed locks
-- **Redis invalidation bus** - pub/sub-based L1 invalidation for memory consistency; set `signingSecret` for shared Redis channels
+- **Redis invalidation bus** - pub/sub-based L1 invalidation for memory consistency; set `signingSecret` for shared Redis channels (and `requireSignature: true` to fail fast when the secret is missing — without signing, any client that can publish to the channel can forge invalidation messages)
 - **Redis tag index** - shared tag tracking with 16 known-key shards by default
 - **Snapshot persistence** - export/import state between instances
 
@@ -406,7 +406,8 @@ const redis = new Redis(process.env.REDIS_URL)
 const bus = new RedisInvalidationBus({
   publisher: redis,
   subscriber: new Redis(process.env.REDIS_URL),
-  signingSecret: process.env.LAYERCACHE_INVALIDATION_SECRET
+  signingSecret: process.env.LAYERCACHE_INVALIDATION_SECRET,
+  requireSignature: process.env.NODE_ENV === 'production'
 })
 const tagIndex = new RedisTagIndex({ client: redis, prefix: 'myapp:tags', knownKeysShards: 16 })
 const coordinator = new RedisSingleFlightCoordinator({ client: redis })

--- a/docs-web/content/docs/api.mdx
+++ b/docs-web/content/docs/api.mdx
@@ -1073,7 +1073,7 @@ import { createTrpcCacheMiddleware } from 'layercache'
 
 // keyResolver is required: it must include every input and context attribute
 // that affects procedure output (including the authenticated user, if any).
-const cacheMiddleware = createTrpcCacheMiddleware(cache, 'trpc', {
+const cacheMiddleware = createTrpcCacheMiddleware<unknown, unknown, { id?: string }>(cache, 'trpc', {
   keyResolver: (input, path, _type, context) => `${context?.id ?? 'anon'}:${path}:${JSON.stringify(input)}`,
   ttl: 60_000
 })

--- a/docs-web/content/docs/api.mdx
+++ b/docs-web/content/docs/api.mdx
@@ -1071,7 +1071,12 @@ app.use('/api/*', createHonoCacheMiddleware(cache, { ttl: 60_000 }))
 ```ts
 import { createTrpcCacheMiddleware } from 'layercache'
 
-const cacheMiddleware = createTrpcCacheMiddleware(cache, 'trpc', { ttl: 60_000 })
+// keyResolver is required: it must include every input and context attribute
+// that affects procedure output (including the authenticated user, if any).
+const cacheMiddleware = createTrpcCacheMiddleware(cache, 'trpc', {
+  keyResolver: (input, path, _type, context) => `${context?.id ?? 'anon'}:${path}:${JSON.stringify(input)}`,
+  ttl: 60_000
+})
 export const cachedProcedure = t.procedure.use(cacheMiddleware)
 ```
 

--- a/docs-web/content/docs/integrations.mdx
+++ b/docs-web/content/docs/integrations.mdx
@@ -65,7 +65,7 @@ app.get('/api/users/:id',
 - `methods` - HTTP methods to cache (default: `['GET']`)
 - `ttl` - Time-to-live in milliseconds
 - `tags` - Tags for invalidation
-- `allowPrivateCaching` - Allow implicit URL-based keys (default: false). Requests with common sensitive query parameters such as `access_token`, `api_key`, `apikey`, `auth`, `authorization`, `client_assertion`, `client_assertion_type`, `client_secret`, `code`, `credentials`, `id_token`, `jwt`, `password`, `private_key`, `refresh_token`, `secret`, `session`, `sessionid`, `session_id`, and `token` bypass implicit caching unless you provide a custom `keyResolver`.
+- `allowPrivateCaching` - Allow implicit URL-based keys (default: false). This is shared URL-based caching, not per-user/private caching; never enable it for responses that vary by cookies, authorization headers, or authenticated user identity. Requests with common sensitive query parameters such as `access_token`, `api_key`, `apikey`, `auth`, `authorization`, `client_assertion`, `client_assertion_type`, `client_secret`, `code`, `credentials`, `id_token`, `jwt`, `password`, `private_key`, `refresh_token`, `secret`, `session`, `sessionid`, `session_id`, and `token` bypass implicit caching unless you provide a custom `keyResolver`. Requests carrying common authentication headers also bypass implicit caching unless you provide a custom `keyResolver`.
 
 Only 2xx JSON responses are written to the cache. 3xx, 4xx, and 5xx responses still return to the client but are not cached.
 
@@ -173,7 +173,7 @@ app.get('/api/users/:id',
 - `methods` - HTTP methods to cache (default: `['GET']`)
 - `ttl` - Time-to-live in milliseconds
 - `tags` - Tags for invalidation
-- `allowPrivateCaching` - Allow implicit URL-based keys (default: false). Requests with sensitive query parameters use the same bypass behavior as the Express middleware unless you provide a custom `keyResolver`.
+- `allowPrivateCaching` - Allow implicit URL-based keys (default: false). This is shared URL-based caching, not per-user/private caching; never enable it for responses that vary by cookies, authorization headers, or authenticated user identity. Requests with sensitive query parameters or common authentication headers bypass implicit caching unless you provide a custom `keyResolver`.
 
 Only 2xx JSON responses are written to the cache. The middleware also respects status set via `context.status(500)` before `context.json(body)`.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -984,7 +984,12 @@ import { RedisInvalidationBus } from 'layercache'
 const bus = new RedisInvalidationBus({
   publisher: redis,
   subscriber: new Redis(),
-  signingSecret: process.env.LAYERCACHE_INVALIDATION_SECRET
+  // Sign messages with HMAC-SHA256 so subscribers can verify authenticity.
+  // Without signing, any client that can publish to the channel can forge
+  // invalidation messages. Use requireSignature: true to fail fast when the
+  // secret is missing in a given environment.
+  signingSecret: process.env.LAYERCACHE_INVALIDATION_SECRET,
+  requireSignature: process.env.NODE_ENV === 'production'
 })
 
 new CacheStack([...], {
@@ -1070,7 +1075,12 @@ app.use('/api/*', createHonoCacheMiddleware(cache, { ttl: 60_000 }))
 ```ts
 import { createTrpcCacheMiddleware } from 'layercache'
 
-const cacheMiddleware = createTrpcCacheMiddleware(cache, 'trpc', { ttl: 60_000 })
+// keyResolver is required: it must include every input and context attribute
+// that affects procedure output (including the authenticated user, if any).
+const cacheMiddleware = createTrpcCacheMiddleware(cache, 'trpc', {
+  keyResolver: (input, path, _type, context) => `${context?.id ?? 'anon'}:${path}:${JSON.stringify(input)}`,
+  ttl: 60_000
+})
 export const cachedProcedure = t.procedure.use(cacheMiddleware)
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1077,7 +1077,7 @@ import { createTrpcCacheMiddleware } from 'layercache'
 
 // keyResolver is required: it must include every input and context attribute
 // that affects procedure output (including the authenticated user, if any).
-const cacheMiddleware = createTrpcCacheMiddleware(cache, 'trpc', {
+const cacheMiddleware = createTrpcCacheMiddleware<unknown, unknown, { id?: string }>(cache, 'trpc', {
   keyResolver: (input, path, _type, context) => `${context?.id ?? 'anon'}:${path}:${JSON.stringify(input)}`,
   ttl: 60_000
 })

--- a/src/integrations/express.ts
+++ b/src/integrations/express.ts
@@ -1,6 +1,6 @@
 import type { CacheStack } from '../CacheStack'
 import type { CacheGetOptions } from '../types'
-import { hasSensitiveHttpCacheQuery, normalizeHttpCacheUrl } from './httpCacheKeys'
+import { hasSensitiveHttpCacheHeaders, hasSensitiveHttpCacheQuery, normalizeHttpCacheUrl } from './httpCacheKeys'
 
 interface ExpressLikeRequest {
   method?: string
@@ -68,6 +68,11 @@ export function createExpressCacheMiddleware(cache: CacheStack, options: Express
 
       const rawUrl = req.originalUrl ?? req.url ?? '/'
       if (!options.keyResolver && hasSensitiveHttpCacheQuery(rawUrl)) {
+        next()
+        return
+      }
+
+      if (!options.keyResolver && hasSensitiveHttpCacheHeaders(req)) {
         next()
         return
       }

--- a/src/integrations/graphql.ts
+++ b/src/integrations/graphql.ts
@@ -3,23 +3,22 @@ import type { CacheGetOptions } from '../types'
 
 interface GraphqlCacheOptions<TArgs extends unknown[]> extends CacheGetOptions {
   /** Converts resolver arguments into a stable cache key suffix. */
-  keyResolver?: (...args: TArgs) => string
-  /** Allow fallback key generation from resolver args when no `keyResolver` is provided. */
-  allowImplicitContextCaching?: boolean
+  keyResolver: (...args: TArgs) => string
 }
 
 /**
- * Wraps a GraphQL resolver with read-through caching.
+ * Wraps a GraphQL resolver with read-through caching. The key resolver must
+ * include every argument and request-context attribute that affects output.
  */
 export function cacheGraphqlResolver<TArgs extends unknown[], TResult>(
   cache: CacheStack,
   prefix: string,
   resolver: (...args: TArgs) => Promise<TResult>,
-  options: GraphqlCacheOptions<TArgs> = {}
+  options: GraphqlCacheOptions<TArgs> = {} as GraphqlCacheOptions<TArgs>
 ): (...args: TArgs) => Promise<TResult | undefined> {
-  if (!options.keyResolver && options.allowImplicitContextCaching !== true) {
+  if (!options.keyResolver) {
     throw new Error(
-      'cacheGraphqlResolver requires a keyResolver or allowImplicitContextCaching=true because resolver output may depend on request context.'
+      'cacheGraphqlResolver requires a keyResolver that includes every resolver argument and request-context attribute affecting output.'
     )
   }
 

--- a/src/integrations/hono.ts
+++ b/src/integrations/hono.ts
@@ -1,6 +1,6 @@
 import type { CacheStack } from '../CacheStack'
 import type { CacheGetOptions } from '../types'
-import { hasSensitiveHttpCacheQuery, normalizeHttpCacheUrl } from './httpCacheKeys'
+import { hasSensitiveHttpCacheHeaders, hasSensitiveHttpCacheQuery, normalizeHttpCacheUrl } from './httpCacheKeys'
 
 interface HonoLikeRequest {
   method?: string
@@ -50,6 +50,11 @@ export function createHonoCacheMiddleware(cache: CacheStack, options: HonoCacheM
 
     const rawPath = context.req.url ?? context.req.path ?? '/'
     if (!options.keyResolver && hasSensitiveHttpCacheQuery(rawPath)) {
+      await next()
+      return
+    }
+
+    if (!options.keyResolver && hasSensitiveHttpCacheHeaders(context.req)) {
       await next()
       return
     }

--- a/src/integrations/httpCacheKeys.ts
+++ b/src/integrations/httpCacheKeys.ts
@@ -21,12 +21,72 @@ const SENSITIVE_QUERY_PARAMETERS = new Set([
   'token'
 ])
 
+const SENSITIVE_HEADERS = new Set([
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'x-api-key',
+  'x-session-id',
+  'x-auth-token',
+  'x-forwarded-user'
+])
+
 export function normalizeHttpCacheUrl(url: string): string {
   return inspectHttpCacheUrl(url).normalizedUrl
 }
 
 export function hasSensitiveHttpCacheQuery(url: string): boolean {
   return inspectHttpCacheUrl(url).hasSensitiveQuery
+}
+
+/**
+ * Checks whether the request carries any authentication-related headers that
+ * make the response caller-specific. When these are present, implicit URL-only
+ * caching would serve one user's authenticated data to another.
+ *
+ * Accepts either a headers object (web `Headers`, a plain record, or an object
+ * with a `get()`/`header()` accessor) or a request-like object with a nested
+ * `headers` field and/or a `get()`/`header()` accessor (Express/Hono style).
+ */
+export function hasSensitiveHttpCacheHeaders(request: unknown): boolean {
+  if (!request || typeof request !== 'object') {
+    return false
+  }
+
+  const record = request as Record<string, unknown>
+
+  for (const name of SENSITIVE_HEADERS) {
+    if (readHeader(record, name)) {
+      return true
+    }
+  }
+
+  const headers = record.headers
+  if (headers && typeof headers === 'object') {
+    const headerRecord = headers as Record<string, unknown>
+    for (const name of SENSITIVE_HEADERS) {
+      if (readHeader(headerRecord, name)) {
+        return true
+      }
+    }
+  }
+
+  return false
+}
+
+function readHeader(record: Record<string, unknown>, name: string): string | undefined | null {
+  if (typeof record.get === 'function' || typeof record.header === 'function') {
+    const accessor = (typeof record.get === 'function' ? record.get : record.header) as (
+      n: string
+    ) => string | undefined | null
+    return accessor(name)
+  }
+
+  if (typeof record[name] === 'string') {
+    return record[name] as string
+  }
+
+  return undefined
 }
 
 function inspectHttpCacheUrl(url: string): { normalizedUrl: string; hasSensitiveQuery: boolean } {

--- a/src/integrations/httpCacheKeys.ts
+++ b/src/integrations/httpCacheKeys.ts
@@ -74,16 +74,21 @@ export function hasSensitiveHttpCacheHeaders(request: unknown): boolean {
   return false
 }
 
+/** Reads a single header value from an accessor-bearing or plain-record header object. */
 function readHeader(record: Record<string, unknown>, name: string): string | undefined | null {
   if (typeof record.get === 'function' || typeof record.header === 'function') {
-    const accessor = (typeof record.get === 'function' ? record.get : record.header) as (
+    const method = (typeof record.get === 'function' ? record.get : record.header) as (
+      this: unknown,
       n: string
     ) => string | undefined | null
-    return accessor(name)
+    return method.call(record, name)
   }
 
-  if (typeof record[name] === 'string') {
-    return record[name] as string
+  // Plain records may use any casing (e.g. `Authorization`); match case-insensitively.
+  for (const [key, value] of Object.entries(record)) {
+    if (key.toLowerCase() === name && typeof value === 'string' && value !== '') {
+      return value
+    }
   }
 
   return undefined

--- a/src/integrations/trpc.ts
+++ b/src/integrations/trpc.ts
@@ -20,30 +20,31 @@ interface TrpcCacheMiddlewareContext<TInput = unknown, TResult = unknown, TConte
 
 interface TrpcCacheMiddlewareOptions<TInput, TContext> extends CacheGetOptions {
   /** Converts procedure input and metadata into a stable cache key suffix. */
-  keyResolver?: (input: TInput, path?: string, type?: string, context?: TContext) => string
-  /** Allow fallback key generation from procedure path and raw input. */
-  allowImplicitContextCaching?: boolean
+  keyResolver: (input: TInput, path?: string, type?: string, context?: TContext) => string
 }
 
 /**
  * Creates a tRPC middleware that caches successful procedure results.
+ *
+ * A `keyResolver` is required: procedure output can depend on authenticated
+ * request context, so the key must include every input and context attribute
+ * that affects the result. Implicit path+input keys do not distinguish
+ * authenticated callers and would leak one user's data to another.
  */
 export function createTrpcCacheMiddleware<TInput = unknown, TResult = unknown, TContext = unknown>(
   cache: CacheStack,
   prefix: string,
-  options: TrpcCacheMiddlewareOptions<TInput, TContext> = {}
+  options: TrpcCacheMiddlewareOptions<TInput, TContext> = {} as TrpcCacheMiddlewareOptions<TInput, TContext>
 ) {
-  if (!options.keyResolver && options.allowImplicitContextCaching !== true) {
+  if (!options.keyResolver) {
     throw new Error(
-      'createTrpcCacheMiddleware requires a keyResolver or allowImplicitContextCaching=true because procedure output may depend on request context.'
+      'createTrpcCacheMiddleware requires a keyResolver that includes every request attribute affecting procedure output, including authenticated context.'
     )
   }
 
   return async (context: TrpcCacheMiddlewareContext<TInput, TResult, TContext>) => {
     const input = await resolveTrpcInput(context)
-    const key = options.keyResolver
-      ? `${prefix}:${options.keyResolver(input, context.path, context.type, context.ctx)}`
-      : `${prefix}:${context.path ?? 'procedure'}:${JSON.stringify(input ?? null)}`
+    const key = `${prefix}:${options.keyResolver(input, context.path, context.type, context.ctx)}`
 
     const callerShouldCache = options.shouldCache
     const cacheOptions: CacheGetOptions = {

--- a/src/invalidation/RedisInvalidationBus.ts
+++ b/src/invalidation/RedisInvalidationBus.ts
@@ -11,10 +11,16 @@ interface RedisInvalidationBusOptions {
   /** Pub/sub channel name. Defaults to `layercache:invalidation`. */
   channel?: string
   /**
-   * Optional shared secret used to sign and verify invalidation messages.
+   * Shared secret used to sign and verify invalidation messages.
    * When configured, unsigned or invalidly signed messages are rejected.
    */
   signingSecret?: string | Buffer
+  /**
+   * Require a signing secret. When `true`, constructing the bus without a
+   * `signingSecret` throws instead of silently running an unsigned channel
+   * that any Redis publisher could forge messages on. Defaults to `false`.
+   */
+  requireSignature?: boolean
   /** Optional logger for invalid payloads or subscriber errors. */
   logger?: CacheLogger
 }
@@ -47,9 +53,17 @@ export class RedisInvalidationBus implements InvalidationBus {
     this.channel = options.channel ?? 'layercache:invalidation'
     this.logger = options.logger
     this.signingKey = options.signingSecret ? normalizeSigningSecret(options.signingSecret) : undefined
+    if (!this.signingKey && options.requireSignature === true) {
+      throw new Error(
+        'RedisInvalidationBus requires a signingSecret when requireSignature=true. ' +
+          'Without signing, any Redis publisher can forge invalidation messages on the channel.'
+      )
+    }
     if (!this.signingKey) {
       this.logger?.warn?.(
-        'RedisInvalidationBus is running without signingSecret; invalidation messages are unsigned.',
+        'RedisInvalidationBus is running without signingSecret; invalidation messages are unsigned. ' +
+          'Any client that can publish to the channel can forge invalidation messages. ' +
+          'Set signingSecret (or requireSignature=true) for shared or untrusted Redis channels.',
         {
           channel: this.channel
         }

--- a/src/invalidation/RedisInvalidationBus.ts
+++ b/src/invalidation/RedisInvalidationBus.ts
@@ -49,16 +49,21 @@ export class RedisInvalidationBus implements InvalidationBus {
 
   constructor(options: RedisInvalidationBusOptions) {
     this.publisher = options.publisher
-    this.subscriber = options.subscriber ?? options.publisher.duplicate()
     this.channel = options.channel ?? 'layercache:invalidation'
     this.logger = options.logger
-    this.signingKey = options.signingSecret ? normalizeSigningSecret(options.signingSecret) : undefined
+
+    const rawSecret = resolveSigningSecret(options.signingSecret)
+    this.signingKey = rawSecret ? normalizeSigningSecret(rawSecret) : undefined
+
     if (!this.signingKey && options.requireSignature === true) {
       throw new Error(
         'RedisInvalidationBus requires a signingSecret when requireSignature=true. ' +
           'Without signing, any Redis publisher can forge invalidation messages on the channel.'
       )
     }
+
+    this.subscriber = options.subscriber ?? options.publisher.duplicate()
+
     if (!this.signingKey) {
       this.logger?.warn?.(
         'RedisInvalidationBus is running without signingSecret; invalidation messages are unsigned. ' +
@@ -228,6 +233,17 @@ export class RedisInvalidationBus implements InvalidationBus {
 function normalizeSigningSecret(secret: string | Buffer): Buffer {
   const raw = Buffer.isBuffer(secret) ? secret : Buffer.from(secret, 'utf8')
   return createHash('sha256').update(raw).digest()
+}
+
+/** Treats zero-length strings and buffers as missing so they cannot pass as a configured secret. */
+function resolveSigningSecret(secret: string | Buffer | undefined): string | Buffer | undefined {
+  if (secret === undefined) {
+    return undefined
+  }
+  if (Buffer.isBuffer(secret)) {
+    return secret.byteLength > 0 ? secret : undefined
+  }
+  return secret.length > 0 ? secret : undefined
 }
 
 function isEqualSignature(actual: string, expected: string): boolean {

--- a/tests/integrations/Integrations.test.ts
+++ b/tests/integrations/Integrations.test.ts
@@ -725,6 +725,41 @@ describe('createExpressCacheMiddleware', () => {
     expect(calls).toBe(1)
   })
 
+  it('bypasses implicit express caching when a differently-cased authorization header is present', async () => {
+    const cache = makeCache()
+    const getSpy = vi.spyOn(cache, 'get')
+    const setSpy = vi.spyOn(cache, 'set')
+    const middleware = createExpressCacheMiddleware(cache, { allowPrivateCaching: true })
+    let calls = 0
+
+    const run = async () => {
+      const response = {
+        setHeader: vi.fn(),
+        json: vi.fn((body: unknown) => body)
+      }
+
+      await middleware(
+        {
+          method: 'GET',
+          url: '/api/me',
+          headers: { Authorization: 'Bearer abc', 'X-API-Key': 'k' }
+        },
+        response,
+        () => {
+          calls += 1
+          response.json?.({ calls })
+        }
+      )
+    }
+
+    await run()
+    await run()
+
+    expect(calls).toBe(2)
+    expect(getSpy).not.toHaveBeenCalled()
+    expect(setSpy).not.toHaveBeenCalled()
+  })
+
   it('allows custom express key resolvers to cache sensitive query URLs', async () => {
     const cache = makeCache()
     const setSpy = vi.spyOn(cache, 'set')
@@ -892,7 +927,10 @@ describe('createExpressCacheMiddleware', () => {
   it('respects custom key resolvers for private request contexts', async () => {
     const cache = makeCache()
     const middleware = createExpressCacheMiddleware(cache, {
-      keyResolver: (request) => `${request.method}:${request.url}:${String(request.headers?.['x-tenant-id'])}`
+      keyResolver: (request) => {
+        const headers = request.headers as Record<string, unknown> | undefined
+        return `${request.method}:${request.url}:${String(headers?.['x-tenant-id'])}`
+      }
     })
     let calls = 0
 
@@ -1371,6 +1409,34 @@ describe('createHonoCacheMiddleware', () => {
           method: 'GET',
           url: '/api/me',
           header: vi.fn((name: string) => (name === 'cookie' ? 'session=abc' : undefined))
+        },
+        header: vi.fn(),
+        json: vi.fn((body) => body)
+      }
+
+      await middleware(context, async () => {
+        calls += 1
+        context.json({ calls })
+      })
+    }
+
+    await run()
+    await run()
+
+    expect(calls).toBe(2)
+  })
+
+  it('bypasses implicit hono caching when a differently-cased request header accessor is used', async () => {
+    const cache = makeCache()
+    const middleware = createHonoCacheMiddleware(cache, { allowPrivateCaching: true })
+    let calls = 0
+
+    const run = async () => {
+      const context = {
+        req: {
+          method: 'GET',
+          url: '/api/me',
+          header: vi.fn((name: string) => (name === 'authorization' ? 'Bearer abc' : undefined))
         },
         header: vi.fn(),
         json: vi.fn((body) => body)

--- a/tests/integrations/Integrations.test.ts
+++ b/tests/integrations/Integrations.test.ts
@@ -5,12 +5,35 @@ import { createExpressCacheMiddleware } from '../../src/integrations/express'
 import { createFastifyLayercachePlugin } from '../../src/integrations/fastify'
 import { cacheGraphqlResolver } from '../../src/integrations/graphql'
 import { createHonoCacheMiddleware } from '../../src/integrations/hono'
+import { hasSensitiveHttpCacheHeaders } from '../../src/integrations/httpCacheKeys'
 import { createTrpcCacheMiddleware } from '../../src/integrations/trpc'
 import { MemoryLayer } from '../../src/layers/MemoryLayer'
 
 function makeCache() {
   return new CacheStack([new MemoryLayer({ ttl: 60_000 })])
 }
+
+// ---------------------------------------------------------------------------
+// Sensitive HTTP header detection
+// ---------------------------------------------------------------------------
+describe('hasSensitiveHttpCacheHeaders', () => {
+  it('returns false for falsy and non-object inputs', () => {
+    expect(hasSensitiveHttpCacheHeaders(undefined)).toBe(false)
+    expect(hasSensitiveHttpCacheHeaders(null)).toBe(false)
+    expect(hasSensitiveHttpCacheHeaders('authorization')).toBe(false)
+    expect(hasSensitiveHttpCacheHeaders(42)).toBe(false)
+  })
+
+  it('returns true for a nested headers record regardless of casing', () => {
+    expect(hasSensitiveHttpCacheHeaders({ headers: { Authorization: 'Bearer abc' } })).toBe(true)
+    expect(hasSensitiveHttpCacheHeaders({ headers: { cookie: 'session=abc' } })).toBe(true)
+  })
+
+  it('returns false when no sensitive headers are present', () => {
+    expect(hasSensitiveHttpCacheHeaders({ headers: { accept: 'application/json' } })).toBe(false)
+    expect(hasSensitiveHttpCacheHeaders({})).toBe(false)
+  })
+})
 
 // ---------------------------------------------------------------------------
 // HTTP stats handler

--- a/tests/integrations/Integrations.test.ts
+++ b/tests/integrations/Integrations.test.ts
@@ -480,30 +480,35 @@ describe('createTrpcCacheMiddleware', () => {
     expect(() => createTrpcCacheMiddleware(cache, 'proc')).toThrow(/requires a keyResolver/i)
   })
 
-  it('supports implicit context caching only when explicitly allowed', async () => {
+  it('separates authenticated callers when the keyResolver includes context', async () => {
     const cache = makeCache()
-    const middleware = createTrpcCacheMiddleware(cache, 'proc', { allowImplicitContextCaching: true })
+    const middleware = createTrpcCacheMiddleware<{ id: number }, { id: number; userId: string }, { userId: string }>(
+      cache,
+      'proc',
+      { keyResolver: (input, _path, _type, context) => `${context?.userId}:${input.id}` }
+    )
     let calls = 0
-    const ctx = {
-      path: 'listUsers',
-      type: 'query',
-      rawInput: { page: 1 },
-      next: async () => {
-        calls += 1
-        return { ok: true, data: ['a'] }
-      }
-    }
 
-    await middleware(ctx)
-    await middleware(ctx)
+    const run = (userId: string) =>
+      middleware({
+        path: 'getCurrentUser',
+        input: { id: 1 },
+        ctx: { userId },
+        next: async () => {
+          calls += 1
+          return { ok: true, data: { id: 1, userId } }
+        }
+      })
 
-    expect(calls).toBe(1)
+    await expect(run('user-a')).resolves.toEqual({ ok: true, data: { id: 1, userId: 'user-a' } })
+    await expect(run('user-b')).resolves.toEqual({ ok: true, data: { id: 1, userId: 'user-b' } })
+    expect(calls).toBe(2)
   })
 
   it('falls back to next() when cache returns undefined without invoking the fetch wrapper', async () => {
     const cache = makeCache()
     const getSpy = vi.spyOn(cache, 'get').mockResolvedValueOnce(undefined)
-    const middleware = createTrpcCacheMiddleware(cache, 'proc', { allowImplicitContextCaching: true })
+    const middleware = createTrpcCacheMiddleware(cache, 'proc', { keyResolver: () => 'ping' })
     const next = vi.fn(async () => ({ ok: true, data: { id: 1 } }))
 
     await expect(middleware({ next, rawInput: { id: 1 } })).resolves.toEqual({ ok: true, data: { id: 1 } })
@@ -621,6 +626,103 @@ describe('createExpressCacheMiddleware', () => {
     expect(calls).toBe(2)
     expect(getSpy).not.toHaveBeenCalled()
     expect(setSpy).not.toHaveBeenCalled()
+  })
+
+  it('bypasses implicit express caching when an authorization header is present', async () => {
+    const cache = makeCache()
+    const getSpy = vi.spyOn(cache, 'get')
+    const setSpy = vi.spyOn(cache, 'set')
+    const middleware = createExpressCacheMiddleware(cache, { allowPrivateCaching: true })
+    let calls = 0
+
+    const run = async () => {
+      const response = {
+        setHeader: vi.fn(),
+        json: vi.fn((body: unknown) => body)
+      }
+
+      await middleware(
+        {
+          method: 'GET',
+          url: '/api/me',
+          headers: { authorization: 'Bearer abc' }
+        },
+        response,
+        () => {
+          calls += 1
+          response.json?.({ calls })
+        }
+      )
+    }
+
+    await run()
+    await run()
+
+    expect(calls).toBe(2)
+    expect(getSpy).not.toHaveBeenCalled()
+    expect(setSpy).not.toHaveBeenCalled()
+  })
+
+  it('bypasses implicit express caching when a cookie header is present', async () => {
+    const cache = makeCache()
+    const middleware = createExpressCacheMiddleware(cache, { allowPrivateCaching: true })
+    let calls = 0
+
+    const run = async () => {
+      const response = {
+        setHeader: vi.fn(),
+        json: vi.fn((body: unknown) => body)
+      }
+
+      await middleware(
+        {
+          method: 'GET',
+          url: '/api/me',
+          headers: { cookie: 'session=abc' }
+        },
+        response,
+        () => {
+          calls += 1
+          response.json?.({ calls })
+        }
+      )
+    }
+
+    await run()
+    await run()
+
+    expect(calls).toBe(2)
+  })
+
+  it('still caches implicit express keys when only non-sensitive headers are present', async () => {
+    const cache = makeCache()
+    const middleware = createExpressCacheMiddleware(cache, { allowPrivateCaching: true })
+    let calls = 0
+
+    const run = async () => {
+      const response = {
+        setHeader: vi.fn(),
+        json: vi.fn((body: unknown) => body)
+      }
+
+      await middleware(
+        {
+          method: 'GET',
+          url: '/public',
+          headers: { accept: 'application/json', 'x-request-id': 'r1' }
+        },
+        response,
+        () => {
+          calls += 1
+          response.json?.({ calls })
+        }
+      )
+    }
+
+    await run()
+    await run()
+
+    expect(calls).toBe(1)
   })
 
   it('allows custom express key resolvers to cache sensitive query URLs', async () => {
@@ -1224,5 +1326,65 @@ describe('createHonoCacheMiddleware', () => {
 
     expect(getSpy).not.toHaveBeenCalled()
     expect(setSpy).not.toHaveBeenCalled()
+  })
+
+  it('bypasses implicit hono caching when an authorization header is present', async () => {
+    const cache = makeCache()
+    const getSpy = vi.spyOn(cache, 'get')
+    const setSpy = vi.spyOn(cache, 'set')
+    const middleware = createHonoCacheMiddleware(cache, { allowPrivateCaching: true })
+    let calls = 0
+
+    const run = async () => {
+      const context = {
+        req: {
+          method: 'GET',
+          path: '/api/me',
+          header: vi.fn((name: string) => (name === 'authorization' ? 'Bearer abc' : undefined))
+        },
+        header: vi.fn(),
+        json: vi.fn((body) => body)
+      }
+
+      await middleware(context, async () => {
+        calls += 1
+        context.json({ calls })
+      })
+    }
+
+    await run()
+    await run()
+
+    expect(calls).toBe(2)
+    expect(getSpy).not.toHaveBeenCalled()
+    expect(setSpy).not.toHaveBeenCalled()
+  })
+
+  it('bypasses implicit hono caching when a cookie header is present', async () => {
+    const cache = makeCache()
+    const middleware = createHonoCacheMiddleware(cache, { allowPrivateCaching: true })
+    let calls = 0
+
+    const run = async () => {
+      const context = {
+        req: {
+          method: 'GET',
+          url: '/api/me',
+          header: vi.fn((name: string) => (name === 'cookie' ? 'session=abc' : undefined))
+        },
+        header: vi.fn(),
+        json: vi.fn((body) => body)
+      }
+
+      await middleware(context, async () => {
+        calls += 1
+        context.json({ calls })
+      })
+    }
+
+    await run()
+    await run()
+
+    expect(calls).toBe(2)
   })
 })

--- a/tests/invalidation/RedisInvalidationBus.test.ts
+++ b/tests/invalidation/RedisInvalidationBus.test.ts
@@ -52,6 +52,42 @@ describe('RedisInvalidationBus', () => {
     subscriber.disconnect()
   })
 
+  it('requires a signing secret when requireSignature is enabled', () => {
+    const publisher = createTestRedis()
+    const subscriber = publisher.duplicate()
+
+    expect(
+      () =>
+        new RedisInvalidationBus({
+          publisher,
+          subscriber,
+          channel: 'layercache:test:required-signature',
+          requireSignature: true
+        })
+    ).toThrow(/requires a signingSecret/i)
+
+    publisher.disconnect()
+    subscriber.disconnect()
+  })
+
+  it('accepts a signing secret when requireSignature is enabled', () => {
+    const publisher = createTestRedis()
+    const subscriber = publisher.duplicate()
+
+    expect(
+      () =>
+        new RedisInvalidationBus({
+          publisher,
+          subscriber,
+          channel: 'layercache:test:required-signature-configured',
+          signingSecret: 'shared-secret',
+          requireSignature: true
+        })
+    ).not.toThrow()
+
+    publisher.disconnect()
+    subscriber.disconnect()
+  })
   it('logs handler errors without breaking the subscription', async () => {
     const publisher = createTestRedis()
     const subscriber = publisher.duplicate()

--- a/tests/invalidation/RedisInvalidationBus.test.ts
+++ b/tests/invalidation/RedisInvalidationBus.test.ts
@@ -88,6 +88,54 @@ describe('RedisInvalidationBus', () => {
     publisher.disconnect()
     subscriber.disconnect()
   })
+  it('rejects zero-length signing secrets when requireSignature is enabled', () => {
+    const publisher = createTestRedis()
+    const subscriber = publisher.duplicate()
+
+    expect(
+      () =>
+        new RedisInvalidationBus({
+          publisher,
+          subscriber,
+          channel: 'layercache:test:empty-string-secret',
+          signingSecret: '',
+          requireSignature: true
+        })
+    ).toThrow(/requires a signingSecret/i)
+
+    expect(
+      () =>
+        new RedisInvalidationBus({
+          publisher,
+          subscriber,
+          channel: 'layercache:test:empty-buffer-secret',
+          signingSecret: Buffer.alloc(0),
+          requireSignature: true
+        })
+    ).toThrow(/requires a signingSecret/i)
+
+    publisher.disconnect()
+    subscriber.disconnect()
+  })
+
+  it('does not create a subscriber before rejecting a missing required signature', () => {
+    const publisher = createTestRedis()
+    const duplicateSpy = vi.spyOn(publisher, 'duplicate')
+
+    expect(
+      () =>
+        new RedisInvalidationBus({
+          publisher,
+          channel: 'layercache:test:no-subscriber-on-reject',
+          requireSignature: true
+        })
+    ).toThrow(/requires a signingSecret/i)
+
+    expect(duplicateSpy).not.toHaveBeenCalled()
+
+    publisher.disconnect()
+  })
+
   it('logs handler errors without breaking the subscription', async () => {
     const publisher = createTestRedis()
     const subscriber = publisher.duplicate()


### PR DESCRIPTION
## Description

Fixes three security findings from the security review: cross-user data exposure through implicit HTTP/context caching, and unsigned Redis invalidation channel forgery.

- **Fixes #109** — implicit Express/Hono URL caching serves authenticated responses across users (`allowPrivateCaching`)
- **Fixes #110** — tRPC/GraphQL implicit context caching can leak caller-specific data across users
- **Fixes #111** — RedisInvalidationBus accepts unsigned messages by default, allowing forgery

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes

- **Express/Hono middlewares**: added `hasSensitiveHttpCacheHeaders()` (authorization, cookie, set-cookie, x-api-key, x-session-id, x-auth-token, x-forwarded-user). Requests carrying these headers bypass implicit URL-only caching when no `keyResolver` is supplied, so one user's authenticated response is never served to another.
- **tRPC middleware**: `keyResolver` is now required; removed the `allowImplicitContextCaching` option and the fallback path+input-only key derivation, which could not distinguish authenticated callers.
- **GraphQL resolver wrapper**: `keyResolver` is now required; removed `allowImplicitContextCaching` and the arg-only implicit keys.
- **RedisInvalidationBus**: added `requireSignature` option — construction now throws when it is `true` and no `signingSecret` is provided, preventing unsigned channels that any Redis publisher could forge messages on. Strengthened the no-secret warning message.
- **Docs**: updated README, `docs/api.md`, `docs-web` API/integrations pages to clarify `allowPrivateCaching` is shared (not per-user) caching and to document `requireSignature`; updated tRPC examples to context-aware `keyResolver` patterns; added CHANGELOG entry.

## Testing

- [x] All existing tests pass (`npm test`)
- [x] New tests added for the changes
- [x] Lint passes (`npm run lint`)
- [x] Build succeeds (`npm run build:all`)

New regression tests:
- Express: bypasses implicit caching on `authorization` / `cookie` headers; still caches on non-sensitive headers
- Hono: bypasses implicit caching on `authorization` / `cookie` headers
- tRPC: `keyResolver` required; context-aware keys separate authenticated callers
- RedisInvalidationBus: throws when `requireSignature: true` without a secret; accepts when a secret is present

## Checklist

- [x] My changes follow the existing code style (single quotes, no semicolons, 2-space indent)
- [x] I have updated documentation where applicable
- [x] I have updated `CHANGELOG.md` and package versions when the PR changes release scope
- [x] I have added tests that prove my fix/feature works
- [x] No type errors suppressed (`as any`, `@ts-ignore`, `@ts-expect-error`)

## Additional Notes

Full verification run:
- `npm run lint` — 124 files checked, no errors
- `npm run test` (unit) — 679 passed, 8 skipped, 45 files
- `npm run build` — ESM/CJS/DTS build succeeded
- Commit authored as `flyingsquirrel <25esihoya@gmail.com>`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved caching safeguards by bypassing implicit caching for requests containing authentication-related headers.
  * Added required cache-key configuration for tRPC and GraphQL integrations to support context-aware caching.
  * Added optional fail-fast enforcement for signed Redis invalidation messages when no signing secret is configured.

* **Documentation**
  * Updated integration guides and examples with secure caching and Redis signature configuration requirements.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->